### PR TITLE
[UPDATE][homeassistant][1.0.6]upgrade version 2025.8.3 add supportArch arm64

### DIFF
--- a/homeassistant/Chart.yaml
+++ b/homeassistant/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: '1.0.5'
+version: '1.0.6'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2025.5.0"
+appVersion: "2025.8.3"

--- a/homeassistant/OlaresManifest.yaml
+++ b/homeassistant/OlaresManifest.yaml
@@ -5,7 +5,7 @@ metadata:
   description: Awaken your home
   icon: https://file.bttcdn.com/appstore/homeassistant/icon.png
   appid: homeassistant
-  version: '1.0.5'
+  version: '1.0.6'
   title: Home Assistant
   categories:
   - Lifestyle
@@ -14,7 +14,7 @@ permission:
   appData: true
   appCache: true
 spec:
-  versionName: '2025.5.0'
+  versionName: '2025.8.3'
   featuredImage: https://file.bttcdn.com/appstore/homeassistant/promote_image_1v2.webp
   promoteImage:
   - https://file.bttcdn.com/appstore/homeassistant/promote_image_1v2.webp
@@ -93,6 +93,7 @@ spec:
     ios: https://apps.apple.com/us/app/home-assistant/id1099568401
   supportArch:
   - amd64
+  - arm64
 options:
   dependencies:
   - name: olares

--- a/homeassistant/templates/deployment.yaml
+++ b/homeassistant/templates/deployment.yaml
@@ -89,7 +89,7 @@ spec:
             runAsUser: 0
       containers:
       - name: homeassistant
-        image: docker.io/aboveos/homeassistant-home-assistant:2025.5.0b9
+        image: docker.io/linuxserver/homeassistant:2025.8.3
         resources:
           requests:
             cpu: 100m
@@ -124,11 +124,11 @@ spec:
       - name: homeassistant-config
         hostPath:
           type: DirectoryOrCreate
-          path: {{ .Values.userspace.appData}}/homeassistant
+          path: "{{ .Values.userspace.appData}}/homeassistant"
       - name: homeassistant-localtime
         hostPath:
           type: DirectoryOrCreate
-          path: {{ .Values.userspace.appData}}/homeassistant/localtime
+          path: "{{ .Values.userspace.appData}}/homeassistant/localtime"
       - name: config
         configMap:
           name: {{ .Release.Name }}-config


### PR DESCRIPTION
### App Title
homeassistant

### Description
- upgrade version 2025.8.3
- add supportArch arm64

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
