### PR TITLE
[UPDATE][lidarr][0.0.3]unsuspend app, add legacy provider and fix home directory issue

### DIFF
--- a/lidarr/Chart.yaml
+++ b/lidarr/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/lidarr/Chart.yaml
+++ b/lidarr/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.0.3
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.1.7.4030"
+appVersion: '2.4.3.4248'

--- a/lidarr/TerminusManifest.yaml
+++ b/lidarr/TerminusManifest.yaml
@@ -114,3 +114,39 @@ entrances:
   icon: https://file.bttcdn.com/appstore/lidarr/icon.png
 permission:
   appCache: true
+  sysData:
+  - dataType: legacy_prowlarr
+    appName: prowlarr
+    port: 9696
+    group: api.prowlarr
+    version: v2
+    ops:
+    - All
+  - dataType: legacy_qbittorrent
+    appName: qbittorrent
+    port: 8001
+    group: apiv2.qbittorrent
+    version: v2
+    ops:
+    - All
+  - dataType: legacy_deluge
+    appName: deluge
+    port: 6881
+    group: api.deluge
+    version: v2
+    ops:
+    - All
+  - dataType: legacy_nzbget
+    appName: nzbget
+    port: 6789
+    group: api.nzbget
+    version: v2
+    ops:
+    - All
+  - dataType: legacy_transmission
+    appName: transmission
+    port: 51413
+    group: api.transmission
+    version: v2
+    ops:
+    - All

--- a/lidarr/TerminusManifest.yaml
+++ b/lidarr/TerminusManifest.yaml
@@ -5,12 +5,12 @@ metadata:
   description: A music collection manager for Usenet and BitTorrent users
   icon: https://file.bttcdn.com/appstore/lidarr/icon.png
   appid: lidarr
-  version: 0.0.2
+  version: 0.0.3
   title: Lidarr
   categories:
   - Entertainment
 spec:
-  versionName: 2.1.7.4030
+  versionName: '2.1.7.4030'
   promoteImage:
   - https://file.bttcdn.com/appstore/lidarr/promote_image_1.jpg
   - https://file.bttcdn.com/appstore/lidarr/promote_image_2.jpg

--- a/lidarr/TerminusManifest.yaml
+++ b/lidarr/TerminusManifest.yaml
@@ -10,73 +10,46 @@ metadata:
   categories:
   - Entertainment
 spec:
-  versionName: '2.1.7.4030'
+  versionName: '2.4.3.4248'
   promoteImage:
   - https://file.bttcdn.com/appstore/lidarr/promote_image_1.jpg
   - https://file.bttcdn.com/appstore/lidarr/promote_image_2.jpg
   - https://file.bttcdn.com/appstore/lidarr/promote_image_3.jpg
-  fullDescription: 'Lidarr can monitor multiple RSS feeds for new albums from your
-    favorite artists and will interface with clients and indexers to grab, sort, and
-    rename them. It can also be configured to automatically upgrade the quality of
-    existing files in the library when a better quality format becomes available.
-
+  fullDescription: |
+    Lidarr can monitor multiple RSS feeds for new albums from your favorite artists and will interface with clients and indexers to grab, sort, and rename them. It can also be configured to automatically upgrade the quality of existing files in the library when a better quality format becomes available.
 
     # Major Features Include:
-
     - Support for major platforms: Windows, Linux, macOS, Raspberry Pi, etc.
-
     - Automatically detects new tracks.
-
     - Can scan your existing library and download any missing tracks.
-
     - Can watch for better quality of the tracks you already have and do an automatic
     upgrade.
-
     - Automatic failed download handling will try another release if one fails
-
     - Manual search so you can pick any release or to see why a release was not downloaded
     automatically
-
     - Fully configurable track renaming
-
     - Full integration with SABnzbd and NZBGet
-
     - Full integration with Kodi, Plex (notification, library update, metadata)
-
     - Full support for specials and multi-album releases
-
     - And a beautiful UI
 
-    '
-  upgradeDescription: 'Changes:
+  upgradeDescription: |
+    Upgrade App Version to 2.4.3.4248
 
