### PR TITLE
fix(clawdbot): add chown to initContainer to fix permission issue

### DIFF
--- a/clawdbot/templates/deployment.yaml
+++ b/clawdbot/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         args:
           - |
             echo '{"gateway":{"mode":"local","auth":{"mode":"token","token":"clawdbot"},"trustedProxies":["10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"],"controlUi":{"allowInsecureAuth":true}}}' > /home/node/.clawdbot/clawdbot.json
+            chown -R 1000:1000 /home/node/.clawdbot
             echo "Created/updated config with trustedProxies and allowInsecureAuth"
         volumeMounts:
         - mountPath: /home/node/.clawdbot


### PR DESCRIPTION
## Summary

Fixes #1795

This PR fixes a permission issue that prevents Clawdbot from connecting to the dashboard after installation via Olares Market.

## Problem

The `initContainer` creates the config file as **root**, but the main container runs as user **node** (uid 1000). This causes the error:

```
disconnected (1008): gateway token mismatch
```

## Solution

Added `chown -R 1000:1000 /home/node/.clawdbot` to the initContainer script to transfer file ownership to the `node` user.

## Changes

| File | Change |
|------|--------|
| `clawdbot/templates/deployment.yaml` | Added `chown` command to initContainer |

## Diff

```diff
  args:
    - |
      echo '{"gateway":...}' > /home/node/.clawdbot/clawdbot.json
+     chown -R 1000:1000 /home/node/.clawdbot
      echo "Created/updated config..."
```

## Testing

| Scenario | Before | After |
|----------|--------|-------|
| File ownership | `root:root` | `node:node` |
| Dashboard status | `disconnected (1008)` | Connected |
| Health check | Failed | OK |

**Test procedure:**
1. Identified permission issue on running Olares instance
2. Manually ran `chown -R 1000:1000 /home/node/.clawdbot`
3. Restarted pod
4. Confirmed dashboard connection successful

## Checklist

- [x] Change follows Kubernetes/Helm best practices
- [x] No breaking changes introduced
- [x] Manually tested on Olares environment