### PR TITLE
fix app version and manifest version

### DIFF
--- a/affine/Chart.yaml
+++ b/affine/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.14.6'
 description: description
 name: affine
 type: application
-version: 0.0.13
+version: '1.0.0'

--- a/affine/TerminusManifest.yaml
+++ b/affine/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: affine
@@ -6,7 +6,7 @@ metadata:
   description: Open-source alternative for Notion, Miro and Airtable.
   appid: affine
   title: AFFiNE
-  version: 0.0.13
+  version: '1.0.0'
   categories:
   - Productivity
   - Utilities

--- a/astral/Chart.yaml
+++ b/astral/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/astral/TerminusManifest.yaml
+++ b/astral/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: astral
   description: Nostr client made with Quasar.
   icon: https://file.bttcdn.com/appstore/astral/icon.png
   appid: astral
-  version: 0.0.4
+  version: '1.0.0'
   title: Astral
   categories:
   - Social Network

--- a/bazarr/Chart.yaml
+++ b/bazarr/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.7
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/bazarr/TerminusManifest.yaml
+++ b/bazarr/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: bazarr
   description: A companion subtitle manager to Sonarr and Radarr.
   icon: https://file.bttcdn.com/appstore/bazarr/icon.png
   appid: bazarr
-  version: 0.0.7
+  version: '1.0.0'
   title: Bazarr
   categories:
   - Entertainment

--- a/bytebase/Chart.yaml
+++ b/bytebase/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.12
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/bytebase/TerminusManifest.yaml
+++ b/bytebase/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: bytebase
@@ -6,7 +6,7 @@ metadata:
     and Platform Engineering teams.
   icon: https://file.bttcdn.com/appstore/bytebase/icon.png
   appid: bytebase
-  version: 0.0.12
+  version: '1.0.0'
   title: Bytebase
   categories:
   - Productivity

--- a/calendar/Chart.yaml
+++ b/calendar/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/calendar/TerminusManifest.yaml
+++ b/calendar/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: calendar
@@ -6,7 +6,7 @@ metadata:
   description: Self-hosted Calendar Client for CalDAV
   appid: calendar
   title: Calendar
-  version: 0.0.2
+  version: '1.0.0'
   categories:
   - Utilities
 entrances:

--- a/calibre/Chart.yaml
+++ b/calibre/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/calibre/TerminusManifest.yaml
+++ b/calibre/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 metadata:
   name: calibre
   description: Web app for browsing, reading and downloading eBooks stored in a Calibre
     database.
   icon: https://file.bttcdn.com/appstore/calibre/icon.png
   appid: calibre
-  version: 0.0.2
+  version: '1.0.0'
   title: Calibre
   categories:
   - Entertainment

--- a/calibreweb/Chart.yaml
+++ b/calibreweb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/calibreweb/TerminusManifest.yaml
+++ b/calibreweb/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: calibreweb
@@ -6,7 +6,7 @@ metadata:
     database
   icon: https://file.bttcdn.com/appstore/calibreweb/icon.png
   appid: calibreweb
-  version: 0.0.3
+  version: '1.0.0'
   title: Calibre-Web
   categories:
   - Entertainment

--- a/chinesesubfinder/Chart.yaml
+++ b/chinesesubfinder/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chinesesubfinder/TerminusManifest.yaml
+++ b/chinesesubfinder/TerminusManifest.yaml
@@ -1,10 +1,10 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 metadata:
   name: chinesesubfinder
   description: Automatically download Chinese subtitles
   icon: https://file.bttcdn.com/appstore/chinesesubfinder/icon.png
   appid: chinesesubfinder
-  version: 0.0.3
+  version: '1.0.0'
   title: ChineseSubFinder
   categories:
   - Entertainment

--- a/chromium/Chart.yaml
+++ b/chromium/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chromium/TerminusManifest.yaml
+++ b/chromium/TerminusManifest.yaml
@@ -1,10 +1,10 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 metadata:
   name: chromium
   description: The open-source projects behind the Google Chrome browser
   icon: https://file.bttcdn.com/appstore/chromium/icon.png
   appid: chromium
-  version: 0.0.2
+  version: '1.0.0'
   title: Chromium
   categories:
   - Utilities

--- a/codeninja7bq4/Chart.yaml
+++ b/codeninja7bq4/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/codeninja7bq4/TerminusManifest.yaml
+++ b/codeninja7bq4/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: model
 metadata:
   name: codeninja7bq4
   description: Your Advanced Coding Assistant
   icon: https://file.bttcdn.com/appstore/default/defaulticon.webp
   appid: codeninja7bq4
-  version: 0.0.4
+  version: '1.0.0'
   title: CodeNinja 7B Q4
   categories:
   - Finetuned

--- a/codeserver/Chart.yaml
+++ b/codeserver/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.15
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/codeserver/TerminusManifest.yaml
+++ b/codeserver/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: codeserver
   description: VS Code in the browser
   icon: https://file.bttcdn.com/appstore/codeserver/icon.png
   appid: codeserver
-  version: 0.0.15
+  version: '1.0.0'
   title: Code Server
   categories:
   - Productivity

--- a/comfyui/Chart.yaml
+++ b/comfyui/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.10
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/comfyui/TerminusManifest.yaml
+++ b/comfyui/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: comfyui
   description: The most powerful and modular stable diffusion GUI and backend.
   icon: https://file.bttcdn.com/appstore/comfyui/icon.png
   appid: comfyui
-  version: 0.1.10
+  version: '1.0.0'
   title: ComfyUI For Cluster
   categories:
   - Productivity

