### PR TITLE
[UPDATE][lobechat][1.0.14] Merge test post-#2393 changes

### DIFF
--- a/lobechat/Chart.yaml
+++ b/lobechat/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "2.1.18"
 description: description
 name: lobechat
 type: application
-version: 1.0.10
+version: '1.0.14'

--- a/lobechat/OlaresManifest.yaml
+++ b/lobechat/OlaresManifest.yaml
@@ -1,16 +1,19 @@
 ---
-olaresManifest.version: "0.10.0"
+olaresManifest.version: '0.12.0'
 olaresManifest.type: app
+apiVersion: 'v3'
+
+workloadReplicas:
+  lobechat: 1
 metadata:
   name: lobechat
   icon: https://app.cdn.olares.com/appstore/lobechat/icon.png
   description: An open-source, modern-design AI chat framework.
   title: LobeChat
-  version: "1.0.10"
+  version: "1.0.14"
   appid: lobechat
   categories:
     - Utilities_v112
-    - Entertainment
 entrances:
   - name: lobechat
     host: lobechat
@@ -132,5 +135,5 @@ options:
   apiTimeout: 0
   dependencies:
     - name: olares
-      version: ">=1.10.1-0"
+      version: '>=1.12.6-0'
       type: system

--- a/lobechat/templates/lobechat.yaml
+++ b/lobechat/templates/lobechat.yaml
@@ -7,7 +7,7 @@ metadata:
   name: "{{ .Release.Name }}"
   namespace: "{{ .Release.Namespace }}"
 spec:
-  replicas: 1
+  replicas: {{ .Values.workloads.lobechat.replicaCount }}
   selector:
     matchLabels:
       app: "{{ .Release.Name }}"

--- a/lobechat/values.yaml
+++ b/lobechat/values.yaml
@@ -1,0 +1,3 @@
+workloads:
+  lobechat:
+    replicaCount: 1


### PR DESCRIPTION
### PR Title 
> [NEW][FolderName][version]
> 
> [UPDATE][FolderName][version]
> 
> [REMOVE][FolderName][version]
> 
> [SUSPEND][FolderName][version]

### App Title
lobechat

### Description
Merge test-environment changes after PR #2393 while keeping production images and core configuration unchanged.

- Add `apiVersion: v3` and `workloadReplicas`
- Cap Olares dependency at `>=1.12.6-0`
- Parameterize workload replicas via `values.yaml`
- Bump chart version `1.0.10` → `1.0.14`
- Keep LobeChat image `2.1.18` and existing deployment layout

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
