### PR TITLE
[UPDATE][ollamallama318bv2][1.0.27] Cap v2 shared app system version at 1.12.5

### DIFF
--- a/ollamallama318bv2/Chart.yaml
+++ b/ollamallama318bv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 'llama3.1:8b-instruct-q4_K_M'
 description: description
 name: ollamallama318bv2
 type: application
-version: '1.0.24'
+version: '1.0.27'

--- a/ollamallama318bv2/OlaresManifest.yaml
+++ b/ollamallama318bv2/OlaresManifest.yaml
@@ -8,7 +8,7 @@ metadata:
   description: A new state-of-the-art model from Meta available in 8B, 70B and 405B parameter sizes.
   appid: ollamallama318bv2
   title: Llama 3.1 8B (Ollama)
-  version: '1.0.24'
+  version: '1.0.27'
   categories:
     - AI
 sharedEntrances:
@@ -104,7 +104,7 @@ options:
   {{- end }}
   dependencies:
     - name: olares
-      version: '>=1.12.3-0'
+      version: '>=1.12.3-0,<1.12.6'
       type: system
   {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
   {{- else }}

--- a/ollamallama318bv2/ollamallama318bv2/Chart.yaml
+++ b/ollamallama318bv2/ollamallama318bv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamallama318bv2
 type: application
-version: '1.0.24'
+version: '1.0.27'

--- a/ollamallama318bv2/ollamallama318bv2server/Chart.yaml
+++ b/ollamallama318bv2/ollamallama318bv2server/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.17.5'
 description: description
 name: ollamallama318bv2server
 type: application
-version: '1.0.24'
+version: '1.0.27'


### PR DESCRIPTION
### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
ollamallama318bv2

### Description
Merge test-environment changes after PR #2393 while keeping production Ollama runtime and API proxy images unchanged.

- Cap Olares system dependency at `<1.12.6` for v2 shared app compatibility
- Bump chart version to `1.0.27`

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