--- a/comfyuiclient/Chart.yaml
+++ b/comfyuiclient/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.108.0'
 description: description
 name: comfyuiclient
 type: application
-version: 0.0.5
+version: '1.0.0'

--- a/comfyuiclient/TerminusManifest.yaml
+++ b/comfyuiclient/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: comfyuiclient
   description: The most powerful and modular stable diffusion GUI and backend.
   icon: https://file.bttcdn.com/appstore/comfyui/icon.png
   appid: comfyuiclient
-  version: 0.0.5
+  version: '1.0.0'
   title: ComfyUI
   categories:
   - Productivity

--- a/deluge/Chart.yaml
+++ b/deluge/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.6
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deluge/TerminusManifest.yaml
+++ b/deluge/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: deluge
   description: A lightweight and free BitTorrent client.
   icon: https://file.bttcdn.com/appstore/deluge/icon.png
   appid: deluge
-  version: 0.0.6
+  version: '1.0.0'
   title: Deluge
   categories:
   - Utilities

--- a/devbox/Chart.yaml
+++ b/devbox/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/devbox/TerminusManifest.yaml
+++ b/devbox/TerminusManifest.yaml
@@ -1,10 +1,10 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: devbox
   description: Development management tools for Terminus
   icon: https://file.bttcdn.com/appstore/devbox/icon.png
-  version: 0.0.8
+  version: '1.0.0'
   title: DevBox
   categories:
   - Productivity

--- a/difyfusion/Chart.yaml
+++ b/difyfusion/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/difyfusion/TerminusManifest.yaml
+++ b/difyfusion/TerminusManifest.yaml
@@ -1,10 +1,10 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: difyfusion
   description: The Innovation Engine for GenAI Applications
   icon: https://file.bttcdn.com/appstore/dify/icon.png
-  version: 0.0.3
+  version: '1.0.0'
   title: Dify For Cluster
   categories:
   - Productivity

--- a/difyfusionclient/Chart.yaml
+++ b/difyfusionclient/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/difyfusionclient/TerminusManifest.yaml
+++ b/difyfusionclient/TerminusManifest.yaml
@@ -1,10 +1,10 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: difyfusionclient
   description: The Innovation Engine for GenAI Applications
   icon: https://file.bttcdn.com/appstore/dify/icon.png
-  version: 0.0.4
+  version: '1.0.0'
   title: Dify
   categories:
   - Productivity

--- a/duplicati/Chart.yaml
+++ b/duplicati/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/duplicati/TerminusManifest.yaml
+++ b/duplicati/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: duplicati
   description: Store securely encrypted backups in the cloud!
   icon: https://file.bttcdn.com/appstore/duplicati/icon.png
   appid: duplicati
-  version: 0.0.4
+  version: '1.0.0'
   title: Duplicati
   categories:
   - Utilities

--- a/farcasterhubble/Chart.yaml
+++ b/farcasterhubble/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.12.2'
 description: description
 name: farcasterhubble
 type: application
-version: 0.0.29
+version: '1.0.0'

--- a/farcasterhubble/TerminusManifest.yaml
+++ b/farcasterhubble/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: farcasterhubble
@@ -6,7 +6,7 @@ metadata:
   description: An official Farcaster Hub implementation
   appid: farcasterhubble
   title: Hubble
-  version: 0.0.29
+  version: '1.0.0'
   categories:
   - Social Network
   - Blockchain

--- a/filebrowser/Chart.yaml
+++ b/filebrowser/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/filebrowser/TerminusManifest.yaml
+++ b/filebrowser/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: filebrowser
   description: Upload, delete, preview, rename, edit and share your files
   icon: https://file.bttcdn.com/appstore/filebrowser/icon.png
   appid: filebrowser
-  version: 0.0.1
+  version: '1.0.0'
   title: Filebrowser
   categories:
   - Utilities

--- a/firefox/Chart.yaml
+++ b/firefox/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.7
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/firefox/TerminusManifest.yaml
+++ b/firefox/TerminusManifest.yaml
@@ -1,10 +1,10 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 metadata:
   name: firefox
   description: Firefox Browser
   icon: https://file.bttcdn.com/appstore/firefox/icon.png
   appid: firefox
-  version: 0.0.7
+  version: '1.0.0'
   title: Firefox
   categories:
   - Utilities

--- a/gaianetai/Chart.yaml
+++ b/gaianetai/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/gaianetai/TerminusManifest.yaml
+++ b/gaianetai/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: gaianetai
   description: Install and run your own AI agent service
   icon: https://file.bttcdn.com/appstore/gaianetai/icon.png
   appid: gaianetai
-  version: 0.1.2
+  version: '1.0.0'
   title: GaiaNet For Cluster
   categories:
   - Productivity

--- a/gaianetaiclient/Chart.yaml
+++ b/gaianetaiclient/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.108.0'
 description: description
 name: gaianetaiclient
 type: application
-version: 0.0.2
+version: '1.0.0'

--- a/gaianetaiclient/TerminusManifest.yaml
+++ b/gaianetaiclient/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: gaianetaiclient
   description: Install and run your own AI agent service
   icon: https://file.bttcdn.com/appstore/gaianetai/icon.png
   appid: gaianetaiclient
-  version: 0.0.2
+  version: '1.0.0'
   title: GaiaNet
   categories:
   - Blockchain

--- a/geth/Chart.yaml
+++ b/geth/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/geth/TerminusManifest.yaml
+++ b/geth/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: geth
   description: Run a node at home, the easy way.
   icon: https://file.bttcdn.com/appstore/geth/icon.png
   appid: geth
