### PR TITLE
 [NEW][vaultwarden][1.0.0]

### DIFF
--- a/vaultwarden/.helmignore
+++ b/vaultwarden/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/vaultwarden/Chart.yaml
+++ b/vaultwarden/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: vaultwarden
+description: Vaultwarden is an alternative Bitwarden compatible server written in Rust, compatible with upstream Bitwarden clients.
+type: application
+version: 1.0.0
+appVersion: "1.36.0"

--- a/vaultwarden/OlaresManifest.yaml
+++ b/vaultwarden/OlaresManifest.yaml
@@ -17,9 +17,9 @@ permission:
   - Home
 spec:
   versionName: '1.36.0'
-  featuredImage: https://app.cdn.olares.com/appstore/default/defaulticon.webp
+  featuredImage: https://app.cdn.olares.com/appstore/memos/1.jpg
   promoteImage:
-  - https://app.cdn.olares.com/appstore/default/defaulticon.webp
+  - https://app.cdn.olares.com/appstore/memos/1.jpg
   fullDescription: |
     Vaultwarden is an alternative Bitwarden compatible server written in Rust, compatible with upstream Bitwarden clients.
   developer: Dani Garcia

--- a/vaultwarden/OlaresManifest.yaml
+++ b/vaultwarden/OlaresManifest.yaml
@@ -1,0 +1,71 @@
+olaresManifest.version: '0.11.0'
+olaresManifest.type: app
+metadata:
+  name: vaultwarden
+  description: Alternative Bitwarden compatible server written in Rust.
+  icon: https://app.cdn.olares.com/appstore/default/defaulticon.webp
+  appid: vaultwarden
+  version: '1.0.0'
+  title: Vaultwarden
+  categories:
+  - Productivity_v112
+  - Utilities
+permission:
+  appData: true
+  appCache: true
+  userData:
+  - Home
+spec:
+  versionName: '1.36.0'
+  featuredImage: https://app.cdn.olares.com/appstore/default/defaulticon.webp
+  promoteImage:
+  - https://app.cdn.olares.com/appstore/default/defaulticon.webp
+  fullDescription: |
+    Vaultwarden is an alternative Bitwarden compatible server written in Rust, compatible with upstream Bitwarden clients.
+  developer: Dani Garcia
+  website: https://github.com/dani-garcia/vaultwarden
+  sourceCode: https://github.com/dani-garcia/vaultwarden
+  submitter: Olares
+  locale:
+  - en-US
+  - zh-CN
+  requiredMemory: 16Mi
+  limitedMemory: 256Mi
+  requiredDisk: 128Mi
+  limitedDisk: 1Gi
+  requiredCpu: 0.05
+  limitedCpu: 0.5
+  supportArch:
+  - amd64
+  - arm64
+options:
+  dependencies:
+  - name: olares
+    type: system
+    version: '>=1.10.1-0'
+entrances:
+- name: vaultwarden
+  port: 80
+  host: vaultwarden
+  title: Vaultwarden
+  icon: https://app.cdn.olares.com/appstore/default/defaulticon.webp
+  openMethod: window
+envs:
+  - envName: SIGNUPS_ALLOWED
+    required: false
+    editable: true
+    applyOnChange: true
+    type: string
+    default: "true"
+  - envName: WEBSOCKET_ENABLED
+    required: false
+    editable: true
+    applyOnChange: true
+    type: string
+    default: "true"
+  - envName: ADMIN_TOKEN
+    required: false
+    editable: true
+    applyOnChange: true
+    type: password
+    default: ""

--- a/vaultwarden/i18n/en-US/OlaresManifest.yaml
+++ b/vaultwarden/i18n/en-US/OlaresManifest.yaml
@@ -1,0 +1,6 @@
+metadata:
+  title: Vaultwarden
+  description: Alternative Bitwarden compatible server written in Rust.
+spec:
+  fullDescription: |
+    Vaultwarden is an alternative Bitwarden compatible server written in Rust, compatible with upstream Bitwarden clients.

