### PR TITLE
[UPDATE][audiobookshelf][1.0.1] Support data sharing between host and application

### DIFF
--- a/audiobookshelf/Chart.yaml
+++ b/audiobookshelf/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 2.25.1
 description: description
 name: audiobookshelf
 type: application
-version: 1.0.0
+version: 1.0.1

--- a/audiobookshelf/OlaresManifest.yaml
+++ b/audiobookshelf/OlaresManifest.yaml
@@ -5,7 +5,7 @@ metadata:
   description: A self-hosted audiobook and podcast server.
   icon: https://file.bttcdn.com/appstore/audiobookshelf/icon.png
   appid: audiobookshelf
-  version: 1.0.0
+  version: 1.0.1
   title: AudioBookShelf
   categories:
   - Entertainment
@@ -28,7 +28,8 @@ options:
 permission:
   appCache: false
   appData: true
-  userData: []
+  userData:
+  - Home
 spec:
   versionName: '2.25.1'
   featuredImage: https://file.bttcdn.com/appstore/audiobookshelf/1.webp
@@ -78,3 +79,4 @@ spec:
   requiredGpu: "0"
   supportArch:
   - amd64
+  - arm64

--- a/audiobookshelf/templates/deployment.yaml
+++ b/audiobookshelf/templates/deployment.yaml
@@ -40,32 +40,32 @@ spec:
             cpu: 200m
             memory: 256Mi
         volumeMounts:
-        - mountPath: /audiobooks
-          name: app-data-audiobooks
-        - mountPath: /podcasts
-          name: app-data-podcasts
-        - mountPath: /metadata
-          name: app-data-metadata
-        - mountPath: /config
-          name: app-data-config
+        - name: home
+          mountPath: /home
+        - name: external
+          mountPath: /external
+        - name: app-data-metadata
+          mountPath: /metadata
+        - name: app-data-config
+          mountPath: /config
       restartPolicy: Always
       volumes:
-      - hostPath:
-          path: '{{ .Values.userspace.appData }}/audiobookshelf/audiobooks/'
+      - name: home
+        hostPath:
+          type: Directory
+          path: '{{ .Values.userspace.userData }}'
+      - name: external
+        hostPath:
           type: DirectoryOrCreate
-        name: app-data-audiobooks
-      - hostPath:
-          path: '{{ .Values.userspace.appData }}/audiobookshelf/podcasts'
+          path: '{{ .Values.sharedlib }}'
+      - name: app-data-metadata
+        hostPath:
           type: DirectoryOrCreate
-        name: app-data-podcasts
-      - hostPath:
           path: '{{ .Values.userspace.appData }}/audiobookshelf/metadata'
+      - name: app-data-config
+        hostPath:
           type: DirectoryOrCreate
-        name: app-data-metadata
-      - hostPath:
           path: '{{ .Values.userspace.appData }}/audiobookshelf/config'
-          type: DirectoryOrCreate
-        name: app-data-config
 
 ---
 apiVersion: v1


### PR DESCRIPTION
The app should mount the home directory and external directory for data sharing.

### PR Title 
> [UPDATE][audiobookshelf][1.0.1]

### App Title
> audiobookshelf

### Description
> Mount userData and external directory into application for data sharing between host and audiobookshelf.

### Statement
- [ ] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
