### PR TITLE
[UPDATE][ollamaembeddinggemmav2][1.0.10] Cap v2 shared app system version at 1.12.5

### DIFF
--- a/ollamaembeddinggemmav2/Chart.yaml
+++ b/ollamaembeddinggemmav2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.17.5'
 description: description
 name: ollamaembeddinggemmav2
 type: application
-version: '1.0.7'
+version: '1.0.10'

--- a/ollamaembeddinggemmav2/OlaresManifest.yaml
+++ b/ollamaembeddinggemmav2/OlaresManifest.yaml
@@ -8,7 +8,7 @@ metadata:
   description: Google's 300M parameter embedding model for search, retrieval, and semantic similarity.
   appid: ollamaembeddinggemmav2
   title: EmbeddingGemma (Ollama)
-  version: '1.0.7'
+  version: '1.0.10'
   categories:
     - AI
 sharedEntrances:
@@ -91,7 +91,7 @@ options:
   {{- end }}
   dependencies:
     - name: olares
-      version: '>=1.12.3-0'
+      version: '>=1.12.3-0,<1.12.6'
       type: system
   {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
   {{- else }}

--- a/ollamaembeddinggemmav2/ollamaembeddinggemmav2/Chart.yaml
+++ b/ollamaembeddinggemmav2/ollamaembeddinggemmav2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamaembeddinggemmav2
 type: application
-version: '1.0.7'
+version: '1.0.10'

--- a/ollamaembeddinggemmav2/ollamaembeddinggemmav2server/Chart.yaml
+++ b/ollamaembeddinggemmav2/ollamaembeddinggemmav2server/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 'embeddinggemma'
 description: description
 name: ollamaembeddinggemmav2server
 type: application
-version: '1.0.7'
+version: '1.0.10'


### PR DESCRIPTION
### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
ollamaembeddinggemmav2

### Description
Merge test-environment changes after PR #2393 while keeping production Ollama runtime and API proxy images unchanged.

- Cap Olares system dependency at `<1.12.6` for v2 shared app compatibility
- Bump chart version to `1.0.10`

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