-  version: 0.0.3
+  version: '1.0.0'
   title: Ethereum
   categories:
   - Blockchain

--- a/ghost/Chart.yaml
+++ b/ghost/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '5.82.3'
 description: description
 name: ghost
 type: application
-version: 0.0.9
+version: '1.0.0'

--- a/ghost/TerminusManifest.yaml
+++ b/ghost/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: ghost
@@ -6,7 +6,7 @@ metadata:
   description: Independent technology for modern publishing, memberships, subscriptions and newsletters.
   appid: ghost
   title: Ghost
-  version: 0.0.9
+  version: '1.0.0'
   categories:
   - Social Network
 entrances:

--- a/gitlabfusion/Chart.yaml
+++ b/gitlabfusion/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/gitlabfusion/TerminusManifest.yaml
+++ b/gitlabfusion/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: gitlabfusion
   description: A web-based Git repository management tool.
   icon: https://file.bttcdn.com/appstore/gitlab/icon.png
   appid: gitlabfusion
-  version: 0.1.0
+  version: '1.0.0'
   title: GitLab Fusion
   categories:
   - Productivity

--- a/gitlabfusionclient/Chart.yaml
+++ b/gitlabfusionclient/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.29
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/gitlabfusionclient/TerminusManifest.yaml
+++ b/gitlabfusionclient/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: gitlabfusionclient
   description: A web-based Git repository management tool.
   icon: https://file.bttcdn.com/appstore/gitlab/icon.png
   appid: gitlabfusionclient
-  version: 0.0.29
+  version: '1.0.0'
   title: GitLab
   categories:
   - Productivity

--- a/gitlabpure/Chart.yaml
+++ b/gitlabpure/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.51
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/gitlabpure/TerminusManifest.yaml
+++ b/gitlabpure/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: gitlabpure
   description: A web-based Git repository management tool.
   icon: https://file.bttcdn.com/appstore/gitlab/icon.png
   appid: gitlabpure
-  version: 0.0.51
+  version: '1.0.0'
   title: GitLab Standard
   categories:
   - Productivity

--- a/homeassistant/Chart.yaml
+++ b/homeassistant/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.15
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/homeassistant/TerminusManifest.yaml
+++ b/homeassistant/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: homeassistant
   description: Awaken your home
   icon: https://file.bttcdn.com/appstore/homeassistant/icon.png
   appid: homeassistant
-  version: 0.0.15
+  version: '1.0.0'
   title: Home Assistant
   categories:
   - Utilities

--- a/immich/Chart.yaml
+++ b/immich/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.108.0'
 description: description
 name: immich
 type: application
-version: 0.2.0
+version: '1.0.0'

--- a/immich/TerminusManifest.yaml
+++ b/immich/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: immich
@@ -6,7 +6,7 @@ metadata:
   description: High performance self-hosted photo and video management solution.
   appid: immich
   title: Immich
-  version: 0.2.0
+  version: '1.0.0'
   categories:
   - Entertainment
 entrances:

--- a/immichclient/Chart.yaml
+++ b/immichclient/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.108.0'
 description: description
 name: immichclient
 type: application
-version: 0.0.4
+version: '1.0.0'

--- a/immichclient/TerminusManifest.yaml
+++ b/immichclient/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: immichclient
   description: High performance self-hosted photo and video management solution
   icon: https://file.bttcdn.com/appstore/immich/icon.png
   appid: immichclient
-  version: 0.0.4
+  version: '1.0.0'
   title: Immich
   categories:
   - Entertainment

--- a/ipfs/Chart.yaml
+++ b/ipfs/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.31
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/ipfs/TerminusManifest.yaml
+++ b/ipfs/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: ipfs
   description: A frontend for an IPFS Kubo node.
   icon: https://file.bttcdn.com/appstore/ipfs/icon.png
   appid: ipfs
-  version: 0.0.31
+  version: '1.0.0'
   title: IPFS
   categories:
   - Blockchain

--- a/jellyfin/Chart.yaml
+++ b/jellyfin/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.12
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/jellyfin/TerminusManifest.yaml
+++ b/jellyfin/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: jellyfin
   description: The Free Software Media System
   icon: https://file.bttcdn.com/appstore/jellyfin/icon.png
   appid: jellyfin
-  version: 0.0.12
+  version: '1.0.0'
   title: Jellyfin
   categories:
   - Entertainment

--- a/lidarr/Chart.yaml
+++ b/lidarr/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/lidarr/TerminusManifest.yaml
+++ b/lidarr/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: lidarr
   description: A music collection manager for Usenet and BitTorrent users
   icon: https://file.bttcdn.com/appstore/lidarr/icon.png
   appid: lidarr
-  version: 0.0.4
+  version: '1.0.0'
   title: Lidarr
   categories:
   - Entertainment

--- a/llama2chat7bq4/Chart.yaml
+++ b/llama2chat7bq4/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/llama2chat7bq4/TerminusManifest.yaml
+++ b/llama2chat7bq4/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: model
 metadata:
   name: llama2chat7bq4
   description: Llama 2 Chat 7b, specifically designed for a comprehensive understanding through training on extensive internet data.
   icon: https://file.bttcdn.com/appstore/default/defaulticon.webp
   appid: llama2chat7bq4
-  version: 0.0.4
+  version: '1.0.0'
   title: Llama 2 Chat 7B Q4
   categories:
   - Foundational

