### PR TITLE
[UPDATE][opennotebook][1.0.3] Upgrade opennotebook from 1.4.0 to 1.8.5

### DIFF
--- a/opennotebook/Chart.yaml
+++ b/opennotebook/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: '1.4.0'
+appVersion: '1.8.5'
 description: Open Notebook - A modern notebook application
 name: opennotebook
 type: application
-version: '1.0.2'
+version: '1.0.3'
 
 

--- a/opennotebook/OlaresManifest.yaml
+++ b/opennotebook/OlaresManifest.yaml
@@ -6,7 +6,7 @@ metadata:
   description: A powerful open-source, AI-powered note-taking/research platform that respects your privacy
   appid: opennotebook
   title: Open Notebook
-  version: '1.0.2'
+  version: '1.0.3'
   categories:
   - Productivity_v112
   - Productivity
@@ -19,7 +19,7 @@ entrances:
   port: 8080
   title: Open Notebook
 spec:
-  versionName: '1.4.0'
+  versionName: '1.8.5'
   promoteImage:
   - https://app.cdn.olares.com/appstore/opennotebook/1.webp
   - https://app.cdn.olares.com/appstore/opennotebook/2.webp
@@ -40,21 +40,9 @@ spec:
     - Chat with context: AI conversations powered by your research
 
   upgradeDescription: |
-    Open Notebook version 1.4.0
+    Open Notebook version 1.8.5
     
-    Major Updates:
-    - Upgraded to Next.js 16 (from v15.4.10)
-    - Increased file upload limit from 10MB to 100MB
-    - Improved offline/airgapped deployment support
-    - Enhanced user onboarding experience with prominent "Create Notebook" button
-    - Better file management: orphaned files are now cleaned up when sources are removed
-    
-    Technical Improvements:
-    - React and react-dom upgraded to 19.2.3
-    - middleware.ts renamed to proxy.ts (Next.js 16 requirement)
-    - Fixed documentation links and removed incorrect ZIP support references
-    
-    Full release note at: https://github.com/lfnovo/open-notebook/releases/tag/v1.4.0
+    Full release note at: https://github.com/lfnovo/open-notebook/releases/tag/v1.8.5
 
   developer: lfnovo
   website: https://www.open-notebook.ai/

--- a/opennotebook/i18n/en-US/OlaresManifest.yaml
+++ b/opennotebook/i18n/en-US/OlaresManifest.yaml
@@ -16,7 +16,7 @@ spec:
     - Chat with context: AI conversations powered by your research
 
   upgradeDescription: |
-    Open Notebook version 1.4.0
+    Open Notebook version 1.8.5
     
     Major Updates:
     - Upgraded to Next.js 16 (from v15.4.10)
@@ -30,5 +30,5 @@ spec:
     - middleware.ts renamed to proxy.ts (Next.js 16 requirement)
     - Fixed documentation links and removed incorrect ZIP support references
     
-    Full release note at: https://github.com/lfnovo/open-notebook/releases/tag/v1.4.0
+    Full release note at: https://github.com/lfnovo/open-notebook/releases/tag/v1.8.5
 

--- a/opennotebook/i18n/zh-CN/OlaresManifest.yaml
+++ b/opennotebook/i18n/zh-CN/OlaresManifest.yaml
@@ -16,7 +16,7 @@ spec:
     - 上下文对话：由您研究内容驱动的 AI 智能对话
 
   upgradeDescription: |
-    Open Notebook 1.4.0 版本
+    Open Notebook 1.8.5 版本
     
     主要更新：
     - 升级到 Next.js 16（从 v15.4.10）
@@ -30,6 +30,6 @@ spec:
     - middleware.ts 重命名为 proxy.ts（Next.js 16 要求）
     - 修复文档链接并移除错误的 ZIP 支持引用
     
-    完整发布说明请参阅：https://github.com/lfnovo/open-notebook/releases/tag/v1.4.0
+    完整发布说明请参阅：https://github.com/lfnovo/open-notebook/releases/tag/v1.8.5
 
 


### PR DESCRIPTION
## Changes
- Upgrade opennotebook from 1.4.0 to 1.8.5
- Chart version: 1.0.2 → 1.0.3
- Updated upgradeDescription with release notes