### PR TITLE
[UPDATE][otmoicrelay][2.1.0] replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/otmoicrelay/templates/redis.yaml
+++ b/otmoicrelay/templates/redis.yaml
@@ -378,7 +378,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: redis
-          image: docker.io/bitnami/redis:7.0.8-debian-11-r13
+          image: docker.io/soldevelo/redis:7.0.15-debian-12-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsUser: 1001
@@ -537,7 +537,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: redis
-          image: docker.io/bitnami/redis:7.0.8-debian-11-r13
+          image: docker.io/soldevelo/redis:7.0.15-debian-12-r0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             runAsUser: 1001


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/redis:7.0.8-debian-11-r13` → [`soldevelo/redis:7.0.15-debian-12-r0`](https://hub.docker.com/r/soldevelo/redis)