### PR TITLE
[UPDATE][ollamaqwen314bv2][1.0.28] Cap v2 shared app system version at 1.12.5

### DIFF
--- a/ollamaqwen314bv2/Chart.yaml
+++ b/ollamaqwen314bv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 'qwen3:14b-q4_K_M'
 description: description
 name: ollamaqwen314bv2
 type: application
-version: '1.0.25'
+version: '1.0.28'

--- a/ollamaqwen314bv2/OlaresManifest.yaml
+++ b/ollamaqwen314bv2/OlaresManifest.yaml
@@ -8,7 +8,7 @@ metadata:
   description: The latest generation of large language models in Qwen series, offering a comprehensive suite of dense and mixture-of-experts (MoE) models.
   appid: ollamaqwen314bv2
   title: Qwen3 14B (Ollama)
-  version: '1.0.25'
+  version: '1.0.28'
   categories:
     - AI
 sharedEntrances:
@@ -103,7 +103,7 @@ options:
   {{- end }}
   dependencies:
     - name: olares
-      version: '>=1.12.3-0'
+      version: '>=1.12.3-0,<1.12.6'
       type: system
   {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
   {{- else }}

--- a/ollamaqwen314bv2/ollamaqwen314bv2/Chart.yaml
+++ b/ollamaqwen314bv2/ollamaqwen314bv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamaqwen314bv2
 type: application
-version: '1.0.25'
+version: '1.0.28'

--- a/ollamaqwen314bv2/ollamaqwen314bv2server/Chart.yaml
+++ b/ollamaqwen314bv2/ollamaqwen314bv2server/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.17.5'
 description: description
 name: ollamaqwen314bv2server
 type: application
-version: '1.0.25'
+version: '1.0.28'


### PR DESCRIPTION
### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
ollamaqwen314bv2

### Description
Merge test-environment changes after PR #2393 while keeping production Ollama runtime and API proxy images unchanged.

- Cap Olares system dependency at `<1.12.6` for v2 shared app compatibility
- Bump chart version to `1.0.28`

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