--- a/vaultwarden/i18n/zh-CN/OlaresManifest.yaml
+++ b/vaultwarden/i18n/zh-CN/OlaresManifest.yaml
@@ -1,0 +1,11 @@
+metadata:
+  title: Vaultwarden
+  description: 兼容 Bitwarden 客户端的 Rust 编写的自托管服务端。
+spec:
+  fullDescription: |
+    Vaultwarden 是用 Rust 编写的备用 Bitwarden 兼容服务器，与上游 Bitwarden 客户端完全兼容。
+
+    **主要功能**
+    - 自托管：完全掌握您自己的密码和敏感数据，不受第三方限制。
+    - 资源占用极低：比官方官方服务更加轻量，适合部署在本地 NAS、树莓派等轻量设备上。
+    - 完美适配：官方的所有客户端（桌面端、浏览器插件、移动端）都可直接连接。

--- a/vaultwarden/owners
+++ b/vaultwarden/owners
@@ -1,0 +1,8 @@
+owners:
+- 'Inverstar'
+- 'LittleLollipop'
+- 'TShentu'
+- 'hysyeah'
+- 'pengpeng'
+- 'harveyff'
+- 'zdf-org'

--- a/vaultwarden/templates/vaultwarden.yaml
+++ b/vaultwarden/templates/vaultwarden.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vaultwarden
+  namespace: {{ .Release.Namespace }}
+  labels:
+    io.kompose.service: vaultwarden
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: vaultwarden
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        io.kompose.service: vaultwarden
+    spec:
+      containers:
+        - name: vaultwarden
+          image: "docker.io/vaultwarden/server:{{ .Values.image.version | default "1.36.0" }}"
+          env:
+            - name: PGID
+              value: "1000"
+            - name: PUID
+              value: "1000"
+            - name: TZ
+              value: Etc/UTC
+            {{- if .Values.olaresEnv }}
+            {{- if .Values.olaresEnv.SIGNUPS_ALLOWED }}
+            - name: SIGNUPS_ALLOWED
+              value: {{ .Values.olaresEnv.SIGNUPS_ALLOWED | quote }}
+            {{- end }}
+            {{- if .Values.olaresEnv.WEBSOCKET_ENABLED }}
+            - name: WEBSOCKET_ENABLED
+              value: {{ .Values.olaresEnv.WEBSOCKET_ENABLED | quote }}
+            {{- end }}
+            {{- if .Values.olaresEnv.ADMIN_TOKEN }}
+            - name: ADMIN_TOKEN
+              value: {{ .Values.olaresEnv.ADMIN_TOKEN | quote }}
+            {{- end }}
+            {{- end }}
+          resources:
+            requests:
+              cpu: 50m
+              memory: 16Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /data
+              name: vaultwarden-data
+      restartPolicy: Always
+      volumes:
+        - name: vaultwarden-data
+          hostPath:
+            type: DirectoryOrCreate
+            path: '{{ .Values.userspace.appData }}/vaultwarden'
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vaultwarden
+  namespace: {{ .Release.Namespace }}
+  labels:
+    io.kompose.service: vaultwarden
+spec:
+  ports:
+    - name: "80"
+      port: 80
+      targetPort: 80
+  selector:
+    io.kompose.service: vaultwarden

--- a/vaultwarden/templates/vaultwarden.yaml
+++ b/vaultwarden/templates/vaultwarden.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: vaultwarden
-          image: "docker.io/vaultwarden/server:{{ .Values.image.version | default "1.36.0" }}"
+          image: docker.io/vaultwarden/server:1.36.0
           env:
             - name: PGID
               value: "1000"

--- a/vaultwarden/values.yaml
+++ b/vaultwarden/values.yaml
@@ -1,0 +1,5 @@
+image:
+  version: '1.36.0'
+
+userspace:
+  appdata: ""


### PR DESCRIPTION
### PR Title 
> [NEW][vaultwarden][1.0.0]

### App Title
> Vaultwarden

### Description
> Vaultwarden 是一个用 Rust 编写的第三方 Bitwarden 兼容服务器，与官方的 Bitwarden 客户端兼容。它为安全地管理密码和敏感数据提供了一个轻量级的自托管解决方案。

### Statement
- [x] 我已测试过此应用，以确保其与 `OlaresManifest.yaml` 中声明的 Olares OS 版本兼容。

---

### PR Title 
> [NEW][vaultwarden][1.0.0]

### App Title
> Vaultwarden

### Description
> Vaultwarden is an alternative Bitwarden compatible server written in Rust, compatible with upstream Bitwarden clients. It provides a lightweight and self-hosted solution for managing passwords and sensitive data securely.

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`

### Related Issue / Closes

Closes #1716 [Add App] vaultwarden
