### PR TITLE
[NEW][llamacppqwen35a3b][1.0.0] Qwen3.5 35B-A3B via llama.cpp by aamsellem

### DIFF
--- a/llamacppqwen35a3b/Chart.yaml
+++ b/llamacppqwen35a3b/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: '1.0.0'
+description: Qwen3.5 35B-A3B served via llama.cpp
+name: llamacppqwen35a3b
+type: application
+version: '1.0.0'

--- a/llamacppqwen35a3b/OlaresManifest.yaml
+++ b/llamacppqwen35a3b/OlaresManifest.yaml
@@ -1,0 +1,56 @@
+---
+olaresManifest.version: '0.11.0'
+olaresManifest.type: app
+metadata:
+  name: llamacppqwen35a3b
+  icon: https://app.cdn.olares.com/appstore/llm/ollama/llm/qwen3-14b.png
+  description: "Qwen3.5 35B-A3B served via llama.cpp"
+  appid: llamacppqwen35a3b
+  title: Qwen 35B-A3B llamacpp
+  version: '1.0.0'
+  categories:
+    - AI
+entrances:
+  - name: llamacppqwen35a3b
+    port: 8080
+    host: llamacppqwen35a3b
+    title: Qwen 35B-A3B llamacpp
+    icon: https://app.cdn.olares.com/appstore/llm/ollama/llm/qwen3-14b.png
+    openMethod: window
+    authLevel: internal
+spec:
+  versionName: '1.0.0'
+  fullDescription: |
+    Qwen3.5 35B-A3B (MoE, 3B active) served via llama.cpp with Q4_K_M quantization.
+    Downloads the GGUF model on first launch and caches it.
+    Exposes an OpenAI-compatible API on port 8080.
+
+  developer: ggerganov
+  website: https://github.com/ggerganov/llama.cpp
+  submitter: orales-market
+  locale:
+    - en-US
+  license:
+    - text: MIT
+      url: https://github.com/ggerganov/llama.cpp/blob/master/LICENSE
+
+  limitedCpu: 8000m
+  requiredCpu: 1000m
+  requiredDisk: 15Gi
+  limitedDisk: 30Gi
+  limitedMemory: 16Gi
+  requiredMemory: 4Gi
+  requiredGpu: 1Gi
+  limitedGpu: 16Gi
+
+  supportArch:
+    - amd64
+    - arm64
+permission:
+  appData: true
+options:
+  apiTimeout: 0
+  dependencies:
+    - name: olares
+      version: '>=1.12.3-0'
+      type: system

--- a/llamacppqwen35a3b/i18n/en-US/OlaresManifest.yaml
+++ b/llamacppqwen35a3b/i18n/en-US/OlaresManifest.yaml
@@ -1,0 +1,9 @@
+metadata:
+  title: Qwen 35B-A3B llamacpp
+  description: "Qwen3.5 35B-A3B served via llama.cpp"
+
+spec:
+  fullDescription: |
+    Qwen3.5 35B-A3B (MoE, 3B active) served via llama.cpp with Q4_K_M quantization.
+    Downloads the GGUF model on first launch and caches it.
+    Exposes an OpenAI-compatible API on port 8080.

--- a/llamacppqwen35a3b/owners
+++ b/llamacppqwen35a3b/owners
@@ -1,0 +1,2 @@
+owners:
+- 'aamsellem'

