### PR TITLE
[UPDATE][steamheadless][1.0.29]add conflict with Isaaclab

### DIFF
--- a/steamheadless/Chart.yaml
+++ b/steamheadless/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.2.0'
 description: description
 name: steamheadless
 type: application
-version: '1.0.28'
+version: '1.0.29'

--- a/steamheadless/OlaresManifest.yaml
+++ b/steamheadless/OlaresManifest.yaml
@@ -5,7 +5,7 @@ metadata:
   description: A Headless Steam Service
   icon: https://app.cdn.olares.com/appstore/steamheadless/icon.png
   appid: steamheadless
-  version: '1.0.28'
+  version: '1.0.29'
   title: Steam Headless
   categories:
   - Fun
@@ -132,6 +132,9 @@ spec:
   - amd64
 options:
   apiTimeout: 0
+  conflicts:
+  - name: isaaclab
+    type: application
   dependencies:
   - name: olares
     type: system


### PR DESCRIPTION


### App Title
Steam Headless
### Description
conflict with Isaaclab

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
