### PR TITLE
[UPDATE][ollamagemma431a4budq4kxlv2][1.0.11] Cap v2 shared app system version at 1.12.5

### DIFF
--- a/ollamagemma431a4budq4kxlv2/Chart.yaml
+++ b/ollamagemma431a4budq4kxlv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 'gemma4:31b-it-ud-q4_K_XL'
 description: description
 name: ollamagemma431a4budq4kxlv2
 type: application
-version: '1.0.9'
+version: '1.0.11'

--- a/ollamagemma431a4budq4kxlv2/OlaresManifest.yaml
+++ b/ollamagemma431a4budq4kxlv2/OlaresManifest.yaml
@@ -8,7 +8,7 @@ metadata:
   description: "Gemma4 31B IT dense (Unsloth Dynamic UD-Q4_K_XL) for efficient local inference"
   appid: ollamagemma431a4budq4kxlv2
   title: Gemma4 31B IT UD-XL (Ollama)
-  version: '1.0.9'
+  version: '1.0.11'
   categories:
     - AI
 sharedEntrances:
@@ -99,7 +99,7 @@ options:
   {{- end }}
   dependencies:
     - name: olares
-      version: '>=1.12.3-0'
+      version: '>=1.12.3-0,<1.12.6'
       type: system
   {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
   {{- else }}

--- a/ollamagemma431a4budq4kxlv2/ollamagemma431a4budq4kxlv2/Chart.yaml
+++ b/ollamagemma431a4budq4kxlv2/ollamagemma431a4budq4kxlv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamagemma431a4budq4kxlv2
 type: application
-version: '1.0.9'
+version: '1.0.11'

--- a/ollamagemma431a4budq4kxlv2/ollamagemma431a4budq4kxlv2s/Chart.yaml
+++ b/ollamagemma431a4budq4kxlv2/ollamagemma431a4budq4kxlv2s/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.30.10'
 description: description
 name: ollamagemma431a4budq4kxlv2s
 type: application
-version: '1.0.9'
+version: '1.0.11'


### PR DESCRIPTION
### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
ollamagemma431a4budq4kxlv2

### Description
Merge test-environment changes after PR #2393 while keeping production Ollama runtime and API proxy images unchanged.

- Cap Olares system dependency at `<1.12.6` for v2 shared app compatibility
- Bump chart version to `1.0.11`

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