--- a/llamacppqwen35a3b/templates/deployment.yaml
+++ b/llamacppqwen35a3b/templates/deployment.yaml
@@ -1,0 +1,145 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: llamacpp-env
+  namespace: "{{ .Release.Namespace }}"
+data:
+  MODEL_URL: "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF/resolve/main/Qwen3.5-35B-A3B-Q4_K_M.gguf"
+  MODEL_FILE: "Qwen3.5-35B-A3B-Q4_K_M.gguf"
+  MODEL_ALIAS: "qwen3.5-35b-a3b"
+  CONTEXT_SIZE: "32768"
+  N_GPU_LAYERS: "99"
+  THREADS: "4"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: llamacppqwen35a3b
+  name: llamacppqwen35a3b
+  namespace: "{{ .Release.Namespace }}"
+  annotations:
+    applications.app.bytetrade.io/gpu-inject: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: llamacppqwen35a3b
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.network/chrome-default: "true"
+        io.kompose.service: llamacppqwen35a3b
+    spec:
+      initContainers:
+        - name: model-downloader
+          image: "docker.io/alpine:3.20"
+          command:
+            - sh
+            - '-c'
+            - |
+              MODEL_PATH="/models/${MODEL_FILE}"
+              if [ -f "$MODEL_PATH" ]; then
+                echo "Model already downloaded: $MODEL_PATH"
+                ls -lh "$MODEL_PATH"
+              else
+                echo "Downloading model from $MODEL_URL ..."
+                wget -O "$MODEL_PATH.tmp" "$MODEL_URL"
+                mv "$MODEL_PATH.tmp" "$MODEL_PATH"
+                echo "Download complete."
+                ls -lh "$MODEL_PATH"
+              fi
+          envFrom:
+            - configMapRef:
+                name: llamacpp-env
+          resources:
+            limits:
+              cpu: "2"
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - mountPath: "/models"
+              name: models
+      containers:
+        - name: llamacpp-server
+          image: "ghcr.io/ggml-org/llama.cpp:server-cuda"
+          args:
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "8080"
+            - "--model"
+            - "/models/$(MODEL_FILE)"
+            - "--alias"
+            - "$(MODEL_ALIAS)"
+            - "--ctx-size"
+            - "$(CONTEXT_SIZE)"
+            - "--n-gpu-layers"
+            - "$(N_GPU_LAYERS)"
+            - "--threads"
+            - "$(THREADS)"
+          envFrom:
+            - configMapRef:
+                name: llamacpp-env
+          ports:
+            - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 60
+            timeoutSeconds: 10
+            periodSeconds: 30
+            failureThreshold: 5
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 10
+            failureThreshold: 120
+          resources:
+            limits:
+              cpu: "6"
+              memory: 16Gi
+            requests:
+              cpu: 500m
+              memory: 2Gi
+          volumeMounts:
+            - mountPath: "/models"
+              name: models
+      volumes:
+        - name: models
+          hostPath:
+            path: "{{ .Values.userspace.appData }}/models"
+            type: DirectoryOrCreate
+      restartPolicy: Always
+status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: llamacppqwen35a3b
+  name: llamacppqwen35a3b
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  ports:
+    - name: "llamacpp"
+      port: 8080
+      targetPort: 8080
+  selector:
+    io.kompose.service: llamacppqwen35a3b
+status:
+  loadBalancer: {}

--- a/llamacppqwen35a3b/values.yaml
+++ b/llamacppqwen35a3b/values.yaml
@@ -1,0 +1,7 @@
+admin: ""
+bfl:
+  username: ""
+userspace:
+  appData: ""
+  appCache: ""
+  userData: ""


### PR DESCRIPTION
## Summary
- Qwen3.5 35B-A3B (MoE, 3B active params) served via llama.cpp
- Q4_K_M GGUF quantization from unsloth/Qwen3.5-35B-A3B-GGUF
- OpenAI-compatible API on port 8080
- Auto-downloads model on first launch, caches in appData
- GPU-accelerated inference with CUDA support

## Details
- **Backend**: ghcr.io/ggml-org/llama.cpp:server-cuda
- **Model**: ~22GB GGUF (Q4_K_M)
- **Context**: 32768 tokens
- **GPU**: Full offload (n-gpu-layers=99)

## Author
- **Submitter**: [@aamsellem](https://github.com/aamsellem)
- **Source**: https://github.com/aamsellem/orales-market