### PR TITLE
[UPDATE][steamheadless][1.0.19] Bump sunshine version to v2025.1201.3826

### DIFF
--- a/steamheadless/Chart.yaml
+++ b/steamheadless/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.2.0'
 description: description
 name: steamheadless
 type: application
-version: '1.0.18'
+version: '1.0.19'

--- a/steamheadless/OlaresManifest.yaml
+++ b/steamheadless/OlaresManifest.yaml
@@ -5,7 +5,7 @@ metadata:
   description: A Headless Steam Service
   icon: https://app.cdn.olares.com/appstore/steamheadless/icon.png
   appid: steamheadless
-  version: '1.0.18'
+  version: '1.0.19'
   title: Steam Headless
   categories:
   - Fun

--- a/steamheadless/templates/steam.yaml
+++ b/steamheadless/templates/steam.yaml
@@ -1,14 +1,3 @@
-{{- $ipfsDomainENV := split  ","  .Values.domain.steamheadlessaudio -}}
-{{- $webDomain := index $ipfsDomainENV "_0" -}}
-
-{{- $parts := split "." $webDomain }}
-{{- $subdomain := index $parts "_0" }}
-{{- $subdomain2 := split  $subdomain  .Values.domain.steamheadlessaudio -}}
-
-{{- $domain := index $subdomain2 "_0" }}
-{{- $domain2 := index $subdomain2 "_1" }}
-
-{{- $newWebDomain := printf "%s.local%s" $subdomain $domain2 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -78,7 +67,7 @@ spec:
             - name: PORT_AUDIO_WEBSOCKET
               value: "8088"
             - name: DOMAIN_AUDIO_WEBSOCKET
-              value: {{ $newWebDomain }}
+              value: {{ .Values.domain.steamheadlessaudio }}
             - name: PORT_NOVNC_WEB
               value: '8083'
             - name: NEKO_NAT1TO1
@@ -100,7 +89,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
-          image: bytetrade/steam-headless:v0.1.10
+          image: bytetrade/steam-headless:v0.1.11
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION

### App Title
steamheadless

### Description
1. Bump sunshine version to v2025.1201.3826 
2. Fix VNC web audio domain name

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
