### PR TITLE
[UPDATE][ollamaqwen35a3budq4klv2][1.0.4]upgrade ollama runtime to 0.18.1 and change default config

### DIFF
--- a/ollamaqwen35a3budq4klv2/Chart.yaml
+++ b/ollamaqwen35a3budq4klv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 'Qwen3.5-35B-A3B-UD-Q4_K_L'
 description: description
 name: ollamaqwen35a3budq4klv2
 type: application
-version: '1.0.2'
+version: '1.0.4'

--- a/ollamaqwen35a3budq4klv2/OlaresManifest.yaml
+++ b/ollamaqwen35a3budq4klv2/OlaresManifest.yaml
@@ -5,10 +5,10 @@ apiVersion: 'v2'
 metadata:
   name: ollamaqwen35a3budq4klv2
   icon: https://app.cdn.olares.com/appstore/llm/ollama/llm/qwen3-14b.png
-  description: Run Qwen3.5-35B-A3B (Q4_K_L quantization) locally via Ollama.
+  description: Run Qwen3.5-35B-A3B GGUF (Q4_K_L quantization) locally via Ollama.
   appid: ollamaqwen35a3budq4klv2
-  title: Qwen3.5 35B A3B UD Q4 (Ollama)
-  version: '1.0.2'
+  title: Qwen3.5 35B A3B Q4 (Ollama)
+  version: '1.0.4'
   categories:
     - AI
 sharedEntrances:
@@ -39,9 +39,13 @@ spec:
     - Model: Qwen3.5-35B-A3B-UD-Q4_K_L
     - Source: unsloth/Qwen3.5-35B-A3B-GGUF (Hugging Face)
     - Quantization: Q4_K_L
-    - Context: 128000
+    - Context: 131072
     - Backend: Ollama
 
+  upgradeDescription: |
+    1. Ollama runtime upgraded to 0.18.1
+    2. num_ctx pinned to 131072 (128K) instead of relying on model defaults
+    3. GGUF models now use explicit Go Template injection, enabling Thinking (<think> blocks) and Tool Call (OpenAI-compatible function calling)
   developer: Alibaba
   website: https://qwen.ai/home
   submitter: Olares
@@ -59,7 +63,7 @@ spec:
   limitedDisk: 500Gi
   limitedMemory: 40Gi
   requiredMemory: 4200Mi
-  requiredGpu: 23.5
+  requiredGpu: 23.5Gi
   limitedGpu: 28Gi
   {{- else }}
   requiredMemory: 64Mi

--- a/ollamaqwen35a3budq4klv2/i18n/en-US/OlaresManifest.yaml
+++ b/ollamaqwen35a3budq4klv2/i18n/en-US/OlaresManifest.yaml
@@ -1,6 +1,6 @@
 metadata:
-  title: Qwen3.5 35B A3B UD Q4 (Ollama)
-  description: Run Qwen3.5-35B-A3B (Q4_K_L quantization) locally via Ollama.
+  title: Qwen3.5 35B A3B Q4 (Ollama)
+  description: Run Qwen3.5-35B-A3B GGUF (Q4_K_L quantization) locally via Ollama.
 
 spec:
   fullDescription: |
@@ -13,5 +13,10 @@ spec:
     - Model: Qwen3.5-35B-A3B-UD-Q4_K_L
     - Source: unsloth/Qwen3.5-35B-A3B-GGUF (Hugging Face)
     - Quantization: Q4_K_L
-    - Context: 128000
+    - Context: 131072
     - Backend: Ollama
+
+  upgradeDescription: |
+    1. Ollama runtime upgraded to 0.18.1
+    2. num_ctx pinned to 131072 (128K) instead of relying on model defaults
+    3. GGUF models now use explicit Go Template injection, enabling Thinking (<think> blocks) and Tool Call (OpenAI-compatible function calling)

--- a/ollamaqwen35a3budq4klv2/i18n/zh-CN/OlaresManifest.yaml
+++ b/ollamaqwen35a3budq4klv2/i18n/zh-CN/OlaresManifest.yaml
@@ -1,6 +1,6 @@
 metadata:
-  title: Qwen3.5 35B A3B UD Q4 (Ollama)
-  description: 通过 Ollama 本地运行 Qwen3.5-35B-A3B（Q4_K_L 量化）。
+  title: Qwen3.5 35B A3B Q4 (Ollama)
+  description: 通过 Ollama 本地运行 Qwen3.5-35B-A3B GGUF（Q4_K_L 量化）。
 
 spec:
   fullDescription: |
@@ -13,5 +13,10 @@ spec:
     - 模型：Qwen3.5-35B-A3B-UD-Q4_K_L
     - 来源：unsloth/Qwen3.5-35B-A3B-GGUF（Hugging Face）
     - 量化：Q4_K_L
-    - 上下文：128000
+    - 上下文：131072
     - 后端：Ollama
+
+  upgradeDescription: |
+    1. Ollama 运行时升级至 0.18.1
+    2. num_ctx 固定为 131072（128K），不再依赖模型默认值
+    3. GGUF 模型通过显式 Go Template 注入，支持 Thinking（<think> 块）及 Tool Call（OpenAI 兼容函数调用）

