### PR TITLE
[UPDATE][ollamaglm47flashv2][1.0.1]upgrade ollama to 0.15.6 and fix shared entrance compatibility

### DIFF
--- a/ollamaglm47flashv2/Chart.yaml
+++ b/ollamaglm47flashv2/Chart.yaml
@@ -3,5 +3,5 @@ appVersion: 'glm-4.7-flash:q4_K_M'
 description: description
 name: ollamaglm47flashv2
 type: application
-version: '1.0.0'
+version: '1.0.1'
 

--- a/ollamaglm47flashv2/OlaresManifest.yaml
+++ b/ollamaglm47flashv2/OlaresManifest.yaml
@@ -8,7 +8,7 @@ metadata:
   description: GLM-4.7-Flash is a high-performance, fast-responding language model
   appid: ollamaglm47flashv2
   title: GLM-4.7-Flash (Ollama)
-  version: '1.0.0'
+  version: '1.0.1'
   categories:
     - AI
 sharedEntrances:

--- a/ollamaglm47flashv2/ollamaglm47flashv2/Chart.yaml
+++ b/ollamaglm47flashv2/ollamaglm47flashv2/Chart.yaml
@@ -3,5 +3,5 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamaglm47flashv2
 type: application
-version: '1.0.0'
+version: '1.0.1'
 

--- a/ollamaglm47flashv2/ollamaglm47flashv2server/Chart.yaml
+++ b/ollamaglm47flashv2/ollamaglm47flashv2server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
-appVersion: '0.15.2'
+appVersion: '0.15.6'
 description: description
 name: ollamaserver
 type: application
-version: '1.0.0'
+version: '1.0.1'
 

--- a/ollamaglm47flashv2/ollamaglm47flashv2server/templates/deployment.yaml
+++ b/ollamaglm47flashv2/ollamaglm47flashv2server/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: ollama
-          image: "docker.io/beclab/ollama-ollama:0.15.2"
+          image: "docker.io/beclab/ollama-ollama:0.15.6"
 {{- with .Values.olaresEnv }}
 {{- if and .KEEP_ALIVE (eq (lower (toString .KEEP_ALIVE)) "true") }}
           command:
@@ -90,7 +90,7 @@ spec:
             - mountPath: "/root/.ollama"
               name: data
         - name: api
-          image: "docker.io/beclab/harveyff-olares-ollama:v0.1.0"
+          image: "docker.io/beclab/harveyff-olares-ollama:v0.1.1"
           env:
             - name: PGID
               value: "1000"


### PR DESCRIPTION
### App Title
ollamaglm47flashv2

### Description

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`