### PR TITLE
[UPDATE][ollamagptoss20bv2][1.0.28] Cap v2 shared app system version at 1.12.5

### DIFF
--- a/ollamagptoss20bv2/Chart.yaml
+++ b/ollamagptoss20bv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 'gpt-oss:20b'
 description: description
 name: ollamagptoss20bv2
 type: application
-version: '1.0.25'
+version: '1.0.28'

--- a/ollamagptoss20bv2/OlaresManifest.yaml
+++ b/ollamagptoss20bv2/OlaresManifest.yaml
@@ -8,7 +8,7 @@ metadata:
   description: "OpenAI's open-weight models designed for powerful reasoning, agentic tasks, and versatile developer use cases."
   appid: ollamagptoss20bv2
   title: GPT-OSS 20B (Ollama)
-  version: '1.0.25'
+  version: '1.0.28'
   categories:
     - AI
 sharedEntrances:
@@ -113,7 +113,7 @@ options:
   {{- end }}
   dependencies:
     - name: olares
-      version: '>=1.12.3-0'
+      version: '>=1.12.3-0,<1.12.6'
       type: system
   {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
   {{- else }}

--- a/ollamagptoss20bv2/ollamagptoss20bv2/Chart.yaml
+++ b/ollamagptoss20bv2/ollamagptoss20bv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamagptoss20bv2
 type: application
-version: '1.0.25'
+version: '1.0.28'

--- a/ollamagptoss20bv2/ollamagptoss20bv2server/Chart.yaml
+++ b/ollamagptoss20bv2/ollamagptoss20bv2server/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.17.5'
 description: description
 name: ollamagptoss20bv2server
 type: application
-version: '1.0.25'
+version: '1.0.28'


### PR DESCRIPTION
### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
ollamagptoss20bv2

### Description
Merge test-environment changes after PR #2393 while keeping production Ollama runtime and API proxy images unchanged.

- Cap Olares system dependency at `<1.12.6` for v2 shared app compatibility
- Bump chart version to `1.0.28`

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