-    - 7f0fab0 Multiple Translations updated by Weblate
+    Changes:
+    4d693f7 Multiple Translations updated by Weblate
+    2dec783 Fixed: Creating root folders without default tags [ #4898 ]
+    9045dea Update SonarCloud pipeline versions
+    2ad7396 New: Added UI for parsing release names
+    bcfabac Bump version to 2.4.3
+    bfcbb67 Fixed: Already imported downloads appearing in Queue briefly [ #4877 ]
+    bc19ead Bump version to 2.4.2
+    39a5abd Bump skipping spotify tests
+    e31f2ad Fixed: Validate metadata and quality profiles for root folders
+    838e49b Bump mac image to 12
 
-    - d68f207 Ignore spotify mapping test temporarily
+    Check the full change log at: https://github.com/Lidarr/Lidarr/releases/tag/v2.4.3.4248
 
-    - f1efd05 Fixed: Spotify Playlist selection
-
-    - 59efffd Multiple Translations updated by Weblate
-
-    - 6c90ac7 Fixed: Don''t use sub folder to check for free disk space for update
-    [ #4566 ]
-
-    - f5eee52 New: Log database engine version on startup
-
-    - 0871949 Fixed: Redirecting after login
-
-    - 1536e90 New: Artist info in Album Delete event for Webhooks [ #4552 ]
-
-    - c744231 Translations for settings index
-
-    - efe0a3d Typings cleanup and improvements [ #3516, #3510, #2778 ]
-
-    And a lot more...
-
-
-    Check the full change log at: https://github.com/Lidarr/Lidarr/releases/tag/v2.1.7.4030
-
-    '
   developer: Lidarr
   website: https://lidarr.audio/
   sourceCode: https://github.com/Lidarr/Lidarr
@@ -113,7 +86,10 @@ entrances:
   title: Lidarr
   icon: https://file.bttcdn.com/appstore/lidarr/icon.png
 permission:
+  appData: true
   appCache: true
+  userData:
+  - Home
   sysData:
   - dataType: legacy_prowlarr
     appName: prowlarr
@@ -131,7 +107,7 @@ permission:
     - All
   - dataType: legacy_deluge
     appName: deluge
-    port: 6881
+    port: 8112
     group: api.deluge
     version: v2
     ops:
@@ -145,7 +121,7 @@ permission:
     - All
   - dataType: legacy_transmission
     appName: transmission
-    port: 51413
+    port: 9091
     group: api.transmission
     version: v2
     ops:

--- a/lidarr/templates/deployment.yaml
+++ b/lidarr/templates/deployment.yaml
@@ -44,4 +44,24 @@ spec:
     - protocol: TCP
       port: 8686
       targetPort: 8686
-      
+
+---
+apiVersion: sys.bytetrade.io/v1alpha1
+kind: ProviderRegistry
+metadata:
+  name: legacy-{{ .Release.Name }}
+  namespace: user-system-{{ .Values.bfl.username }}
+spec:
+  dataType: legacy_{{ .Release.Name }}
+  deployment: {{ .Release.Name }}
+  description: {{ .Release.Name }} legacy api
+  endpoint: {{ .Release.Name }}-svc.{{ .Release.Namespace }}:8686
+  group: api.{{ .Release.Name }}
+  kind: provider
+  namespace: {{ .Release.Namespace }}
+  version: v2
+  opApis:
+  - name: All
+    uri: /
+status:
+  state: active      

--- a/lidarr/templates/deployment.yaml
+++ b/lidarr/templates/deployment.yaml
@@ -1,3 +1,23 @@
+apiVersion: v1
+data:
+  init.sh: |
+    #!/bin/bash
+
+    source_dir="/config"
+    dest_dir="/new-config"
+
+    if [ -z "$(ls -A $dest_dir)" ]; then
+      echo "$dest_dir is empty. Copying files from $source_dir..."
+      cp -r $source_dir/. $dest_dir
+      echo "Files copied successfully."
+    else
+      echo "$dest_dir is not empty. No action taken."
+    fi
+kind: ConfigMap
+metadata:
+  name: init-config
+  namespace: {{ .Release.Namespace }}
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -16,9 +36,39 @@ spec:
       labels:
         app: lidarr
     spec:
+      initContainers:
+      - env:
+        - name: PGID
+          value: "1000" 
+        - name: PUID
+          value: "1000" 
+        - name: TZ
+          value: Europe/London
+        name: lidarr-init-data
+        image: linuxserver/lidarr:version-2.4.3.4248
+        command:
+          - sh
+          - '-c'
+          - |
+            chmod +x /init.sh & bash /init.sh
+        resources:
+          requests:
+            cpu: 100m
+            memory: 32Mi
+          limits:
+            cpu: 1000m
+            memory: 256Mi
+        ports:
+        - containerPort: 8686
+        volumeMounts:
+        - mountPath: /new-config
+          name: lidarr-config
+        - name: init-config 
+          mountPath: /init.sh
+          subPath: init.sh
       containers:
       - name: lidarr
-        image: hotio/lidarr:{{ .Values.image.version }}
+        image: linuxserver/lidarr:version-2.4.3.4248
         resources:
           requests:
             cpu: 100m
@@ -26,10 +76,36 @@ spec:
           limits:
             cpu: 500m
             memory: 512Mi
+        env:
+        - name: PGID
+          value: "1000" 
+        - name: PUID
+          value: "1000" 
+        - name: TZ
+          value: Europe/London
         ports:
         - containerPort: 8686
-
-
+        volumeMounts:
+        - mountPath: /config
+          name: lidarr-config
+        - mountPath: /home
+          name: home
+      volumes:
+      - name: lidarr-config
+        hostPath:
+          type: DirectoryOrCreate
+          path: {{ .Values.userspace.appData }}/lidarr 
+      - name: home
+        hostPath:
+          type: DirectoryOrCreate
+          path: {{ .Values.userspace.userData }}           
+      - name: init-config
+        configMap:
+          name: init-config
+          defaultMode: 438
+          items:
+          - key: init.sh
+            path: init.sh
 ---
 apiVersion: v1
 kind: Service

--- a/lidarr/values.yaml
+++ b/lidarr/values.yaml
@@ -1,3 +1,0 @@
-image:
-  version: 'latest'
-


### PR DESCRIPTION
### App Title
lidarr

### Description
add legacy provider
update image to '2.4.3.4248'
mount home directory to pod

### Statement
- [x] I have tested this application to ensure it is compatible with the Terminus OS version stated in the `TerminusManifest.yaml`
