### PR TITLE
[UPDATE][codeserver][1.0.5]upgrade to 4.105.1 and remove os env

### DIFF
--- a/codeserver/Chart.yaml
+++ b/codeserver/Chart.yaml
@@ -1,8 +1,6 @@
 apiVersion: v2
 name: codeserver
 description: Run VS Code on any machine anywhere and access it in the browser.
-maintainers:
-- name: bytetrade
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -17,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: '1.0.3'
+version: '1.0.5'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "4.20.1"
+appVersion: "4.105.1"

--- a/codeserver/OlaresManifest.yaml
+++ b/codeserver/OlaresManifest.yaml
@@ -5,7 +5,7 @@ metadata:
   description: VS Code in the browser
   icon: https://app.cdn.olares.com/appstore/codeserver/icon.png
   appid: codeserver
-  version: '1.0.3'
+  version: '1.0.5'
   title: Code Server
   categories:
   - Developer Tools
@@ -15,14 +15,8 @@ permission:
   appData: true
   userData:
   - Home
-  sysData:
-  - dataType: app
-    group: service.bfl
-    version: v1
-    ops:
-    - InstallDevApp
 spec:
-  versionName: '4.20.1'
+  versionName: '4.105.1'
   featuredImage: https://app.cdn.olares.com/appstore/codeserver/promote_image_1v2.webp
   promoteImage:
   - https://app.cdn.olares.com/appstore/codeserver/promote_image_1v2.webp
@@ -53,12 +47,9 @@ spec:
 
   upgradeDescription: |
     Changed
-    * Updated to Code 1.85.2.
+    * Update to Code 1.105.1
 
-    Fixed
-    * Query variables are no longer double-encoded when going over the path proxy.
-
-    Origin: https://github.com/coder/code-server/releases/tag/v4.20.1
+    Origin: https://github.com/coder/code-server/releases/tag/v4.105.1
 
   developer: Coder Technologies, Inc.
   website: https://coder.com/

--- a/codeserver/i18n/en-US/OlaresManifest.yaml
+++ b/codeserver/i18n/en-US/OlaresManifest.yaml
@@ -25,9 +25,6 @@ spec:
     on various machines.
   upgradeDescription: |
     Changed
-    * Updated to Code 1.85.2.
+    * Update to Code 1.105.1
 
-    Fixed
-    * Query variables are no longer double-encoded when going over the path proxy.
-
-    Origin: https://github.com/coder/code-server/releases/tag/v4.20.1
+    Origin: https://github.com/coder/code-server/releases/tag/v4.105.1

--- a/codeserver/i18n/zh-CN/OlaresManifest.yaml
+++ b/codeserver/i18n/zh-CN/OlaresManifest.yaml
@@ -26,9 +26,6 @@ spec:
 
   upgradeDescription: |
     变更
-    * 更新至 Code 1.85.2。
+    * 更新至 Code 1.105.1
 
-    修复
-    * 修复了通过路径代理时查询变量重复编码的问题。
-
-    来源：https://github.com/coder/code-server/releases/tag/v4.20.1 
+    来源：https://github.com/coder/code-server/releases/tag/v4.105.1 

--- a/codeserver/templates/chartmuseum.yaml
+++ b/codeserver/templates/chartmuseum.yaml
@@ -25,7 +25,7 @@ spec:
             type: DirectoryOrCreate
       initContainers:
         - name: init-chmod-data
-          image: 'docker.io/aboveos/busybox:latest'
+          image: "docker.io/aboveos/busybox:1.37.0"
           command:
             - sh
             - '-c'

--- a/codeserver/templates/codeserver.yaml
+++ b/codeserver/templates/codeserver.yaml
@@ -78,7 +78,7 @@ spec:
       initContainers:
 
         - name: init-config
-          image: 'docker.io/aboveos/busybox:latest'
+          image: 'docker.io/aboveos/busybox:1.37.0'
           command:
             - sh
             - '-c'
@@ -92,7 +92,7 @@ spec:
               mountPath: /config.yaml
               subPath: config.yaml
         - name: init-chmod-data
-          image: 'docker.io/aboveos/busybox:latest'
+          image: 'docker.io/aboveos/busybox:1.37.0'
           command:
             - sh
             - '-c'
@@ -106,7 +106,7 @@ spec:
             runAsUser: 0
       containers:
         - name: code-server
-          image: docker.io/aboveos/codercom-code-server:latest
+          image: "docker.io/beclab/codercom-code-server:4.105.1"
           resources:
             requests:
               cpu: 100m
@@ -130,10 +130,6 @@ spec:
                 secretKeyRef:
                   name:  {{ .Release.Name }}-secret
                   key: password
-            - name: OS_API_KEY
-              value: {{ .Values.os.appKey }}
-            - name: OS_API_SECRET
-              value: {{ .Values.os.appSecret }}
             - name: OS_SYSTEM_SERVER
               value: system-server.user-system-{{ .Values.bfl.username }}
             - name: NAME_SPACE


### PR DESCRIPTION


### App Title
codeserver
### Description
upgrade to 4.105.1 and remove os env

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
