### PR TITLE
[UPDATE][ollamagemma426a4budq4kxlv2][1.0.12] Cap v2 shared app system version at 1.12.5

### DIFF
--- a/ollamagemma426a4budq4kxlv2/Chart.yaml
+++ b/ollamagemma426a4budq4kxlv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 'gemma4:26b-a4b-it-ud-q4_K_XL (Unsloth GGUF)'
 description: description
 name: ollamagemma426a4budq4kxlv2
 type: application
-version: '1.0.10'
+version: '1.0.12'

--- a/ollamagemma426a4budq4kxlv2/OlaresManifest.yaml
+++ b/ollamagemma426a4budq4kxlv2/OlaresManifest.yaml
@@ -8,7 +8,7 @@ metadata:
   description: "Gemma4 26B A4B MoE (Unsloth Dynamic UD-Q4_K_XL) multimodal local inference"
   appid: ollamagemma426a4budq4kxlv2
   title: Gemma4 26B A4B UD-XL (Ollama)
-  version: '1.0.10'
+  version: '1.0.12'
   categories:
     - AI
 sharedEntrances:
@@ -100,7 +100,7 @@ options:
   {{- end }}
   dependencies:
     - name: olares
-      version: '>=1.12.3-0'
+      version: '>=1.12.3-0,<1.12.6'
       type: system
   {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
   {{- else }}

--- a/ollamagemma426a4budq4kxlv2/ollamagemma426a4budq4kxlv2/Chart.yaml
+++ b/ollamagemma426a4budq4kxlv2/ollamagemma426a4budq4kxlv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamagemma426a4budq4kxlv2
 type: application
-version: '1.0.10'
+version: '1.0.12'

--- a/ollamagemma426a4budq4kxlv2/ollamagemma426a4budq4kxlv2s/Chart.yaml
+++ b/ollamagemma426a4budq4kxlv2/ollamagemma426a4budq4kxlv2s/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.30.10'
 description: description
 name: ollamagemma426a4budq4kxlv2s
 type: application
-version: '1.0.10'
+version: '1.0.12'


### PR DESCRIPTION
### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
ollamagemma426a4budq4kxlv2

### Description
Merge test-environment changes after PR #2393 while keeping production Ollama runtime and API proxy images unchanged.

- Cap Olares system dependency at `<1.12.6` for v2 shared app compatibility
- Bump chart version to `1.0.12`

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
