### PR TITLE
Upgrade OS dependencies and add arm64 tag

### DIFF
--- a/affine/TerminusManifest.yaml
+++ b/affine/TerminusManifest.yaml
@@ -70,6 +70,7 @@ spec:
   limitedCpu: '4'
   supportArch:
   - amd64
+  - arm64
 permission:
   appData: true
   appCache: true

--- a/astral/TerminusManifest.yaml
+++ b/astral/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: astral
@@ -40,7 +40,7 @@ options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: astral-svc
   port: 8000

--- a/bazarr/TerminusManifest.yaml
+++ b/bazarr/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: bazarr
@@ -105,11 +105,12 @@ spec:
   limitedCpu: 0.5
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: bazarr-svc
   port: 6767

--- a/calibre/TerminusManifest.yaml
+++ b/calibre/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 metadata:
   name: calibre
   description: Web app for browsing, reading and downloading eBooks stored in a Calibre
@@ -43,11 +43,12 @@ spec:
     url: https://github.com/kovidgoyal/calibre/blob/master/LICENSE
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: calibre-svc
   port: 8080

--- a/calibreweb/TerminusManifest.yaml
+++ b/calibreweb/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: calibreweb
@@ -86,7 +86,7 @@ options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: calibreweb-svc
   port: 8083

--- a/chinesesubfinder/TerminusManifest.yaml
+++ b/chinesesubfinder/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 metadata:
   name: chinesesubfinder
   description: Automatically download Chinese subtitles
@@ -48,11 +48,12 @@ spec:
     url: https://github.com/ChineseSubFinder/ChineseSubFinder/blob/master/LICENSE
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=1.3.0-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: chinesesubfinder-svc
   port: 19035

--- a/chromium/TerminusManifest.yaml
+++ b/chromium/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 metadata:
   name: chromium
   description: The open-source projects behind the Google Chrome browser
@@ -34,11 +34,12 @@ spec:
     url: https://chromium.googlesource.com/chromium/src/+/HEAD/LICENSE
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: chromium
   port: 3000

--- a/codeninja7bq4/TerminusManifest.yaml
+++ b/codeninja7bq4/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: model
 metadata:
   name: codeninja7bq4
@@ -57,10 +57,11 @@ spec:
   limitedCpu: 0.5
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
   appScope:
     clusterScoped: true

--- a/codeserver/TerminusManifest.yaml
+++ b/codeserver/TerminusManifest.yaml
@@ -88,11 +88,12 @@ spec:
   limitedCpu: 2
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=1.3.0-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: codeserver-svc
   port: 8080

--- a/deluge/TerminusManifest.yaml
+++ b/deluge/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: deluge
@@ -57,11 +57,12 @@ spec:
     url: https://github.com/deluge-torrent/deluge/blob/develop/LICENSE
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: deluge-svc
   port: 8112

--- a/devbox/TerminusManifest.yaml
+++ b/devbox/TerminusManifest.yaml
@@ -63,12 +63,12 @@ spec:
   limitedCpu: 3000m
   supportArch:
   - amd64
-  - arm64v8
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=1.7.0-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: devbox-frontend
   port: 8080

--- a/devbox/TerminusManifest.yaml
+++ b/devbox/TerminusManifest.yaml
@@ -68,7 +68,7 @@ options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=1.6.0-0'
+    version: '>=1.7.0-0'
 entrances:
 - name: devbox-frontend
   port: 8080

--- a/difyfusion/TerminusManifest.yaml
+++ b/difyfusion/TerminusManifest.yaml
@@ -78,6 +78,7 @@ spec:
   limitedCpu: 200000m
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus

--- a/difyfusionclient/TerminusManifest.yaml
+++ b/difyfusionclient/TerminusManifest.yaml
@@ -72,6 +72,7 @@ spec:
   limitedCpu: 200000m
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus

--- a/duplicati/TerminusManifest.yaml
+++ b/duplicati/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: duplicati
@@ -39,11 +39,12 @@ spec:
     url: https://github.com/duplicati/duplicati/blob/master/LICENSE.txt
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: duplicati-svc
   port: 8200

--- a/farcasterhubble/TerminusManifest.yaml
+++ b/farcasterhubble/TerminusManifest.yaml
@@ -76,6 +76,7 @@ spec:
   limitedDisk: 500Gi
   supportArch:
   - amd64
+  - arm64
 permission:
   appData: true
   appCache: true
@@ -87,7 +88,7 @@ options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=1.3.0-0'
+    version: '>=1.6.0-0'
   appScope:
     clusterScoped: false
     appRef: []

--- a/filebrowser/TerminusManifest.yaml
+++ b/filebrowser/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 metadata:
   name: filebrowser
   description: Upload, delete, preview, rename, edit and share your files
