### PR TITLE
[UPDATE][nextcloud][1.0.15] proxy DAV paths and bump chart to 1.0.15 for Calendar

### DIFF
--- a/nextcloud/Chart.yaml
+++ b/nextcloud/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 31.0.4
 description: A Helm chart for Kubernetes
 name: nextcloud
 type: application
-version: 1.0.13
+version: 1.0.15

--- a/nextcloud/OlaresManifest.yaml
+++ b/nextcloud/OlaresManifest.yaml
@@ -5,7 +5,7 @@ metadata:
   description: The productivity platform that keeps you in control
   icon: https://app.cdn.olares.com/appstore/nextcloud/icon2.png
   appid: nextcloud
-  version: '1.0.13'
+  version: '1.0.15'
   title: Nextcloud
   categories:
   - Productivity_v112
@@ -35,25 +35,13 @@ spec:
     - Security with our encryption mechanisms, HackerOne bounty program and two-factor authentication.
 
   upgradeDescription: |
-    Upgrade App Version to 31.0.4
-    
-    What's Changed
-    - [stable31] fix(taskprocessing): use the event for AppAPI to get list of AI providers by @backportbot in #52120
-    - [stable31] fix(dav): Really only run the chunk cleanup once by @backportbot in #52054
-    - [stable31] fix(files_sharing): fix share creation error handling by @backportbot in #52078
-    - [stable31] feat(bulk-upload): change the default to disabled as there are still some bugs present by @backportbot in #52123
-    - [stable31] fix(federation): Don't load the addressbook when resolving a cloud ID by @backportbot in #52068
-    - [stable31] ignore missing theming app by @ArtificialOwl in #52135
-    - [stable31] fix(ContextAgent): Do not translate the name ContextAgent by @backportbot in #52169
-    - build(deps): bump marked from 15.0.7 to 15.0.8 by @dependabot in #52155
-    - [stable31] chore(files_trashbin): Add user details in log from Trashbin by @backportbot in #51999
-    - [stable31] fix: Handle missing share providers when promoting reshares by @backportbot in #52043
-    - build(deps): bump @nextcloud/event-bus from 3.3.1 to 3.3.2 by @dependabot in #51348
-    - build(deps): bump dompurify from 3.2.4 to 3.2.5 by @dependabot in #51964
-    - [stable31] fix(files_sharing): rate limit share creation 20 times per 10 minutes by @backportbot in #52206
-    - [stable31] fix(files_sharing): Apply default password setting in SharingDetailsTab by @backportbot in #52208
+    Fix update (v1.0.14)
 
-    View full release note at: https://github.com/nextcloud/server/releases/tag/v31.0.4
+    What's Fixed
+    - Fix Calendar, Contacts, and other CalDAV/CardDAV features stuck loading or failing with errors such as `findAllCalendars` / `_extractAdvertisedDavFeatures`
+    - The reverse proxy no longer short-circuits OPTIONS requests for `/remote.php/dav/` and related API paths; DAV headers are now passed through from Nextcloud correctly
+
+    Note: Nextcloud version remains 31.0.4. No application upgrade in this release.
 
   developer: Nextcloud GmbH
   submitter: Olares

--- a/nextcloud/i18n/en-US/OlaresManifest.yaml
+++ b/nextcloud/i18n/en-US/OlaresManifest.yaml
@@ -13,22 +13,10 @@ spec:
     - Expandable with hundreds of Apps ...like Calendar, Contacts, Mail, Video Chat and all those you can discover in our App Store
     - Security with our encryption mechanisms, HackerOne bounty program and two-factor authentication.
   upgradeDescription: |
-    Upgrade App Version to 31.0.4
-    
-    What's Changed
-    - [stable31] fix(taskprocessing): use the event for AppAPI to get list of AI providers by @backportbot in #52120
-    - [stable31] fix(dav): Really only run the chunk cleanup once by @backportbot in #52054
-    - [stable31] fix(files_sharing): fix share creation error handling by @backportbot in #52078
-    - [stable31] feat(bulk-upload): change the default to disabled as there are still some bugs present by @backportbot in #52123
-    - [stable31] fix(federation): Don't load the addressbook when resolving a cloud ID by @backportbot in #52068
-    - [stable31] ignore missing theming app by @ArtificialOwl in #52135
-    - [stable31] fix(ContextAgent): Do not translate the name ContextAgent by @backportbot in #52169
-    - build(deps): bump marked from 15.0.7 to 15.0.8 by @dependabot in #52155
-    - [stable31] chore(files_trashbin): Add user details in log from Trashbin by @backportbot in #51999
-    - [stable31] fix: Handle missing share providers when promoting reshares by @backportbot in #52043
-    - build(deps): bump @nextcloud/event-bus from 3.3.1 to 3.3.2 by @dependabot in #51348
-    - build(deps): bump dompurify from 3.2.4 to 3.2.5 by @dependabot in #51964
-    - [stable31] fix(files_sharing): rate limit share creation 20 times per 10 minutes by @backportbot in #52206
-    - [stable31] fix(files_sharing): Apply default password setting in SharingDetailsTab by @backportbot in #52208
+    Fix update (v1.0.14)
 