--- a/mastodon/Chart.yaml
+++ b/mastodon/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.47
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/mastodon/TerminusManifest.yaml
+++ b/mastodon/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: mastodon
   description: Your self-hosted, globally interconnected microblogging community
   icon: https://file.bttcdn.com/appstore/mastodon/icon.png
   appid: mastodon
-  version: 0.0.47
+  version: '1.0.0'
   title: Mastodon
   categories:
   - Social Network

--- a/mattermost/Chart.yaml
+++ b/mattermost/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "9.9.1"
 description: description
 name: mattermost
 type: application
-version: 0.0.7
+version: '1.0.0'

--- a/mattermost/TerminusManifest.yaml
+++ b/mattermost/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: mattermost
@@ -6,7 +6,7 @@ metadata:
   description: An open source platform for secure collaboration across the entire software development lifecycle.
   appid: mattermost
   title: Mattermost
-  version: 0.0.7
+  version: '1.0.0'
   categories:
   - Productivity
 entrances:

--- a/miniflux/Chart.yaml
+++ b/miniflux/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/miniflux/TerminusManifest.yaml
+++ b/miniflux/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: miniflux
   description: Miniflux is a minimalist and opinionated feed reader.
   icon: https://file.bttcdn.com/appstore/miniflux/icon.png
   appid: miniflux
-  version: 0.0.4
+  version: '1.0.0'
   title: Miniflux
   categories:
   - Productivity

--- a/mistralins7bq4/Chart.yaml
+++ b/mistralins7bq4/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/mistralins7bq4/TerminusManifest.yaml
+++ b/mistralins7bq4/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: model
 metadata:
   name: mistralins7bq4
   description: An instruct fine-tuned version of the Mistral-7B-v0.2.
   icon: https://file.bttcdn.com/appstore/default/defaulticon.webp
   appid: mistralins7bq4
-  version: 0.0.3
+  version: '1.0.0'
   title: Mistral Instruct 7B Q4
   categories:
   - Foundational

--- a/mongodb/Chart.yaml
+++ b/mongodb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.0.5
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/mongodb/TerminusManifest.yaml
+++ b/mongodb/TerminusManifest.yaml
@@ -1,10 +1,10 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: middleware
 metadata:
   name: mongodb
   description: Terminus Middleware for MongoDB
   icon: https://file.bttcdn.com/appstore/mongodb/icon.png
-  version: 6.0.5
+  version: '1.0.0'
   title: MongoDB 6.0
   categories:
   - Utilities

--- a/n8n/Chart.yaml
+++ b/n8n/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.9
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/n8n/TerminusManifest.yaml
+++ b/n8n/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: n8n
   description: n8n is an extendable workflow automation tool.
   icon: https://file.bttcdn.com/appstore/n8n/icon.png
   appid: n8n
-  version: 0.0.9
+  version: '1.0.0'
   title: n8n
   categories:
   - Productivity

--- a/navidrome/Chart.yaml
+++ b/navidrome/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.52.5'
 description: description
 name: navidrome
 type: application
-version: 0.0.8
+version: '1.0.0'

--- a/navidrome/TerminusManifest.yaml
+++ b/navidrome/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 entrances:
 - authLevel: private
@@ -16,7 +16,7 @@ metadata:
   icon: https://file.bttcdn.com/appstore/navidrome/icon.png
   name: navidrome
   title: Navidrome
-  version: 0.0.8
+  version: '1.0.0'
 options:
   analytics:
     enabled: false

--- a/nextcloud/Chart.yaml
+++ b/nextcloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.14
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/nextcloud/TerminusManifest.yaml
+++ b/nextcloud/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: nextcloud
   description: The productivity platform that keeps you in control
   icon: https://file.bttcdn.com/appstore/nextcloud/icon.png
   appid: nextcloud
-  version: 0.0.14
+  version: '1.0.0'
   title: Nextcloud
   categories:
   - Productivity

--- a/nocodb/Chart.yaml
+++ b/nocodb/Chart.yaml
@@ -1,5 +1,5 @@
 name: nocodb
-version: 0.0.10
+version: '1.0.0'
 apiVersion: v1
 
 # A chart can be either an 'application' or a 'library' chart.

--- a/nocodb/TerminusManifest.yaml
+++ b/nocodb/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: nocodb
   description: Open Source Airtable Alternative.
   icon: https://file.bttcdn.com/appstore/nocodb/icon.png
   appid: nocodb
-  version: 0.0.10
+  version: '1.0.0'
   title: Nocodb
   categories:
   - Productivity

--- a/noromaid7b/Chart.yaml
+++ b/noromaid7b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/noromaid7b/TerminusManifest.yaml
+++ b/noromaid7b/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: model
 metadata:
   name: noromaid7b
   description: Suitable for RP, ERP and general stuff.
   icon: https://file.bttcdn.com/appstore/default/defaulticon.webp
   appid: noromaid7b
-  version: 0.0.3
+  version: '1.0.0'
   title: Noromaid 7B Q5
   categories:
   - Merged

--- a/nostream/Chart.yaml
+++ b/nostream/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.7
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/nostream/TerminusManifest.yaml
+++ b/nostream/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: nostream
   description: A Nostr Relay written in TypeScript.
   icon: https://file.bttcdn.com/appstore/nostream/icon.png
   appid: nostream
-  version: 0.0.7
+  version: '1.0.0'
   title: Nostream
   categories:
   - Social Network

--- a/novella/Chart.yaml
+++ b/novella/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.14
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/novella/TerminusManifest.yaml
+++ b/novella/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: novella
   description: Notion-style WYSIWYG editor with AI-powered autocompletion
   icon: https://file.bttcdn.com/appstore/novel/icon.png
   appid: novella
