### PR TITLE
[UPDATE][ollamaglm47flashv2][1.0.16] Cap v2 shared app system version at 1.12.5

### DIFF
--- a/ollamaglm47flashv2/Chart.yaml
+++ b/ollamaglm47flashv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 'glm-4.7-flash:q4_K_M'
 description: description
 name: ollamaglm47flashv2
 type: application
-version: '1.0.13'
+version: '1.0.16'

--- a/ollamaglm47flashv2/OlaresManifest.yaml
+++ b/ollamaglm47flashv2/OlaresManifest.yaml
@@ -8,7 +8,7 @@ metadata:
   description: GLM-4.7-Flash is a high-performance, fast-responding language model
   appid: ollamaglm47flashv2
   title: GLM-4.7-Flash (Ollama)
-  version: '1.0.13'
+  version: '1.0.16'
   categories:
     - AI
 sharedEntrances:
@@ -105,7 +105,7 @@ options:
   {{- end }}
   dependencies:
     - name: olares
-      version: '>=1.12.3-0'
+      version: '>=1.12.3-0,<1.12.6'
       type: system
   {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
   {{- else }}

--- a/ollamaglm47flashv2/ollamaglm47flashv2/Chart.yaml
+++ b/ollamaglm47flashv2/ollamaglm47flashv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamaglm47flashv2
 type: application
-version: '1.0.13'
+version: '1.0.16'

--- a/ollamaglm47flashv2/ollamaglm47flashv2server/Chart.yaml
+++ b/ollamaglm47flashv2/ollamaglm47flashv2server/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.17.5'
 description: description
 name: ollamaglm47flashv2server
 type: application
-version: '1.0.13'
+version: '1.0.16'


### PR DESCRIPTION
### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
ollamaglm47flashv2

### Description
Merge test-environment changes after PR #2393 while keeping production Ollama runtime and API proxy images unchanged.

- Cap Olares system dependency at `<1.12.6` for v2 shared app compatibility
- Bump chart version to `1.0.16`

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