@@ -48,11 +48,12 @@ spec:
     url: https://github.com/filebrowser/filebrowser/blob/master/LICENSE
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: filebrowser-service
   port: 80

--- a/firefox/TerminusManifest.yaml
+++ b/firefox/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 metadata:
   name: firefox
   description: Firefox Browser
@@ -32,11 +32,12 @@ spec:
   doc: https://support.mozilla.org/
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: firefox
   port: 3000

--- a/geth/TerminusManifest.yaml
+++ b/geth/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: geth
@@ -91,7 +91,7 @@ options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: traefik
   port: 80

--- a/gitlabpure/TerminusManifest.yaml
+++ b/gitlabpure/TerminusManifest.yaml
@@ -132,6 +132,7 @@ spec:
   limitedCpu: 12
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus

--- a/homeassistant/TerminusManifest.yaml
+++ b/homeassistant/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: homeassistant
@@ -101,7 +101,7 @@ options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: homeassistant
   port: 8001

--- a/ipfs/TerminusManifest.yaml
+++ b/ipfs/TerminusManifest.yaml
@@ -79,6 +79,7 @@ spec:
   limitedCpu: 2000m
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus

--- a/jellyfin/TerminusManifest.yaml
+++ b/jellyfin/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: jellyfin
@@ -76,11 +76,12 @@ spec:
     linux: https://flathub.org/apps/com.github.iwalton3.jellyfin-media-player
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: jellyfin-svc
   port: 8096

--- a/lidarr/TerminusManifest.yaml
+++ b/lidarr/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: lidarr
@@ -100,11 +100,12 @@ spec:
   limitedCpu: 0.5
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: lidarr-svc
   port: 8686

--- a/llama2chat7bq4/TerminusManifest.yaml
+++ b/llama2chat7bq4/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: model
 metadata:
   name: llama2chat7bq4
@@ -46,10 +46,11 @@ spec:
   limitedCpu: 0.5
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
   appScope:
     clusterScoped: true

--- a/mastodon/TerminusManifest.yaml
+++ b/mastodon/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: mastodon
@@ -82,11 +82,12 @@ spec:
     ios: https://apps.apple.com/us/app/mastodon-for-iphone-and-ipad/id1571998974
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=1.4.0-0'
+    version: '>=1.6.0-0'
   policies:
     - uriRegex: ^/
       level: public

--- a/miniflux/TerminusManifest.yaml
+++ b/miniflux/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: miniflux
@@ -105,7 +105,7 @@ options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: miniflux
   port: 80

--- a/mistralins7bq4/TerminusManifest.yaml
+++ b/mistralins7bq4/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: model
 metadata:
   name: mistralins7bq4
@@ -43,10 +43,11 @@ spec:
   limitedCpu: 0.5
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
   appScope:
     clusterScoped: true

--- a/mongodb/TerminusManifest.yaml
+++ b/mongodb/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.7.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: middleware
 metadata:
   name: mongodb
@@ -43,6 +43,7 @@ spec:
   limitedCpu: 200000m
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus

--- a/n8n/TerminusManifest.yaml
+++ b/n8n/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: n8n
@@ -120,11 +120,12 @@ spec:
     url: https://github.com/n8n-io/n8n/blob/master/LICENSE.md
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
   policies:
     - uriRegex: ^/(webhook)
       level: public

--- a/navidrome/TerminusManifest.yaml
+++ b/navidrome/TerminusManifest.yaml
@@ -92,3 +92,4 @@ spec:
   requiredMemory: 100Mi
   supportArch:
   - amd64
+  - arm64

--- a/nextcloud/TerminusManifest.yaml
+++ b/nextcloud/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 metadata:
   name: nextcloud
   description: The productivity platform that keeps you in control
@@ -47,6 +47,7 @@ spec:
     ios: https://apps.apple.com/us/app/nextcloud/id1125420102
   supportArch:
   - amd64
+  - arm64
 middleware:
   postgres:
     username: nextcloud

--- a/nocodb/TerminusManifest.yaml
+++ b/nocodb/TerminusManifest.yaml
@@ -95,6 +95,7 @@ spec:
     url: https://github.com/nocodb/nocodb/blob/develop/LICENSE
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus

--- a/noromaid7b/TerminusManifest.yaml
+++ b/noromaid7b/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: model
 metadata:
   name: noromaid7b
@@ -46,10 +46,11 @@ spec:
   limitedCpu: 0.5
   supportArch:
   - amd64
+  - arm64 
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
   appScope:
     clusterScoped: true