-  version: 0.0.14
+  version: '1.0.0'
   title: Novel
   categories:
   - Productivity

--- a/nzbget/Chart.yaml
+++ b/nzbget/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.10
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/nzbget/TerminusManifest.yaml
+++ b/nzbget/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: nzbget
   description: Efficient Usenet downloader.
   icon: https://file.bttcdn.com/appstore/nzbget/icon.png
   appid: nzbget
-  version: 0.0.10
+  version: '1.0.0'
   title: Nzbget
   categories:
   - Utilities

--- a/obsidian/Chart.yaml
+++ b/obsidian/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.15
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/obsidian/TerminusManifest.yaml
+++ b/obsidian/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: obsidian
   description: Obsidian sync server.
   icon: https://file.bttcdn.com/appstore/obsidian/icon.png
   appid: obsidian
-  version: 0.0.15
+  version: '1.0.0'
   title: Obsidian LiveSync
   categories:
   - Productivity

--- a/ollama/Chart.yaml
+++ b/ollama/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.2.5'
 description: description
 name: ollama
 type: application
-version: 0.1.5
+version: '1.0.0'

--- a/ollama/TerminusManifest.yaml
+++ b/ollama/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: ollama
@@ -6,7 +6,7 @@ metadata:
   description: Get up and running with large language models.
   appid: ollama
   title: Ollama
-  version: 0.1.5
+  version: '1.0.0'
   categories:
   - Productivity
 entrances:

--- a/onlyoffice/Chart.yaml
+++ b/onlyoffice/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.37
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/onlyoffice/TerminusManifest.yaml
+++ b/onlyoffice/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: onlyoffice
   description: Run your private office with the ONLYOFFICE
   icon: https://file.bttcdn.com/appstore/onlyoffice/icon.png
   appid: onlyoffice
-  version: 0.0.37
+  version: '1.0.0'
   title: OnlyOffice For Cluster
   categories:
   - Productivity

--- a/onlyofficeclient/Chart.yaml
+++ b/onlyofficeclient/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '8.0.1'
 description: description
 name: onlyofficeclient
 type: application
-version: 0.0.19
+version: '1.0.0'

--- a/onlyofficeclient/TerminusManifest.yaml
+++ b/onlyofficeclient/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: onlyofficeclient
   description: Run your private office with the ONLYOFFICE
   icon: https://file.bttcdn.com/appstore/onlyoffice/icon.png
   appid: onlyofficeclient
-  version: 0.0.19
+  version: '1.0.0'
   title: OnlyOffice
   categories:
   - Productivity

--- a/openchat7b/Chart.yaml
+++ b/openchat7b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/openchat7b/TerminusManifest.yaml
+++ b/openchat7b/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: model
 metadata:
   name: openchat7b
   description: Advancing Open-source Language Models with Mixed-Quality Data
   icon: https://file.bttcdn.com/appstore/default/defaulticon.webp
   appid: openchat7b
-  version: 0.0.3
+  version: '1.0.0'
   title: Openchat-3.5 7B Q4
   categories:
   - Finetuned

--- a/openedaispeech/Chart.yaml
+++ b/openedaispeech/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.17.2'
 description: description
 name: openedaispeech
 type: application
-version: 0.1.1
+version: '1.0.0'

--- a/openedaispeech/TerminusManifest.yaml
+++ b/openedaispeech/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   appid: openedaispeech
@@ -6,7 +6,7 @@ metadata:
   title: OpenedAI Speech For Cluster
   description: An OpenAI API compatible text to speech server using Coqui AI and/or piper TTS as the backend.
   icon: https://file.bttcdn.com/appstore/openedai/icon.png
-  version: 0.1.1
+  version: '1.0.0'
   categories:
   - Productivity
 entrances:

--- a/openllm/Chart.yaml
+++ b/openllm/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.10
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/openllm/TerminusManifest.yaml
+++ b/openllm/TerminusManifest.yaml
@@ -1,10 +1,10 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 metadata:
   name: openllm
   description: An open platform for operating LLMs in production
   icon: https://file.bttcdn.com/appstore/openllm/icon.png
   appid: openllm
-  version: 0.0.10
+  version: '1.0.0'
   title: OpenLLM
   categories:
   - Productivity

--- a/openwebui/Chart.yaml
+++ b/openwebui/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.3.10'
 description: description
 name: openwebui
 type: application
-version: 0.1.2
+version: '1.0.0'

--- a/openwebui/TerminusManifest.yaml
+++ b/openwebui/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: openwebui
   title: Open WebUI
   description: User-friendly WebUI for LLMs
   icon: https://file.bttcdn.com/appstore/openwebui/icon.png
-  version: 0.1.2
+  version: '1.0.0'
   appid: openwebui
   categories:
   - Productivity

--- a/otmoiclp/Chart.yaml
+++ b/otmoiclp/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.20
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/otmoiclp/TerminusManifest.yaml
+++ b/otmoiclp/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: otmoiclp
   description: Otmoic LP
   icon: https://file.bttcdn.com/appstore/obridgelpnode/icon.png
   appid: otmoiclp
-  version: 0.0.20
+  version: '1.0.0'
   title: Otmoic LP
   categories:
   - Blockchain

--- a/otmoicrelay/Chart.yaml
+++ b/otmoicrelay/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.11
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/otmoicrelay/TerminusManifest.yaml
+++ b/otmoicrelay/TerminusManifest.yaml
@@ -1,10 +1,10 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 metadata:
   name: otmoicrelay
   description: Otmoic Relay
   icon: https://file.bttcdn.com/appstore/obridgelpnode/icon.png
   appid: otmoicrelay