-    View full release note at: https://github.com/nextcloud/server/releases/tag/v31.0.4
+    What's Fixed
+    - Fix Calendar, Contacts, and other CalDAV/CardDAV features stuck loading or failing with errors such as `findAllCalendars` / `_extractAdvertisedDavFeatures`
+    - The reverse proxy no longer short-circuits OPTIONS requests for `/remote.php/dav/` and related API paths; DAV headers are now passed through from Nextcloud correctly
+
+    Note: Nextcloud version remains 31.0.4. No application upgrade in this release.

--- a/nextcloud/i18n/zh-CN/OlaresManifest.yaml
+++ b/nextcloud/i18n/zh-CN/OlaresManifest.yaml
@@ -14,22 +14,10 @@ spec:
     - 加强安全 我们通过加密技术、HackerOne 赏金计划和双因素认证来保护您的数据安全。
 
   upgradeDescription: |
-    应用版本升级至 31.0.4
-    
-    更新内容
-    - [stable31] 修复taskprocessing：使用AppAPI事件获取AI提供商列表，@backportbot在#52120中提到
-    - [stable31] 修复dav：实际上只运行一次块清理，@backportbot在#52054中提到
-    - [stable31] 修复files_sharing：修复共享创建错误处理，@backportbot在#52078中提到
-    - [stable31] feat(bulk-upload)：将默认功能更改为禁用，因为仍然存在一些bug，@backportbot在#52123中提到
-    - [stable31] 修复federation：解析云ID时不加载地址簿，@backportbot在#52068中提到
-    - [stable31] 忽略缺失的主题应用，@ArtificialOwl在#52135中提到
-    - [stable31] 修复ContextAgent：不翻译ContextAgent名称，@backportbot在#52169
-    - build(deps)：@dependabot 在 #52155 中将版本从 15.0.7 升级到 15.0.8
-    - [stable31] chore(files_trashbin)：@backportbot 在 #51999 中将垃圾桶中的用户详细信息添加到日志中
-    - [stable31] 修复：@backportbot 在 #52043 中修复推广转发时缺少的共享提供程序
-    - build(deps)：@dependabot 在 #51348 中将 @nextcloud/event-bus 从 3.3.1 升级到 3.3.2
-    - build(deps)：@dependabot 在 #51964 中将 dompurify 从 3.2.4 升级到 3.2.5
-    - [stable31] 修复(files_sharing)：@backportbot 在 #52206 中将共享创建频率限制为每 10 分钟 20 次
-    - [stable31]修复（files_sharing）：在 SharingDetailsTab 中应用默认密码设置（由 @backportbot 在 #52208 中提供）
+    问题修复更新（v1.0.14）
 
-    完整更新详情请访问：https://github.com/nextcloud/server/releases/tag/v31.0.4  
+    修复内容
+    - 修复日历、通讯录等 CalDAV/CardDAV 功能一直加载或报错（如 `findAllCalendars`、`_extractAdvertisedDavFeatures`）
+    - 反向代理不再对 `/remote.php/dav/` 等 API 路径的 OPTIONS 请求直接返回 204，DAV 响应头可正常从 Nextcloud 透传
+
+    说明：Nextcloud 仍为 31.0.4，本次无应用版本升级。

