### PR TITLE
[UPDATE][ollamav2][1.1.4] Cap v2 shared app system version at 1.12.5

### DIFF
--- a/ollamav2/Chart.yaml
+++ b/ollamav2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.30.11'
 description: description
 name: ollamav2
 type: application
-version: 1.1.2
+version: '1.1.4'

--- a/ollamav2/OlaresManifest.yaml
+++ b/ollamav2/OlaresManifest.yaml
@@ -8,10 +8,9 @@ metadata:
   description: Get up and running with large language models.
   appid: ollamav2
   title: Ollama
-  version: "1.1.2"
+  version: '1.1.4'
   categories:
     - Utilities_v112
-    - Productivity
 sharedEntrances:
   - name: ollamav2
     host: sharedentrances-ollama
@@ -171,7 +170,7 @@ options:
   {{- end }}
   dependencies:
     - name: olares
-      version: '>=1.12.3-0'
+      version: '>=1.12.3-0,<1.12.6'
       type: system
   {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
   {{- else }}

--- a/ollamav2/ollamaserver/Chart.yaml
+++ b/ollamav2/ollamaserver/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.30.11'
 description: description
 name: ollamaserver
 type: application
-version: 1.1.2
+version: '1.1.4'

--- a/ollamav2/ollamav2/Chart.yaml
+++ b/ollamav2/ollamav2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.25.3-2'
 description: description
 name: ollamav2
 type: application
-version: 1.1.0
+version: '1.1.4'


### PR DESCRIPTION
### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
ollamav2

### Description
Merge test-environment changes after PR #2393 while keeping production Ollama runtime and API proxy images unchanged.

- Cap Olares system dependency at `<1.12.6` for v2 shared app compatibility
- Bump chart version to `1.1.4`

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