-  version: 0.0.11
+  version: '1.0.0'
   title: Otmoic-Relay
   categories:
   - Blockchain

--- a/penpot/Chart.yaml
+++ b/penpot/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/penpot/TerminusManifest.yaml
+++ b/penpot/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: penpot
@@ -6,7 +6,7 @@ metadata:
   the gap between designers and developers.'
   icon: https://file.bttcdn.com/appstore/penpot/icon.png
   appid: penpot
-  version: 0.0.4
+  version: '1.0.0'
   title: penpot
   categories:
   - Productivity

--- a/perplexica/Chart.yaml
+++ b/perplexica/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.7.1'
 description: description
 name: perplexica
 type: application
-version: 0.1.7
+version: '1.0.0'

--- a/perplexica/TerminusManifest.yaml
+++ b/perplexica/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: perplexica
@@ -6,7 +6,7 @@ metadata:
   description: An Open source alternative to Perplexity AI
   appid: perplexica
   title: Perplexica
-  version: 0.1.7
+  version: '1.0.0'
   categories:
   - Productivity
 entrances:

--- a/phi23b/Chart.yaml
+++ b/phi23b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.5
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/phi23b/TerminusManifest.yaml
+++ b/phi23b/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: model
 metadata:
   name: phi23b
   description: Phi-2 is a 2.7B model, excelling in common sense and logical reasoning benchmarks, trained with synthetic texts and filtered websites.
   icon: https://file.bttcdn.com/appstore/default/defaulticon.webp
   appid: phi23b
-  version: 0.0.5
+  version: '1.0.0'
   title: Phi-2 3B Q8
   categories:
   - Foundational

--- a/photoprism/Chart.yaml
+++ b/photoprism/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.7
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/photoprism/TerminusManifest.yaml
+++ b/photoprism/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: photoprism
   description: AI-Powered Photos App for the Decentralized Web
   icon: https://file.bttcdn.com/appstore/photoprism/icon.png
   appid: photoprism
-  version: 0.0.7
+  version: '1.0.0'
   title: PhotoPrism
   categories:
   - Entertainment

--- a/photoview/Chart.yaml
+++ b/photoview/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/photoview/TerminusManifest.yaml
+++ b/photoview/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: photoview
   description: Photo gallery for self-hosted personal servers
   icon: https://file.bttcdn.com/appstore/photoview/icon.png
   appid: photoview
-  version: 0.0.3
+  version: '1.0.0'
   title: Photoview
   categories:
   - Entertainment

--- a/prometheusclient/Chart.yaml
+++ b/prometheusclient/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/prometheusclient/TerminusManifest.yaml
+++ b/prometheusclient/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: prometheusclient
   description: From metrics to insight
   icon: https://file.bttcdn.com/appstore/prometheus/icon.png
   appid: prometheusclient
-  version: 0.0.4
+  version: '1.0.0'
   title: Prometheus
   categories:
   - Utilities

--- a/prowlarr/Chart.yaml
+++ b/prowlarr/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.12
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/prowlarr/TerminusManifest.yaml
+++ b/prowlarr/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: prowlarr
   description: Integration of various PVR applications
   icon: https://file.bttcdn.com/appstore/prowlarr/icon.png
   appid: prowlarr
-  version: 0.0.12
+  version: '1.0.0'
   title: Prowlarr
   categories:
   - Utilities

--- a/qbittorrent/Chart.yaml
+++ b/qbittorrent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.11
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/qbittorrent/TerminusManifest.yaml
+++ b/qbittorrent/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: qbittorrent
   description: Free BitTorrent downloader
   icon: https://file.bttcdn.com/appstore/qbittorrent/icon.png
   appid: qbittorrent
-  version: 0.0.11
+  version: '1.0.0'
   title: qBittorrent
   categories:
   - Utilities

--- a/r4business/Chart.yaml
+++ b/r4business/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.40
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/r4business/TerminusManifest.yaml
+++ b/r4business/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: recommend
 metadata:
   name: r4business
   description: Business by R4. Keep up with in-depth reportage and breaking news in Business, Economy, and Finance
   icon: https://file.bttcdn.com/appstore/default/defaulticon.webp
   appid: r4business
-  version: 0.1.40
+  version: '1.0.0'
   title: Business
   categories:
   - News

--- a/r4entertainment/Chart.yaml
+++ b/r4entertainment/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.41
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/r4entertainment/TerminusManifest.yaml
+++ b/r4entertainment/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: recommend
 metadata:
   name: r4entertainment
   description: Entertainment by R4. Get your daily dose of the latest TV, movie, music, game, book news and reviews.
   icon: https://file.bttcdn.com/appstore/default/defaulticon.webp
   appid: r4entertainment
-  version: 0.1.41
+  version: '1.0.0'
   title: Entertainment
   categories:
   - Lifestyle

--- a/r4sport/Chart.yaml
+++ b/r4sport/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.40
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/r4sport/TerminusManifest.yaml
+++ b/r4sport/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: recommend
 metadata:
   name: r4sport
   description: Sports News by R4. Watch the best coverage of your favourite sports.
   icon: https://file.bttcdn.com/appstore/default/defaulticon.webp
   appid: r4sport
-  version: 0.1.40
+  version: '1.0.0'
   title: Sport
   categories:
   - Sports

