### PR TITLE
[UPDATE][ollamaqwen359bv2][1.0.12] Cap v2 shared app system version at 1.12.5

### DIFF
--- a/ollamaqwen359bv2/Chart.yaml
+++ b/ollamaqwen359bv2/Chart.yaml
@@ -3,4 +3,4 @@ appversion: '1.0.1'
 description: description
 name: ollamaqwen359bv2
 type: application
-version: '1.0.10'
+version: '1.0.12'

--- a/ollamaqwen359bv2/OlaresManifest.yaml
+++ b/ollamaqwen359bv2/OlaresManifest.yaml
@@ -8,7 +8,7 @@ metadata:
   description: "Open-source multimodal models that delivers exceptional utility and performance"
   appid: ollamaqwen359bv2
   title: Qwen3.5 9B Q4_K_M (Ollama)
-  version: '1.0.10'
+  version: '1.0.12'
   categories:
     - AI
 sharedEntrances:
@@ -105,7 +105,7 @@ options:
   {{- end }}
   dependencies:
     - name: olares
-      version: '>=1.12.3-0'
+      version: '>=1.12.3-0,<1.12.6'
       type: system
   {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
   {{- else }}

--- a/ollamaqwen359bv2/ollamaqwen359bv2/Chart.yaml
+++ b/ollamaqwen359bv2/ollamaqwen359bv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamaqwen359bv2
 type: application
-version: '1.0.10'
+version: '1.0.12'

--- a/ollamaqwen359bv2/ollamaqwen359bv2server/Chart.yaml
+++ b/ollamaqwen359bv2/ollamaqwen359bv2server/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.30.10'
 description: description
 name: ollamaqwen359bv2server
 type: application
-version: '1.0.10'
+version: '1.0.12'


### PR DESCRIPTION
### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
ollamaqwen359bv2

### Description
Merge test-environment changes after PR #2393 while keeping production Ollama runtime and API proxy images unchanged.

- Cap Olares system dependency at `<1.12.6` for v2 shared app compatibility
- Bump chart version to `1.0.12`

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
