### PR TITLE
[UPDATE][otmoiclp][2.5.5]

### DIFF
--- a/otmoiclp/Chart.yaml
+++ b/otmoiclp/Chart.yaml
@@ -17,10 +17,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.4
+version: 2.5.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.5.4"
+appVersion: "2.5.5"

--- a/otmoiclp/OlaresManifest.yaml
+++ b/otmoiclp/OlaresManifest.yaml
@@ -5,7 +5,7 @@ metadata:
   description: Otmoic LP
   icon: https://app.cdn.olares.com/appstore/obridgelpnode/icon.png
   appid: otmoiclp
-  version: 2.5.4
+  version: 2.5.5
   title: Otmoic LP
   categories:
   - Lifestyle
@@ -48,7 +48,7 @@ permission:
   userData:
   - Home/Code
 spec:
-  versionName: "2.5.4"
+  versionName: "2.5.5"
   promoteImage:
   - https://app.cdn.olares.com/appstore/obridgelpnode/1.png
   - https://app.cdn.olares.com/appstore/obridgelpnode/2.png
@@ -64,7 +64,9 @@ spec:
     Supports automatic market making by liquidity providers through applications installation in Olares OS
 
   upgradeDescription: |
-    Upgrade to v2.5.4
+    Upgrade to v2.5.5
+    
+    Change traefik ports to 8001/4443 to avoid privilege requirement
 
     # Node
     Verification of matching between the transaction party's KYC information and the KYC restrictions in the bridge configuration
@@ -109,7 +111,7 @@ options:
   dependencies:
   - name: olares
     type: system
-    version: '>=1.10.1-0'
+    version: '>=1.12.2-0'
   - name: mongodb
     version: ">=6.0.0-0"
     type: middleware
@@ -121,7 +123,7 @@ options:
       entranceName: traefik
 entrances:
 - name: traefik
-  port: 80
+  port: 8001
   host: traefik
   title: Otmoic LP
   icon: https://app.cdn.olares.com/appstore/obridgelpnode/icon.png

--- a/otmoiclp/templates/lpnode.yaml
+++ b/otmoiclp/templates/lpnode.yaml
@@ -41,10 +41,10 @@ spec:
         resources:
           requests:
             cpu: 20m
-            memory: 128Mi
+            memory: 512Mi
           limits:
             cpu: 500m
-            memory: 512Mi
+            memory: 1Gi
         ports:
           - containerPort: 9202
         env:

--- a/otmoiclp/templates/traefik.yaml
+++ b/otmoiclp/templates/traefik.yaml
@@ -118,11 +118,11 @@ spec:
     name: "traefik"
     targetPort: traefik
     protocol: TCP
-  - port: 80
+  - port: 8001
     name: "web"
     targetPort: web
     protocol: TCP
-  - port: 443
+  - port: 4443
     name: "websecure"
     targetPort: websecure
     protocol: TCP
@@ -171,10 +171,10 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 64Mi
-          limits:
-            cpu: 100m
             memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
         ports:
         - name: "metrics"
           containerPort: 9100
@@ -183,21 +183,19 @@ spec:
           containerPort: 8080
           protocol: "TCP"
         - name: "web"
-          containerPort: 80
+          containerPort: 8001
           protocol: "TCP"
         - name: "websecure"
-          containerPort: 443
+          containerPort: 4443
           protocol: "TCP"
         securityContext:
           capabilities:
-            add:
-            - NET_BIND_SERVICE
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 0
-          runAsNonRoot: false
-          runAsUser: 0
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
         volumeMounts:
           - name: data
             mountPath: /data
@@ -208,8 +206,8 @@ spec:
           - "--global.sendanonymoususage"
           - "--entrypoints.metrics.address=:9100/tcp"
           - "--entrypoints.traefik.address=:8080/tcp"
-          - "--entrypoints.web.address=:80/tcp"
-          - "--entrypoints.websecure.address=:443/tcp"
+          - "--entrypoints.web.address=:8001/tcp"
+          - "--entrypoints.websecure.address=:4443/tcp"
           - "--api.dashboard=true"
           - "--ping=true"
           - "--metrics.prometheus=true"


### PR DESCRIPTION
### App Title
Otmoic LP

### Description
- Bump version to 2.5.5
- Change traefik ports from 80/443 to 8001/4443 to avoid privilege requirement
- Run traefik as non-root user (UID 65532)
- Update olares dependency to >=1.12.2-0
- Adjust resource limits (lpnode: 512Mi/1Gi, traefik: 128Mi/256Mi)

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`