### PR TITLE
[UPDATE][ollamagemma412budq8kxlv2][1.0.3] Cap v2 shared app system version at 1.12.5

### DIFF
--- a/ollamagemma412budq8kxlv2/Chart.yaml
+++ b/ollamagemma412budq8kxlv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 'gemma4:12b-it-ud-q8_K_XL (Unsloth GGUF)'
 description: description
 name: ollamagemma412budq8kxlv2
 type: application
-version: '1.0.2'
+version: '1.0.3'

--- a/ollamagemma412budq8kxlv2/Chart.yaml
+++ b/ollamagemma412budq8kxlv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 'gemma4:12b-it-ud-q8_K_XL (Unsloth GGUF)'
 description: description
 name: ollamagemma412budq8kxlv2
 type: application
-version: '1.0.1'
+version: '1.0.2'

--- a/ollamagemma412budq8kxlv2/OlaresManifest.yaml
+++ b/ollamagemma412budq8kxlv2/OlaresManifest.yaml
@@ -8,7 +8,7 @@ metadata:
   description: "Gemma4 12B (Unsloth Dynamic UD-Q8_K_XL) multimodal local inference"
   appid: ollamagemma412budq8kxlv2
   title: Gemma4 12B Q8 (Ollama)
-  version: '1.0.1'
+  version: '1.0.2'
   categories:
     - AI
 sharedEntrances:
@@ -100,7 +100,7 @@ options:
   {{- end }}
   dependencies:
     - name: olares
-      version: '>=1.12.3-0'
+      version: '>=1.12.3-0,<1.12.6'
       type: system
   {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
   {{- else }}

--- a/ollamagemma412budq8kxlv2/OlaresManifest.yaml
+++ b/ollamagemma412budq8kxlv2/OlaresManifest.yaml
@@ -8,7 +8,7 @@ metadata:
   description: "Gemma4 12B (Unsloth Dynamic UD-Q8_K_XL) multimodal local inference"
   appid: ollamagemma412budq8kxlv2
   title: Gemma4 12B Q8 (Ollama)
-  version: '1.0.2'
+  version: '1.0.3'
   categories:
     - AI
 sharedEntrances:

--- a/ollamagemma412budq8kxlv2/ollamagemma412budq8kxlv2/Chart.yaml
+++ b/ollamagemma412budq8kxlv2/ollamagemma412budq8kxlv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamagemma412budq8kxlv2
 type: application
-version: '1.0.2'
+version: '1.0.3'

--- a/ollamagemma412budq8kxlv2/ollamagemma412budq8kxlv2/Chart.yaml
+++ b/ollamagemma412budq8kxlv2/ollamagemma412budq8kxlv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamagemma412budq8kxlv2
 type: application
-version: '1.0.1'
+version: '1.0.2'

--- a/ollamagemma412budq8kxlv2/ollamagemma412budq8kxlv2s/Chart.yaml
+++ b/ollamagemma412budq8kxlv2/ollamagemma412budq8kxlv2s/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.30.10'
 description: description
 name: ollamagemma412budq8kxlv2s
 type: application
-version: '1.0.2'
+version: '1.0.3'

--- a/ollamagemma412budq8kxlv2/ollamagemma412budq8kxlv2s/Chart.yaml
+++ b/ollamagemma412budq8kxlv2/ollamagemma412budq8kxlv2s/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.30.10'
 description: description
 name: ollamagemma412budq8kxlv2s
 type: application
-version: '1.0.1'
+version: '1.0.2'


### PR DESCRIPTION
### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
ollamagemma412budq8kxlv2

### Description
Merge test-environment changes after PR #2393 while keeping production Ollama runtime (`ollama/ollama:0.30.10`) and API proxy (`beclab/harveyff-olares-ollama:v0.1.22`) unchanged.

- Cap Olares system dependency at `<1.12.6` for v2 shared app compatibility
- Bump chart version `1.0.1` → `1.0.3`

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
