### PR TITLE
[UPDATE][ollamaqwen3635ba3budq4kmv2][1.0.6] Cap v2 shared app system version at 1.12.5

### DIFF
--- a/ollamaqwen3635ba3budq4kmv2/Chart.yaml
+++ b/ollamaqwen3635ba3budq4kmv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 'qwen3.6:35b-a3b-ud-q4_k_m'
 description: description
 name: ollamaqwen3635ba3budq4kmv2
 type: application
-version: '1.0.4'
+version: '1.0.6'

--- a/ollamaqwen3635ba3budq4kmv2/OlaresManifest.yaml
+++ b/ollamaqwen3635ba3budq4kmv2/OlaresManifest.yaml
@@ -8,7 +8,7 @@ metadata:
   description: "Qwen3.6 35B A3B MoE (Unsloth Dynamic UD-Q4_K_M) for efficient local inference"
   appid: ollamaqwen3635ba3budq4kmv2
   title: Qwen3.6 35B A3B UD-KM (Ollama)
-  version: '1.0.4'
+  version: '1.0.6'
   categories:
     - AI
 sharedEntrances:
@@ -107,7 +107,7 @@ options:
   {{- end }}
   dependencies:
     - name: olares
-      version: '>=1.12.3-0'
+      version: '>=1.12.3-0,<1.12.6'
       type: system
   {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
   {{- else }}

--- a/ollamaqwen3635ba3budq4kmv2/ollamaqwen3635ba3budq4kmv2/Chart.yaml
+++ b/ollamaqwen3635ba3budq4kmv2/ollamaqwen3635ba3budq4kmv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamaqwen3635ba3budq4kmv2
 type: application
-version: '1.0.4'
+version: '1.0.6'

--- a/ollamaqwen3635ba3budq4kmv2/ollamaqwen3635ba3budq4kmv2srv/Chart.yaml
+++ b/ollamaqwen3635ba3budq4kmv2/ollamaqwen3635ba3budq4kmv2srv/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.30.10'
 description: description
 name: ollamaqwen3635ba3budq4kmv2srv
 type: application
-version: '1.0.4'
+version: '1.0.6'


### PR DESCRIPTION
### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
ollamaqwen3635ba3budq4kmv2

### Description
Merge test-environment changes after PR #2393 while keeping production Ollama runtime and API proxy images unchanged.

- Cap Olares system dependency at `<1.12.6` for v2 shared app compatibility
- Bump chart version to `1.0.6`

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