--- a/ollamaqwen35a3budq4klv2/ollamaqwen35a3budq4klv2/Chart.yaml
+++ b/ollamaqwen35a3budq4klv2/ollamaqwen35a3budq4klv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamaqwen35a3budq4klv2
 type: application
-version: '1.0.2'
+version: '1.0.4'

--- a/ollamaqwen35a3budq4klv2/ollamaqwen35a3budq4klv2server/Chart.yaml
+++ b/ollamaqwen35a3budq4klv2/ollamaqwen35a3budq4klv2server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: '0.18.0'
+appVersion: '0.18.1'
 description: description
 name: ollamaqwen35a3budq4klv2server
 type: application
-version: '1.0.2'
+version: '1.0.4'

--- a/ollamaqwen35a3budq4klv2/ollamaqwen35a3budq4klv2server/templates/api.yaml
+++ b/ollamaqwen35a3budq4klv2/ollamaqwen35a3budq4klv2server/templates/api.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: api
-          image: "docker.io/beclab/harveyff-olares-ollama:v0.1.15"
+          image: "docker.io/beclab/harveyff-olares-ollama:v0.1.17"
           env:
             - name: PGID
               value: "1000"
@@ -79,6 +79,21 @@ spec:
                 configMapKeyRef:
                   name: ollama-env
                   key: GGUF_TEMPLATE_NAME
+            - name: OLLAMA_CONTEXT_LENGTH
+              valueFrom:
+                configMapKeyRef:
+                  name: ollama-env
+                  key: OLLAMA_CONTEXT_LENGTH
+            - name: OLLAMA_REPEAT_PENALTY
+              valueFrom:
+                configMapKeyRef:
+                  name: ollama-env
+                  key: OLLAMA_REPEAT_PENALTY
+            - name: OLLAMA_REPEAT_LAST_N
+              valueFrom:
+                configMapKeyRef:
+                  name: ollama-env
+                  key: OLLAMA_REPEAT_LAST_N
           resources:
             requests:
               cpu: 300m

--- a/ollamaqwen35a3budq4klv2/ollamaqwen35a3budq4klv2server/templates/configmap.yaml
+++ b/ollamaqwen35a3budq4klv2/ollamaqwen35a3budq4klv2server/templates/configmap.yaml
@@ -19,9 +19,11 @@ data:
   HF_FILE: "Qwen3.5-35B-A3B-UD-Q4_K_L.gguf"
   HF_ENDPOINT: "{{ $hfEndpoint }}"
   GGUF_DIR: "/models"
-  GGUF_PARAMS: '{"num_ctx": 128000, "stop": ["<|im_end|>", "<|endoftext|>"]}'
-  GGUF_TEMPLATE_NAME: "chatml"
-  OLLAMA_CONTEXT_LENGTH: "128000"
+  GGUF_PARAMS: '{"stop": ["<|im_end|>", "<|endoftext|>"], "repeat_penalty": 1.2, "repeat_last_n": 128}'
+  GGUF_TEMPLATE_NAME: "qwen3.5"
+  OLLAMA_CONTEXT_LENGTH: "131072"
+  OLLAMA_REPEAT_PENALTY: "1.2"
+  OLLAMA_REPEAT_LAST_N: "128"
   OLLAMA_NUM_PARALLEL: "1"
   OLLAMA_FLASH_ATTENTION: "1"
   OLLAMA_KV_CACHE_TYPE: "q8_0"

--- a/ollamaqwen35a3budq4klv2/ollamaqwen35a3budq4klv2server/templates/deployment.yaml
+++ b/ollamaqwen35a3budq4klv2/ollamaqwen35a3budq4klv2server/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: ollama
-          image: "docker.io/beclab/ollama-ollama:0.18.0"
+          image: "docker.io/beclab/ollama-ollama:0.18.1"
           command:
             - sh
             - '-c'
@@ -40,19 +40,6 @@ spec:
                 sleep 1
               done
               echo "Ollama server is ready."
-
-              # Background: wait for API container to register model (chatml),
-              # then re-create with tool-supporting template
-              (
-                echo "Waiting for model ${MODEL_NAME} to be registered by API container..."
-                while ! ollama list 2>/dev/null | grep -q "${MODEL_NAME}"; do
-                  sleep 5
-                done
-                echo "Model ${MODEL_NAME} found. Decoding Modelfile and re-creating with tool support..."
-                echo "${MODELFILE_B64}" | base64 -d > /tmp/Modelfile
-                ollama create ${MODEL_NAME} -f /tmp/Modelfile || true
-                echo "Model re-created with tool support."
-              ) &
 
               {{- with .Values.olaresEnv }}
               {{- if and .KEEP_ALIVE (eq (lower (toString .KEEP_ALIVE)) "true") }}


### PR DESCRIPTION
### App Title
ollamaqwen35a3budq4klv2

### Description
    1. Ollama runtime upgraded to 0.18.1
    2. num_ctx pinned to 131072 (128K) instead of relying on model defaults
    3. GGUF models now use explicit Go Template injection, enabling Thinking (<think> blocks) and Tool Call (OpenAI-compatible function calling)
### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`