--- a/r4tech/Chart.yaml
+++ b/r4tech/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.40
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/r4tech/TerminusManifest.yaml
+++ b/r4tech/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: recommend
 metadata:
   name: r4tech
   description: Tech News by R4. Find the latest technology news from every corner of the globe.
   icon: https://file.bttcdn.com/appstore/default/defaulticon.webp
   appid: r4tech
-  version: 0.1.40
+  version: '1.0.0'
   title: Tech
   categories:
   - News

--- a/r4techbiz/Chart.yaml
+++ b/r4techbiz/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.44
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/r4techbiz/TerminusManifest.yaml
+++ b/r4techbiz/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: recommend
 metadata:
   name: r4techbiz
   description: "Tech & Business News by R4. Trending Tech and Business News on Chinese Social Media."
   icon: https://file.bttcdn.com/appstore/default/defaulticon.webp
   appid: r4techbiz
-  version: 0.1.44
+  version: '1.0.0'
   title: 'TechBiz'
   categories:
   - News

--- a/r4world/Chart.yaml
+++ b/r4world/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.41
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/r4world/TerminusManifest.yaml
+++ b/r4world/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: recommend
 metadata:
   name: r4world
   description: World News by R4. Get the latest world news headlines every day.
   icon: https://file.bttcdn.com/appstore/default/defaulticon.webp
   appid: r4world
-  version: 0.1.41
+  version: '1.0.0'
   title: World
   categories:
   - News

--- a/radarr/Chart.yaml
+++ b/radarr/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.10
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/radarr/TerminusManifest.yaml
+++ b/radarr/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: radarr
   description: A movie collection manager for Usenet and BitTorrent users.
   icon: https://file.bttcdn.com/appstore/radarr/icon.png
   appid: radarr
-  version: 0.0.10
+  version: '1.0.0'
   title: Radarr
   categories:
   - Entertainment

--- a/radicale/Chart.yaml
+++ b/radicale/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/radicale/TerminusManifest.yaml
+++ b/radicale/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: radicale
   description: Free and Open-Source CalDAV and CardDAV Server
   icon: https://file.bttcdn.com/appstore/radicale/icon.png
   appid: radicale
-  version: 0.0.3
+  version: '1.0.0'
   title: Radicale
   categories:
   - Productivity

--- a/readarr/Chart.yaml
+++ b/readarr/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.7
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/readarr/TerminusManifest.yaml
+++ b/readarr/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: readarr
@@ -6,7 +6,7 @@ metadata:
     users
   icon: https://file.bttcdn.com/appstore/readarr/icon.png
   appid: readarr
-  version: 0.0.7
+  version: '1.0.0'
   title: Readarr
   categories:
   - Entertainment

--- a/rsshub/Chart.yaml
+++ b/rsshub/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/rsshub/TerminusManifest.yaml
+++ b/rsshub/TerminusManifest.yaml
@@ -1,10 +1,10 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 metadata:
   name: rsshub
   description: A extensible RSS feed generator
   icon: https://file.bttcdn.com/appstore/rsshub/icon.png
   appid: rsshub
-  version: 0.0.2
+  version: '1.0.0'
   title: Rsshub
   categories:
   - Productivity

--- a/sdwebui/Chart.yaml
+++ b/sdwebui/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.19
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/sdwebui/TerminusManifest.yaml
+++ b/sdwebui/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: sdwebui
   description: Stable Diffusion web UI.
   icon: https://file.bttcdn.com/appstore/sdwebui/icon.png
   appid: sdwebui
-  version: 0.1.19
+  version: '1.0.0'
   title: SD Web UI For Cluster
   categories:
   - Productivity

--- a/sdwebuiclient/Chart.yaml
+++ b/sdwebuiclient/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.108.0'
 description: description
 name: sdwebuiclient
 type: application
-version: 0.0.9
+version: '1.0.0'

--- a/sdwebuiclient/TerminusManifest.yaml
+++ b/sdwebuiclient/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: sdwebuiclient
   description: Stable Diffusion web UI.
   icon: https://file.bttcdn.com/appstore/sdwebui/icon.png
   appid: sdwebuiclient
-  version: 0.0.9
+  version: '1.0.0'
   title: SD Web UI
   categories:
   - Productivity

--- a/sealcaster/Chart.yaml
+++ b/sealcaster/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/sealcaster/TerminusManifest.yaml
+++ b/sealcaster/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: sealcaster
   description: A way to publish casts anonymously at Farcaster
   icon: https://file.bttcdn.com/appstore/sealcaster/icon.webp
   appid: sealcaster
-  version: 0.0.2
+  version: '1.0.0'
   title: SealCaster
   categories:
   - Social Network

--- a/searxng/Chart.yaml
+++ b/searxng/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '2024.7.15-9a4fa7cc4'
 description: description
 name: searxng
 type: application
-version: 0.1.4
+version: '1.0.0'

--- a/searxng/TerminusManifest.yaml
+++ b/searxng/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: searxng
@@ -6,7 +6,7 @@ metadata:
   description: Search without being tracked.
   appid: searxng
   title: SearXNG For Cluster
-  version: 0.1.4
+  version: '1.0.0'
   categories:
   - Productivity
 entrances:

--- a/searxngclient/Chart.yaml
+++ b/searxngclient/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.108.0'
 description: description
 name: searxngclient
 type: application
-version: 0.0.1
+version: '1.0.0'

--- a/searxngclient/TerminusManifest.yaml
+++ b/searxngclient/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: searxngclient
   description: Search without being tracked.
   icon: https://file.bttcdn.com/appstore/searxng/icon.png
   appid: searxngclient
