### PR TITLE
[UPDATE][ollamaqwen3527budq4kxlv2][1.0.4] Cap v2 shared app system version at 1.12.5

### DIFF
--- a/ollamaqwen3527budq4kxlv2/Chart.yaml
+++ b/ollamaqwen3527budq4kxlv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 'qwen3.5:27b-ud-q4_K_XL'
 description: description
 name: ollamaqwen3527budq4kxlv2
 type: application
-version: '1.0.2'
+version: '1.0.4'

--- a/ollamaqwen3527budq4kxlv2/OlaresManifest.yaml
+++ b/ollamaqwen3527budq4kxlv2/OlaresManifest.yaml
@@ -8,7 +8,7 @@ metadata:
   description: "Open-source multimodal models that delivers exceptional utility and performance (Unsloth Dynamic UD-Q4_K_XL)"
   appid: ollamaqwen3527budq4kxlv2
   title: Qwen3.5 27B UD-XL (Ollama)
-  version: '1.0.2'
+  version: '1.0.4'
   categories:
     - AI
 sharedEntrances:
@@ -107,7 +107,7 @@ options:
   {{- end }}
   dependencies:
     - name: olares
-      version: '>=1.12.3-0'
+      version: '>=1.12.3-0,<1.12.6'
       type: system
   {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
   {{- else }}

--- a/ollamaqwen3527budq4kxlv2/ollamaqwen3527budq4kxlv2/Chart.yaml
+++ b/ollamaqwen3527budq4kxlv2/ollamaqwen3527budq4kxlv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamaqwen3527budq4kxlv2
 type: application
-version: '1.0.2'
+version: '1.0.4'

--- a/ollamaqwen3527budq4kxlv2/ollamaqwen3527budq4kxlv2srv/Chart.yaml
+++ b/ollamaqwen3527budq4kxlv2/ollamaqwen3527budq4kxlv2srv/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.30.10'
 description: description
 name: ollamaqwen3527budq4kxlv2srv
 type: application
-version: '1.0.2'
+version: '1.0.4'


### PR DESCRIPTION
### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
ollamaqwen3527budq4kxlv2

### Description
Merge test-environment changes after PR #2393 while keeping production Ollama runtime and API proxy images unchanged.

- Cap Olares system dependency at `<1.12.6` for v2 shared app compatibility
- Bump chart version to `1.0.4`

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
