### PR TITLE
[UPDATE][ollamaqwen3coder30bv2][1.0.5] Cap v2 shared app system version at 1.12.5

### DIFF
--- a/ollamaqwen3coder30bv2/Chart.yaml
+++ b/ollamaqwen3coder30bv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 'qwen3-coder:30b'
 description: description
 name: ollamaqwen3coder30bv2
 type: application
-version: '1.0.3'
+version: '1.0.5'

--- a/ollamaqwen3coder30bv2/OlaresManifest.yaml
+++ b/ollamaqwen3coder30bv2/OlaresManifest.yaml
@@ -8,7 +8,7 @@ metadata:
   description: "Qwen3-Coder 30B (Ollama library) for agentic coding and tool use"
   appid: ollamaqwen3coder30bv2
   title: Qwen3-Coder 30B (Ollama)
-  version: '1.0.3'
+  version: '1.0.5'
   categories:
     - AI
 sharedEntrances:
@@ -97,7 +97,7 @@ options:
   {{- end }}
   dependencies:
     - name: olares
-      version: '>=1.12.3-0'
+      version: '>=1.12.3-0,<1.12.6'
       type: system
   {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
   {{- else }}

--- a/ollamaqwen3coder30bv2/ollamaqwen3coder30bv2/Chart.yaml
+++ b/ollamaqwen3coder30bv2/ollamaqwen3coder30bv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamaqwen3coder30bv2
 type: application
-version: '1.0.3'
+version: '1.0.5'

--- a/ollamaqwen3coder30bv2/ollamaqwen3coder30bv2server/Chart.yaml
+++ b/ollamaqwen3coder30bv2/ollamaqwen3coder30bv2server/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.30.10'
 description: description
 name: ollamaqwen3coder30bv2server
 type: application
-version: '1.0.3'
+version: '1.0.5'


### PR DESCRIPTION
### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
ollamaqwen3coder30bv2

### Description
Merge test-environment changes after PR #2393 while keeping production Ollama runtime and API proxy images unchanged.

- Cap Olares system dependency at `<1.12.6` for v2 shared app compatibility
- Bump chart version to `1.0.5`

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