--- a/nzbget/TerminusManifest.yaml
+++ b/nzbget/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: nzbget
@@ -64,11 +64,12 @@ spec:
     url: https://github.com/nzbget/nzbget/blob/develop/COPYING
   supportArch:
   - amd64
-options:
+  - arm64
+  options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: nzbget-svc
   port: 6789

--- a/nzbget/TerminusManifest.yaml
+++ b/nzbget/TerminusManifest.yaml
@@ -65,7 +65,7 @@ spec:
   supportArch:
   - amd64
   - arm64
-  options:
+options:
   dependencies:
   - name: terminus
     type: system

--- a/obsidian/TerminusManifest.yaml
+++ b/obsidian/TerminusManifest.yaml
@@ -92,7 +92,8 @@ spec:
     linux: https://github.com/obsidianmd/obsidian-releases/releases/download/v1.5.11/Obsidian-1.5.11.AppImage
   supportArch:
   - amd64
-options:
+  - arm64
+  options:
   dependencies:
   - name: terminus
     type: system

--- a/obsidian/TerminusManifest.yaml
+++ b/obsidian/TerminusManifest.yaml
@@ -93,7 +93,7 @@ spec:
   supportArch:
   - amd64
   - arm64
-  options:
+options:
   dependencies:
   - name: terminus
     type: system

--- a/onlyoffice/TerminusManifest.yaml
+++ b/onlyoffice/TerminusManifest.yaml
@@ -149,6 +149,7 @@ spec:
   limitedCpu: 2.5
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus

--- a/openchat7b/TerminusManifest.yaml
+++ b/openchat7b/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: model
 metadata:
   name: openchat7b
@@ -66,10 +66,11 @@ spec:
   limitedCpu: 0.5
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
   appScope:
     clusterScoped: true

--- a/openllm/TerminusManifest.yaml
+++ b/openllm/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 metadata:
   name: openllm
   description: An open platform for operating LLMs in production
@@ -49,7 +49,7 @@ options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: traefik
   port: 80

--- a/otmoicrelay/TerminusManifest.yaml
+++ b/otmoicrelay/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 metadata:
   name: otmoicrelay
   description: Otmoic Relay
@@ -30,7 +30,7 @@ options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
   policies:
     - uriRegex: ^/(ping|relay|socket.io|connect|app|upload|get_application_schema|get_presentation_definition|relay-admin-panel/kyc|relay-admin-panel/lpnode_admin_panel|reputation/)
       level: public

--- a/penpot/TerminusManifest.yaml
+++ b/penpot/TerminusManifest.yaml
@@ -75,6 +75,7 @@ spec:
   limitedCpu: 2
   supportArch:
   - amd64
+  - arm64
 middleware:
   postgres:
     username: penpot
@@ -88,7 +89,7 @@ options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=1.3.0-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: penpot
   port: 80

--- a/phi23b/TerminusManifest.yaml
+++ b/phi23b/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: model
 metadata:
   name: phi23b
@@ -49,10 +49,11 @@ spec:
   limitedCpu: 0.5
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
   appScope:
     clusterScoped: true

--- a/photoprism/TerminusManifest.yaml
+++ b/photoprism/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: photoprism
@@ -79,7 +79,7 @@ options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: photoprism-svc
   port: 2342

--- a/photoview/TerminusManifest.yaml
+++ b/photoview/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: photoview
@@ -93,11 +93,12 @@ spec:
     ios: https://apps.apple.com/dk/app/photoview-media-gallery/id1578380271
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: photoview-svc
   port: 80

--- a/prowlarr/TerminusManifest.yaml
+++ b/prowlarr/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: prowlarr
@@ -101,11 +101,12 @@ spec:
   limitedCpu: 0.5
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: prowlarr-svc
   port: 9696

--- a/qbittorrent/TerminusManifest.yaml
+++ b/qbittorrent/TerminusManifest.yaml
@@ -92,7 +92,7 @@ options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=1.3.0-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: qbittorrent-svc
   port: 8001

--- a/r4business/TerminusManifest.yaml
+++ b/r4business/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.7.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: recommend
 metadata:
   name: r4business
@@ -35,7 +35,7 @@ spec:
   limitedCpu: 0.5
   supportArch:
   - amd64
-  - arm64v8
+  - arm64
 options:
   dependencies:
   - name: terminus

--- a/r4entertainment/TerminusManifest.yaml
+++ b/r4entertainment/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.7.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: recommend
 metadata:
   name: r4entertainment
@@ -35,7 +35,7 @@ spec:
   limitedCpu: 0.5
   supportArch:
   - amd64
-  - arm64v8
+  - arm64
 options:
   dependencies:
   - name: terminus

--- a/r4sport/TerminusManifest.yaml
+++ b/r4sport/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.7.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: recommend
 metadata:
   name: r4sport
