### PR TITLE
[UPDATE][ollamaqwen35a3budq4klv2][1.0.15] Cap v2 shared app system version at 1.12.5

### DIFF
--- a/ollamaqwen35a3budq4klv2/Chart.yaml
+++ b/ollamaqwen35a3budq4klv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 'Qwen3.5-35B-A3B-UD-Q4_K_L'
 description: description
 name: ollamaqwen35a3budq4klv2
 type: application
-version: '1.0.13'
+version: '1.0.15'

--- a/ollamaqwen35a3budq4klv2/OlaresManifest.yaml
+++ b/ollamaqwen35a3budq4klv2/OlaresManifest.yaml
@@ -8,7 +8,7 @@ metadata:
   description: Run Qwen3.5-35B-A3B GGUF (Q4_K_L quantization) locally via Ollama.
   appid: ollamaqwen35a3budq4klv2
   title: Qwen3.5 35B A3B UD-Q4 (Ollama)
-  version: '1.0.13'
+  version: '1.0.15'
   categories:
     - AI
 sharedEntrances:
@@ -96,7 +96,7 @@ options:
   {{- end }}
   dependencies:
     - name: olares
-      version: '>=1.12.3-0'
+      version: '>=1.12.3-0,<1.12.6'
       type: system
   {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
   {{- else }}

--- a/ollamaqwen35a3budq4klv2/ollamaqwen35a3budq4klv2/Chart.yaml
+++ b/ollamaqwen35a3budq4klv2/ollamaqwen35a3budq4klv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamaqwen35a3budq4klv2
 type: application
-version: '1.0.13'
+version: '1.0.15'

--- a/ollamaqwen35a3budq4klv2/ollamaqwen35a3budq4klv2server/Chart.yaml
+++ b/ollamaqwen35a3budq4klv2/ollamaqwen35a3budq4klv2server/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.30.10'
 description: description
 name: ollamaqwen35a3budq4klv2server
 type: application
-version: '1.0.13'
+version: '1.0.15'


### PR DESCRIPTION
### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
ollamaqwen35a3budq4klv2

### Description
Merge test-environment changes after PR #2393 while keeping production Ollama runtime and API proxy images unchanged.

- Cap Olares system dependency at `<1.12.6` for v2 shared app compatibility
- Bump chart version to `1.0.15`

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