--- a/nextcloud/templates/_helpers.tpl
+++ b/nextcloud/templates/_helpers.tpl
@@ -1,0 +1,50 @@
+{{/*
+Nginx reverse proxy config for nextcloudweb (clientproxy).
+Referenced by nginx-configmap.yaml; checksum in Deployment triggers rollout on change.
+*/}}
+{{- define "nextcloud.nginx.conf" -}}
+server {
+    listen 8080;
+    access_log /opt/bitnami/openresty/nginx/logs/access.log;
+    error_log /opt/bitnami/openresty/nginx/logs/error.log;
+
+    proxy_connect_timeout 30s;
+    proxy_send_timeout 60s;
+    proxy_read_timeout 300s;
+    proxy_set_header host $host;
+    proxy_set_header x-forwarded-host $http_host;
+
+    proxy_http_version 1.1;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header upgrade $http_upgrade;
+    proxy_set_header connection "upgrade";
+
+    location = /healthz {
+        access_log off;
+        return 200 'ok\n';
+        add_header Content-Type text/plain;
+    }
+
+    location ~ ^/(remote\.php|public\.php|ocs|ocm-provider|ocs-provider|dav) {
+        proxy_pass http://nextcloud-svc:80;
+    }
+
+    location / {
+        proxy_hide_header Access-Control-Allow-Origin;
+        proxy_hide_header Access-Control-Allow-Methods;
+        proxy_hide_header Access-Control-Allow-Headers;
+        add_header Access-Control-Allow-Origin *;
+        add_header Access-Control-Allow-Methods GET,POST,PUT,DELETE,OPTIONS;
+        add_header Access-Control-Allow-Headers "deviceType,token, authorization, content-type,x-csrftoken";
+        if ($request_method = 'OPTIONS') {
+            add_header Access-Control-Allow-Origin *;
+            add_header Access-Control-Allow-Methods GET,POST,PUT,DELETE,OPTIONS;
+            add_header Access-Control-Allow-Headers "deviceType,token, authorization, content-type,x-csrftoken";
+            return 204;
+        }
+        proxy_pass http://nextcloud-svc:80;
+    }
+}
+{{- end -}}

--- a/nextcloud/templates/clientproxy.yaml
+++ b/nextcloud/templates/clientproxy.yaml
@@ -1,45 +1,3 @@
-﻿apiVersion: v1
-data:
-  nginx.conf: |
-    server {
-        listen 8080;
-        access_log /opt/bitnami/openresty/nginx/logs/access.log;
-        error_log /opt/bitnami/openresty/nginx/logs/error.log;
-
-        proxy_connect_timeout 30s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 300s;
-        proxy_set_header host $host;
-        proxy_set_header x-forwarded-host $http_host;
-
-        proxy_http_version 1.1;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header upgrade $http_upgrade;
-        proxy_set_header connection "upgrade";
-
-        location / {
-            proxy_hide_header Access-Control-Allow-Origin;
-            proxy_hide_header Access-Control-Allow-Methods;
-            proxy_hide_header Access-Control-Allow-Headers;
-            add_header Access-Control-Allow-Origin *;
-            add_header Access-Control-Allow-Methods GET,POST,PUT,DELETE,OPTIONS;
-            add_header Access-Control-Allow-Headers "deviceType,token, authorization, content-type,x-csrftoken";
-            if ($request_method = 'OPTIONS') {
-                add_header Access-Control-Allow-Origin *;
-                add_header Access-Control-Allow-Methods GET,POST,PUT,DELETE,OPTIONS;
-                add_header Access-Control-Allow-Headers "deviceType,token, authorization, content-type,x-csrftoken";
-                return 204;
-            }
-            proxy_pass http://nextcloud-svc:80;
-        }
-    }
-kind: ConfigMap
-metadata:
-  name: nginx-config
-  namespace: {{ .Release.Namespace }}
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -59,6 +17,8 @@ spec:
       labels:
         io.kompose.network/chrome-default: "true"
         io.kompose.service: nextcloudweb
+      annotations:
+        checksum/nginx-config: {{ include "nextcloud.nginx.conf" . | sha256sum }}
     spec:
       volumes:
         - name: nginx-config
@@ -78,18 +38,23 @@ spec:
             - name: OPENRESTY_CONF_FILE
               value: /etc/nginx/nginx.conf
           readinessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - |
-                  http_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080)
-                  [ $http_code -ge 200 ] && [ $http_code -lt 500 ]
-            initialDelaySeconds: 20
-            timeoutSeconds: 10
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
             periodSeconds: 5
             successThreshold: 1
-            failureThreshold: 240
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 15
+            timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
           resources:
             limits:
               cpu: 500m

--- a/nextcloud/templates/nginx-configmap.yaml
+++ b/nextcloud/templates/nginx-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: {{ .Release.Namespace }}
+data:
+  nginx.conf: |
+{{ include "nextcloud.nginx.conf" . | indent 4 }}


### PR DESCRIPTION
### App Title
nextcloud

### Description

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`