@@ -34,7 +34,7 @@ spec:
   limitedCpu: 0.5
   supportArch:
   - amd64
-  - arm64v8
+  - arm64
 options:
   dependencies:
   - name: terminus

--- a/r4tech/TerminusManifest.yaml
+++ b/r4tech/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.7.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: recommend
 metadata:
   name: r4tech
@@ -35,7 +35,7 @@ spec:
   limitedCpu: 0.5
   supportArch:
   - amd64
-  - arm64v8
+  - arm64
 options:
   dependencies:
   - name: terminus

--- a/r4techbiz/TerminusManifest.yaml
+++ b/r4techbiz/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.7.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: recommend
 metadata:
   name: r4techbiz
@@ -35,7 +35,7 @@ spec:
   limitedCpu: 0.5
   supportArch:
   - amd64
-  - arm64v8
+  - arm64
 options:
   dependencies:
   - name: terminus

--- a/r4world/TerminusManifest.yaml
+++ b/r4world/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.7.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: recommend
 metadata:
   name: r4world
@@ -35,7 +35,7 @@ spec:
   limitedCpu: 0.5
   supportArch:
   - amd64
-  - arm64v8
+  - arm64
 options:
   dependencies:
   - name: terminus

--- a/radarr/TerminusManifest.yaml
+++ b/radarr/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: radarr
@@ -122,12 +122,12 @@ spec:
   requiredCpu: 0.1
   limitedCpu: 0.5
   supportArch:
-  - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: radarr-svc
   port: 7878

--- a/radicale/TerminusManifest.yaml
+++ b/radicale/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: radicale
@@ -71,11 +71,12 @@ spec:
     url: https://github.com/Kozea/Radicale/blob/master/COPYING.md
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: radicale
   port: 5232

--- a/readarr/TerminusManifest.yaml
+++ b/readarr/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: readarr
@@ -98,11 +98,12 @@ spec:
   limitedCpu: 0.5
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: readarr-svc
   port: 8787

--- a/rsshub/TerminusManifest.yaml
+++ b/rsshub/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 metadata:
   name: rsshub
   description: A extensible RSS feed generator
@@ -45,11 +45,12 @@ spec:
     ios: https://apps.apple.com/us/app/rssbud/id1531443645
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: rsshub
   port: 1200

--- a/sdwebui/TerminusManifest.yaml
+++ b/sdwebui/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: sdwebui
@@ -53,7 +53,7 @@ options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=1.3.0-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: sdwebui-svc
   port: 7860

--- a/sealcaster/TerminusManifest.yaml
+++ b/sealcaster/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: sealcaster
@@ -40,7 +40,7 @@ options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: sealcaster-svc
   port: 3000

--- a/showdoc/TerminusManifest.yaml
+++ b/showdoc/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: showdoc
@@ -101,7 +101,7 @@ options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: showdoc
   port: 80

--- a/sickchill/TerminusManifest.yaml
+++ b/sickchill/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: sickchill
@@ -105,11 +105,12 @@ spec:
   limitedCpu: 0.5
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: sickchill-svc
   port: 8081

--- a/sonarr/TerminusManifest.yaml
+++ b/sonarr/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: sonarr
@@ -72,11 +72,12 @@ spec:
   limitedCpu: 1
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: sonarr-svc
   port: 8989

--- a/stealth7b/TerminusManifest.yaml
+++ b/stealth7b/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: model
 metadata:
   name: stealth7b
@@ -43,10 +43,11 @@ spec:
   limitedCpu: 0.5
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
   appScope:
     clusterScoped: true

--- a/transmission/TerminusManifest.yaml
+++ b/transmission/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: app
 metadata:
   name: transmission
@@ -112,11 +112,12 @@ spec:
     url: https://github.com/transmission/transmission/blob/main/COPYING
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
 entrances:
 - name: transmission-svc
   port: 9091

--- a/yarnmistral7b/TerminusManifest.yaml
+++ b/yarnmistral7b/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: 0.6.0
+terminusManifest.version: '0.7.0'
 terminusManifest.type: model
 metadata:
   name: yarnmistral7b
@@ -49,10 +49,11 @@ spec:
   limitedCpu: 0.5
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: terminus
     type: system
-    version: '>=0.3.7-0'
+    version: '>=1.6.0-0'
   appScope:
     clusterScoped: true


### PR DESCRIPTION
Since the release of version 1.6.0, Terminus OS has expanded its capabilities to support installation on devices with arm64 architecture. Consequently, we upgraded all the TAC to adapt to this change. 

This pr upgrade OS dependencies for all apps and add the arm64 tag for apps that support arm64 architecture.