### PR TITLE
[UPDATE][agentzero][1.0.7] Merge test post-#2393 changes

### DIFF
--- a/agentzero/Chart.yaml
+++ b/agentzero/Chart.yaml
@@ -15,8 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
-
+version: '1.0.7'
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/agentzero/OlaresManifest.yaml
+++ b/agentzero/OlaresManifest.yaml
@@ -1,15 +1,19 @@
-olaresManifest.version: '0.11.0'
+olaresManifest.version: '0.12.0'
 olaresManifest.type: app
+apiVersion: 'v3'
+
+workloadReplicas:
+  agentzero: 1
+  agentzeroingress: 1
 metadata:
   name: agentzero
   description: Agentic AI Framework
   icon: https://app.cdn.olares.com/appstore/agentzero/icon.png
   appid: agentzero
-  version: '1.0.3'
+  version: '1.0.7'
   title: Agent Zero
   categories:
   - Productivity_v112
-  - Productivity
 permission:
   appData: true
 spec:
@@ -50,9 +54,9 @@ options:
   dependencies:
   - name: olares
     type: system
-    version: '>=1.12.3-0'
+    version: '>=1.12.6-0'
 entrances:
-  - authLevel: private
+  - authLevel: internal
     host: agentzeroingress
     icon: https://app.cdn.olares.com/appstore/agentzero/icon.png
     name: agentzero

--- a/agentzero/templates/agentzero.yaml
+++ b/agentzero/templates/agentzero.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     io.kompose.service: agentzero
 spec:
-  replicas: 1
+  replicas: {{ .Values.workloads.agentzero.replicaCount }}
   selector:
     matchLabels:
       io.kompose.service: agentzero

--- a/agentzero/templates/ingress.yaml
+++ b/agentzero/templates/ingress.yaml
@@ -48,7 +48,7 @@ metadata:
   name: agentzeroingress
   namespace: '{{ .Release.Namespace }}'
 spec:
-  replicas: 1
+  replicas: {{ .Values.workloads.agentzeroingress.replicaCount }}
   selector:
     matchLabels:
       io.kompose.service: agentzeroingress

--- a/agentzero/values.yaml
+++ b/agentzero/values.yaml
@@ -1,1 +1,5 @@
-
+workloads:
+  agentzeroingress:
+    replicaCount: 1
+  agentzero:
+    replicaCount: 1


### PR DESCRIPTION
### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
agentzero

### Description
Merge test-environment changes after PR #2393 while keeping production images and core configuration unchanged.

- Add `apiVersion: v3` and `workloadReplicas`
- Cap Olares dependency at `>=1.12.6-0`
- Set entrance `authLevel` to `internal`
- Parameterize workload replicas via `values.yaml`
- Bump chart version `1.0.3` → `1.0.7`

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
