### PR TITLE
[UPDATE][ollamagemma327bv2][1.0.27] Cap v2 shared app system version at 1.12.5

### DIFF
--- a/ollamagemma327bv2/Chart.yaml
+++ b/ollamagemma327bv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 'gemma3:27b-it-q4_K_M'
 description: description
 name: ollamagemma327bv2
 type: application
-version: '1.0.24'
+version: '1.0.27'

--- a/ollamagemma327bv2/OlaresManifest.yaml
+++ b/ollamagemma327bv2/OlaresManifest.yaml
@@ -8,7 +8,7 @@ metadata:
   description: The current, most capable model that runs on a single GPU.
   appid: ollamagemma327bv2
   title: Gemma3 27B (Ollama)
-  version: '1.0.24'
+  version: '1.0.27'
   categories:
     - AI
 sharedEntrances:
@@ -112,7 +112,7 @@ options:
   {{- end }}
   dependencies:
     - name: olares
-      version: '>=1.12.3-0'
+      version: '>=1.12.3-0,<1.12.6'
       type: system
   {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
   {{- else }}

--- a/ollamagemma327bv2/ollamagemma327bv2/Chart.yaml
+++ b/ollamagemma327bv2/ollamagemma327bv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamagemma327bv2
 type: application
-version: '1.0.24'
+version: '1.0.27'

--- a/ollamagemma327bv2/ollamagemma327bv2server/Chart.yaml
+++ b/ollamagemma327bv2/ollamagemma327bv2server/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.17.5'
 description: description
 name: ollamagemma327bv2server
 type: application
-version: '1.0.24'
+version: '1.0.27'


### PR DESCRIPTION
### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
ollamagemma327bv2

### Description
Merge test-environment changes after PR #2393 while keeping production Ollama runtime and API proxy images unchanged.

- Cap Olares system dependency at `<1.12.6` for v2 shared app compatibility
- Bump chart version to `1.0.27`

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
