### PR TITLE
[UPDATE][llamacppqwen35a3b][1.0.2] Fix title, disk, arch and metadata

### DIFF
--- a/llamacppqwen35a3b/Chart.yaml
+++ b/llamacppqwen35a3b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: '1.0.0'
+appVersion: '1.0.2'
 description: Qwen3.5 35B-A3B served via llama.cpp
 name: llamacppqwen35a3b
 type: application
-version: '1.0.1'
+version: '1.0.2'

--- a/llamacppqwen35a3b/OlaresManifest.yaml
+++ b/llamacppqwen35a3b/OlaresManifest.yaml
@@ -6,8 +6,8 @@ metadata:
   icon: https://app.cdn.olares.com/appstore/llm/ollama/llm/qwen3-14b.png
   description: "Qwen3.5 35B-A3B served via llama.cpp"
   appid: llamacppqwen35a3b
-  title: Qwen 35B-A3B llamacpp
-  version: '1.0.1'
+  title: Qwen3.5 35B-A3B Q4_K_M (lcpp)
+  version: '1.0.2'
   categories:
     - AI
 entrances:
@@ -19,7 +19,7 @@ entrances:
     openMethod: window
     authLevel: internal
 spec:
-  versionName: '1.0.0'
+  versionName: '1.0.2'
   fullDescription: |
     Qwen3.5 35B-A3B (MoE, 3B active) served via llama.cpp with Q4_K_M quantization.
     Downloads the GGUF model on first launch and caches it.
@@ -27,6 +27,7 @@ spec:
 
   developer: aamsellem
   website: https://github.com/aamsellem/orales-market
+  sourceCode: https://github.com/aamsellem/orales-market
   submitter: aamsellem
   locale:
     - en-US
@@ -36,8 +37,8 @@ spec:
 
   limitedCpu: 8000m
   requiredCpu: 1000m
-  requiredDisk: 15Gi
-  limitedDisk: 30Gi
+  requiredDisk: 25Gi
+  limitedDisk: 50Gi
   limitedMemory: 16Gi
   requiredMemory: 4Gi
   requiredGpu: 1Gi
@@ -45,7 +46,6 @@ spec:
 
   supportArch:
     - amd64
-    - arm64
 permission:
   appData: true
 options:

--- a/llamacppqwen35a3b/i18n/en-US/OlaresManifest.yaml
+++ b/llamacppqwen35a3b/i18n/en-US/OlaresManifest.yaml
@@ -1,5 +1,5 @@
 metadata:
-  title: Qwen 35B-A3B llamacpp
+  title: Qwen3.5 35B-A3B Q4_K_M (lcpp)
   description: "Qwen3.5 35B-A3B served via llama.cpp"
 
 spec:


### PR DESCRIPTION
## Summary
- **Title**: `Qwen3.5 35B-A3B Q4_K_M (lcpp)` (consistent with store naming convention)
- **Disk**: `requiredDisk: 25Gi`, `limitedDisk: 50Gi` (GGUF model is ~20GB)
- **Arch**: amd64 only (server-cuda image, no arm64 support)
- **Metadata**: add `sourceCode` field, sync `versionName` to `1.0.2`

## Test plan
- [ ] Verify lint passes with updated title format
- [ ] Confirm disk requirements match actual model size
- [ ] Check amd64-only arch is correct for server-cuda image

🤖 Generated with [Claude Code](https://claude.com/claude-code)