### PR TITLE
[UPDATE][ollamagemma426bitq4kmv2][1.0.8] Cap v2 shared app system version at 1.12.5

### DIFF
--- a/ollamagemma426bitq4kmv2/Chart.yaml
+++ b/ollamagemma426bitq4kmv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 'gemma4:26b'
 description: description
 name: ollamagemma426bitq4kmv2
 type: application
-version: '1.0.6'
+version: '1.0.8'

--- a/ollamagemma426bitq4kmv2/OlaresManifest.yaml
+++ b/ollamagemma426bitq4kmv2/OlaresManifest.yaml
@@ -8,7 +8,7 @@ metadata:
   description: "Gemma4 26B (Ollama library, Q4_K_M) for efficient multimodal local inference"
   appid: ollamagemma426bitq4kmv2
   title: Gemma4 26B Q4_K_M (Ollama)
-  version: '1.0.6'
+  version: '1.0.8'
   categories:
     - AI
 sharedEntrances:
@@ -95,7 +95,7 @@ options:
   {{- end }}
   dependencies:
     - name: olares
-      version: '>=1.12.3-0'
+      version: '>=1.12.3-0,<1.12.6'
       type: system
   {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
   {{- else }}

--- a/ollamagemma426bitq4kmv2/ollamagemma426bitq4kmv2/Chart.yaml
+++ b/ollamagemma426bitq4kmv2/ollamagemma426bitq4kmv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamagemma426bitq4kmv2
 type: application
-version: '1.0.6'
+version: '1.0.8'

--- a/ollamagemma426bitq4kmv2/ollamagemma426bitq4kmv2server/Chart.yaml
+++ b/ollamagemma426bitq4kmv2/ollamagemma426bitq4kmv2server/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.30.10'
 description: description
 name: ollamagemma426bitq4kmv2server
 type: application
-version: '1.0.6'
+version: '1.0.8'


### PR DESCRIPTION
### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
ollamagemma426bitq4kmv2

### Description
Merge test-environment changes after PR #2393 while keeping production Ollama runtime and API proxy images unchanged.

- Cap Olares system dependency at `<1.12.6` for v2 shared app compatibility
- Bump chart version to `1.0.8`

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
