### PR TITLE
[UPDATE][otmoiclp][2.5.3]

### DIFF
--- a/otmoiclp/Chart.yaml
+++ b/otmoiclp/Chart.yaml
@@ -17,10 +17,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.2
+version: 2.5.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.5.2"
+appVersion: "2.5.3"

--- a/otmoiclp/OlaresManifest.yaml
+++ b/otmoiclp/OlaresManifest.yaml
@@ -5,7 +5,7 @@ metadata:
   description: Otmoic LP
   icon: https://app.cdn.olares.com/appstore/obridgelpnode/icon.png
   appid: otmoiclp
-  version: 2.5.2
+  version: 2.5.3
   title: Otmoic LP
   categories:
   - Lifestyle
@@ -48,7 +48,7 @@ permission:
   userData:
   - Home/Code
 spec:
-  versionName: "2.5.2"
+  versionName: "2.5.3"
   promoteImage:
   - https://app.cdn.olares.com/appstore/obridgelpnode/1.png
   - https://app.cdn.olares.com/appstore/obridgelpnode/2.png
@@ -64,7 +64,7 @@ spec:
     Supports automatic market making by liquidity providers through applications installation in Olares OS
 
   upgradeDescription: |
-    Upgrade to v2.5.2
+    Upgrade to v2.5.3
 
     # Node
     Verification of matching between the transaction party's KYC information and the KYC restrictions in the bridge configuration

--- a/otmoiclp/i18n/en-US/OlaresManifest.yaml
+++ b/otmoiclp/i18n/en-US/OlaresManifest.yaml
@@ -13,7 +13,7 @@ spec:
     Supports automatic market making by liquidity providers through applications installation in Olares OS
 
   upgradeDescription: |
-    Upgrade to v2.5.2
+    Upgrade to v2.5.3
     # Node
     Enhanced dashboard with hedge configuration support and transaction history viewer;
     ChainClient stability improvements;

--- a/otmoiclp/i18n/zh-CN/OlaresManifest.yaml
+++ b/otmoiclp/i18n/zh-CN/OlaresManifest.yaml
@@ -14,7 +14,7 @@ spec:
     通过在 Olares 中安装应用程序，支持流动性提供者进行自动做市
 
   upgradeDescription: |
-    升级至 v2.5.2
+    升级至 v2.5.3
     # Node
     更完善的dashbord,可在dashboard中配置hedge, 查看发送历史;
     chainClient 稳定性提升;

--- a/otmoiclp/templates/admin.yaml
+++ b/otmoiclp/templates/admin.yaml
@@ -173,6 +173,34 @@ metadata:
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: lpnode-admin
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "pods/status"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "deployments/scale", "deployments/status"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["services", "services/status"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: lpnode-sa-rolebinding
@@ -183,7 +211,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: admin
+  name: lpnode-admin
   apiGroup: rbac.authorization.k8s.io
 ---
 # Source: lpnode-admin/templates/service.yaml


### PR DESCRIPTION
### Otmoic LP

### Description
> Update Otmoic LP to version 2.5.3
> Added custom RBAC role lpnode-admin with specific permissions for pods, deployments, services, configmaps, secrets, PVCs, and events
> Replaced generic admin role with the new lpnode-admin role in RoleBinding for better security and permission control

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
