### PR TITLE
[UPDATE][ollamanomicembedtextv2][1.0.11]upgrade ollama to 0.15.6 and fix shared entrance compatibility

### DIFF
--- a/ollamanomicembedtextv2/Chart.yaml
+++ b/ollamanomicembedtextv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 'nomic-embed-text:137m-v1.5-fp16'
 description: description
 name: ollamanomicembedtextv2
 type: application
-version: '1.0.10'
+version: '1.0.11'

--- a/ollamanomicembedtextv2/OlaresManifest.yaml
+++ b/ollamanomicembedtextv2/OlaresManifest.yaml
@@ -8,7 +8,7 @@ metadata:
   description: A high-performing open embedding model with a large token context window.
   appid: ollamanomicembedtextv2
   title: Nomic Embed v1.5 (Ollama)
-  version: '1.0.10'
+  version: '1.0.11'
   categories:
     - AI
 sharedEntrances:

--- a/ollamanomicembedtextv2/ollamanomicembedtextv2/Chart.yaml
+++ b/ollamanomicembedtextv2/ollamanomicembedtextv2/Chart.yaml
@@ -3,5 +3,5 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamanomicembedtextv2
 type: application
-version: '1.0.10'
+version: '1.0.11'
 

--- a/ollamanomicembedtextv2/ollamanomicembedtextv2server/Chart.yaml
+++ b/ollamanomicembedtextv2/ollamanomicembedtextv2server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
-appVersion: '0.13.4'
+appVersion: '0.15.6'
 description: description
 name: ollamaserver
 type: application
-version: '1.0.10'
+version: '1.0.11'
 

--- a/ollamanomicembedtextv2/ollamanomicembedtextv2server/templates/deployment.yaml
+++ b/ollamanomicembedtextv2/ollamanomicembedtextv2server/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: ollama
-          image: "docker.io/beclab/ollama-ollama:0.15.2"
+          image: "docker.io/beclab/ollama-ollama:0.15.6"
 {{- with .Values.olaresEnv }}
 {{- if and .KEEP_ALIVE (eq (lower (toString .KEEP_ALIVE)) "true") }}
           command:
@@ -90,7 +90,7 @@ spec:
             - mountPath: "/root/.ollama"
               name: data
         - name: api
-          image: "docker.io/beclab/harveyff-olares-ollama:v0.1.0"
+          image: "docker.io/beclab/harveyff-olares-ollama:v0.1.1"
           env:
             - name: PGID
               value: "1000"


### PR DESCRIPTION
### App Title
ollamanomicembedtextv2

### Description

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`