### PR TITLE
[UPDATE][louter][0.2.0]Per-key routing mode, simplified distillation

### DIFF
--- a/louter/Chart.yaml
+++ b/louter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: louter
 description: Local LLM gateway with hybrid inference and distillation
 type: application
-version: '0.1.0'
-appVersion: '1.0.0'
+version: '0.2.0'
+appVersion: '2.0.0'

--- a/louter/OlaresManifest.yaml
+++ b/louter/OlaresManifest.yaml
@@ -6,7 +6,7 @@ metadata:
   description: Local LLM gateway with hybrid inference and distillation. Route AI agents to the right model — cloud or local — with automatic training data collection.
   icon: https://raw.githubusercontent.com/Drlucaslu/louter/main/web/public/icon.png
   appid: louter
-  version: '0.1.0'
+  version: '0.2.0'
   title: Louter
   categories:
     - Productivity
@@ -26,20 +26,24 @@ permission:
   appCache: true
 
 spec:
-  versionName: '1.0.0'
+  versionName: '2.0.0'
   fullDescription: |
     Louter is a single-binary LLM API gateway that sits between your AI agents and LLM providers.
 
     Features:
     - One endpoint for all providers (OpenAI, Anthropic, Azure, DeepSeek, Ollama)
     - Hybrid inference: route simple requests to local model, complex ones to cloud
+    - Per-key routing mode: choose "rules", "hybrid", or "smart" per API key
     - Distillation pipeline: collect cloud responses, fine-tune local model, deploy
     - Session-aware routing: same model throughout a conversation
     - Tool call normalizer: parse Hermes/Qwen/ReAct formats to OpenAI standard
     - Implicit feedback: detect agent retries to label training data
     - Runtime tuning: adjust routing thresholds via API without restart
     - Built-in Web UI for management and monitoring
-  upgradeDescription: Initial release
+  upgradeDescription: |
+    - Per-key routing mode: choose rules, hybrid, or smart per API key
+    - Simplified distillation: direct Ollama safetensors import, no GGUF needed
+    - Dead code cleanup and documentation updates
   developer: Drlucaslu
   website: https://github.com/Drlucaslu/louter
   sourceCode: https://github.com/Drlucaslu/louter

--- a/louter/templates/deployment.yaml
+++ b/louter/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: louter
-          image: "docker.io/sixwings740/louter:0.1.0"
+          image: "docker.io/sixwings740/louter:0.2.0"
           ports:
             - name: http
               containerPort: 6188


### PR DESCRIPTION
## Update: Louter 0.2.0

- **Per-key routing mode**: each API key can now choose "rules", "hybrid", or "smart" routing independently
- **Simplified distillation**: removed GGUF conversion, uses Ollama 0.18+ direct safetensors import for all model architectures
- Dead code cleanup and documentation updates

Image: `sixwings740/louter:0.2.0`