### PR TITLE
[UPDATE][mongodb]fix: mongodb node affinity selector

### DIFF
--- a/mongodb/templates/deployment.yaml
+++ b/mongodb/templates/deployment.yaml
@@ -92,7 +92,7 @@ spec:
             requiredDuringSchedulingIgnoredDuringExecution:
               nodeSelectorTerms:
               - matchExpressions:
-                - key: node-role.kubernetes.io/master
+                - key: node-role.kubernetes.io/control-plane
                   operator: Exists
       resources:
         limits:


### PR DESCRIPTION


### App Title
> mongodb

### Description
> failed to taint node affinity selector in mac minikube cluster

### Statement
- [ ] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
