### PR TITLE
[UPDATE][comfyuisharev2][1.0.41] Merge test post-#2393 changes

### DIFF
--- a/comfyuisharev2/Chart.yaml
+++ b/comfyuisharev2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.21.0
 description: description
 name: comfyuisharev2
 type: application
-version: 1.0.39
+version: '1.0.41'

--- a/comfyuisharev2/OlaresManifest.yaml
+++ b/comfyuisharev2/OlaresManifest.yaml
@@ -7,11 +7,10 @@ metadata:
   description: The most powerful and modular stable diffusion GUI and backend.
   icon: https://app.cdn.olares.com/appstore/comfyui/icon2.png
   appid: comfyuisharev2
-  version: '1.0.39'
+  version: '1.0.41'
   title: ComfyUI Shared
   categories:
   - Creativity
-  - Productivity
 sharedEntrances:
 - name: comfyuisharev2
   title: ComfyUI
@@ -45,9 +44,6 @@ entrances:
 #   authLevel: public
 #   invisible: true
 permission:
-  provider:
-  - appName: olares-app
-    providerName: desktop
   appData: true
   appCache: true
 {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
@@ -192,7 +188,7 @@ options:
   dependencies:
   - name: olares
     type: system
-    version: '>=1.12.3-0'
+    version: '>=1.12.3-0,<1.12.6'
 {{- if and .Values.admin .Values.bfl.username (eq .Values.admin .Values.bfl.username) }}
 {{- else }}
   - name: comfyuisharev2

--- a/comfyuisharev2/comfyuisharev2/Chart.yaml
+++ b/comfyuisharev2/comfyuisharev2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "1.25.3-2"
 description: description
 name: comfyuisharev2
 type: application
-version: 1.0.39
+version: '1.0.41'

--- a/comfyuisharev2/comfyuisharev2server/Chart.yaml
+++ b/comfyuisharev2/comfyuisharev2server/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "0.21.0"
 description: description
 name: comfyuisharev2server
 type: application
-version: 1.0.39
+version: '1.0.41'


### PR DESCRIPTION
### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
comfyuisharev2

### Description
Merge test-environment changes after PR #2393 while keeping production images and core configuration unchanged.

- Remove `Productivity` category and desktop `provider` permission
- Cap Olares system dependency at `<1.12.6`
- Bump chart version `1.0.39` → `1.0.41`
- Keep ComfyUI v0.26.0 images and upgrade notes

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
