### PR TITLE
[UPDATE][ollamanomicembedtextv2][1.0.27] Cap v2 shared app system version at 1.12.5

### DIFF
--- a/ollamanomicembedtextv2/Chart.yaml
+++ b/ollamanomicembedtextv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 'nomic-embed-text:137m-v1.5-fp16'
 description: description
 name: ollamanomicembedtextv2
 type: application
-version: '1.0.24'
+version: '1.0.27'

--- a/ollamanomicembedtextv2/OlaresManifest.yaml
+++ b/ollamanomicembedtextv2/OlaresManifest.yaml
@@ -8,7 +8,7 @@ metadata:
   description: A high-performing open embedding model with a large token context window.
   appid: ollamanomicembedtextv2
   title: Nomic Embed v1.5 (Ollama/CPU)
-  version: '1.0.24'
+  version: '1.0.27'
   categories:
     - AI
 sharedEntrances:
@@ -97,7 +97,7 @@ options:
   {{- end }}
   dependencies:
     - name: olares
-      version: '>=1.12.3-0'
+      version: '>=1.12.3-0,<1.12.6'
       type: system
   {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
   {{- else }}

--- a/ollamanomicembedtextv2/ollamanomicembedtextv2/Chart.yaml
+++ b/ollamanomicembedtextv2/ollamanomicembedtextv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamanomicembedtextv2
 type: application
-version: '1.0.24'
+version: '1.0.27'

--- a/ollamanomicembedtextv2/ollamanomicembedtextv2server/Chart.yaml
+++ b/ollamanomicembedtextv2/ollamanomicembedtextv2server/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.17.5'
 description: description
 name: ollamanomicembedtextv2server
 type: application
-version: '1.0.24'
+version: '1.0.27'


### PR DESCRIPTION
### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
ollamanomicembedtextv2

### Description
Merge test-environment changes after PR #2393 while keeping production Ollama runtime and API proxy images unchanged.

- Cap Olares system dependency at `<1.12.6` for v2 shared app compatibility
- Bump chart version to `1.0.27`

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