-  version: 0.0.1
+  version: '1.0.0'
   title: SearXNG
   categories:
   - Productivity

--- a/showdoc/Chart.yaml
+++ b/showdoc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.6
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/showdoc/TerminusManifest.yaml
+++ b/showdoc/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: showdoc
   description: A tool greatly applicable for an IT team to share documents online
   icon: https://file.bttcdn.com/appstore/showdoc/icon.png
   appid: showdoc
-  version: 0.0.6
+  version: '1.0.0'
   title: ShowDoc
   categories:
   - Productivity

--- a/sickchill/Chart.yaml
+++ b/sickchill/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/sickchill/TerminusManifest.yaml
+++ b/sickchill/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: sickchill
   description: SickChill is an automatic Video Library Manager for TV Shows.
   icon: https://file.bttcdn.com/appstore/sickchill/icon.png
   appid: sickchill
-  version: 0.0.4
+  version: '1.0.0'
   title: Sickchill
   categories:
   - Entertainment

--- a/sonarr/Chart.yaml
+++ b/sonarr/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.14
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/sonarr/TerminusManifest.yaml
+++ b/sonarr/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: sonarr
   description: Smart PVR for newsgroup and bittorrent users.
   icon: https://file.bttcdn.com/appstore/sonarr/icon.png
   appid: sonarr
-  version: 0.0.14
+  version: '1.0.0'
   title: Sonarr
   categories:
   - Entertainment

--- a/stealth7b/Chart.yaml
+++ b/stealth7b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/stealth7b/TerminusManifest.yaml
+++ b/stealth7b/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: model
 metadata:
   name: stealth7b
   description: A model enhanced in Math and Logic.
   icon: https://file.bttcdn.com/appstore/default/defaulticon.webp
   appid: stealth7b
-  version: 0.0.3
+  version: '1.0.0'
   title: Stealth 7B Q4
   categories:
   - Finetuned

--- a/steamheadless/Chart.yaml
+++ b/steamheadless/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.2.0'
 description: description
 name: steamheadless
 type: application
-version: 0.0.10
+version: '1.0.0'

--- a/steamheadless/TerminusManifest.yaml
+++ b/steamheadless/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: steamheadless
   description: A Headless Steam Service
   icon: https://file.bttcdn.com/appstore/steamheadless/icon.png
   appid: steamheadless
-  version: 0.0.10
+  version: '1.0.0'
   title: Steam Headless
   categories:
   - Entertainment

--- a/transmission/Chart.yaml
+++ b/transmission/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.6
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/transmission/TerminusManifest.yaml
+++ b/transmission/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: transmission
   description: Transmission is a cross-platform BitTorrent client
   icon: https://file.bttcdn.com/appstore/transmission/icon.png
   appid: transmission
-  version: 0.0.6
+  version: '1.0.0'
   title: Transmission
   categories:
   - Utilities

--- a/whisper/Chart.yaml
+++ b/whisper/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.3.0'
 description: description
 name: whisper
 type: application
-version: 0.1.1
+version: '1.0.0'

--- a/whisper/TerminusManifest.yaml
+++ b/whisper/TerminusManifest.yaml
@@ -1,4 +1,4 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   appid: whisper
@@ -8,7 +8,7 @@ metadata:
   icon: https://file.bttcdn.com/appstore/fasterwhisper/icon.png
   name: whisper
   title: Faster Whisper For Cluster
-  version: 0.1.1
+  version: '1.0.0'
 entrances:
 - authLevel: private
   host: whisper

--- a/whisperclient/Chart.yaml
+++ b/whisperclient/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.108.0'
 description: description
 name: whisperclient
 type: application
-version: 0.0.1
+version: '1.0.0'

--- a/whisperclient/TerminusManifest.yaml
+++ b/whisperclient/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: whisperclient
   description: Faster Whisper transcription with CTranslate2
   icon: https://file.bttcdn.com/appstore/fasterwhisper/icon.png
   appid: whisperclient
-  version: 0.0.1
+  version: '1.0.0'
   title: Faster Whisper
   categories:
   - Productivity

--- a/wordpress/Chart.yaml
+++ b/wordpress/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.16
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/wordpress/TerminusManifest.yaml
+++ b/wordpress/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: app
 metadata:
   name: wordpress
   description: Blog Tool, Publishing Platform, and CMS
   icon: https://file.bttcdn.com/appstore/wordpress/icon.png
   appid: wordpress
-  version: 0.0.16
+  version: '1.0.0'
   title: WordPress
   categories:
   - Social Network

--- a/yarnmistral7b/Chart.yaml
+++ b/yarnmistral7b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: '1.0.0'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/yarnmistral7b/TerminusManifest.yaml
+++ b/yarnmistral7b/TerminusManifest.yaml
@@ -1,11 +1,11 @@
-terminusManifest.version: '0.7.1'
+terminusManifest.version: '0.8.0'
 terminusManifest.type: model
 metadata:
   name: yarnmistral7b
   description: A state-of-the-art language model for long context.
   icon: https://file.bttcdn.com/appstore/default/defaulticon.webp
   appid: yarnmistral7b
-  version: 0.0.3
+  version: '1.0.0'
   title: Yarn Mistral 7B Q4
   categories:
   - Finetuned


### PR DESCRIPTION
Starting from Terminus 1.10.0, any TAC with TerminusManifest.yaml version lower than 0.8.0 can not be installed
This PR fix all existing apps in repo to accommodate this change by
- batch upgrading TerminusManifest.yaml to 0.8.0,
- batch upgrading exists chart version to 1.0.0, pushing updates to installed users
