### PR TITLE
[UPDATE][vllmllmbasev3][1.2.24] Drop accelerator CPU mode

### DIFF
--- a/vllmllmbasev3/Chart.yaml
+++ b/vllmllmbasev3/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.24.0
 description: Generic vLLM + llm-init base; the model is supplied at install time via env
 name: vllmllmbasev3
 type: application
-version: 1.2.23
+version: 1.2.24

--- a/vllmllmbasev3/OlaresManifest.yaml
+++ b/vllmllmbasev3/OlaresManifest.yaml
@@ -7,7 +7,7 @@ metadata:
   description: "Generic vLLM engine base. Pick any HuggingFace Safetensors model at install via env."
   appid: vllmllmbasev3
   title: vLLM Engine Base
-  version: '1.2.23'
+  version: '1.2.24'
   categories:
     - AI
 sharedEntrances:
@@ -35,7 +35,7 @@ spec:
   onlyAdmin: true
   versionName: '0.24.0'
   upgradeDescription: |
-    v1.2.23: bump llm-init to v1.3.1.
+    Drop accelerator mode `cpu` (GPU-only: `nvidia` / `nvidia-gb10`). Chart 1.2.24.
   fullDescription: |
     **IMPORTANT NOTE**  
     This app is a template and cannot be used on its own. To use it, set the environment variables below to connect a specific model.
@@ -47,7 +47,7 @@ spec:
     - `MODEL_SUPPORTS`: Model capability options (Vision / Tools / Thinking / None). Pick what your model supports.
     - `ENGINE_ARGS`: `--max-model-len 65536 --gpu-memory-utilization 0.9 --tensor-parallel-size 1 --max-num-batched-tokens 8192 --enable-prefix-caching --kv-cache-dtype fp8`. Extra vLLM CLI flags. Separate multiple `--key value` pairs with spaces. See https://docs.vllm.ai/en/v0.17.0/configuration/engine_args/.
     - `LOG_LEVEL`: `debug`, `info`, `warn`, or `error`. Log level for the llm-init container.
-    - `VLLM_REQUIRED_GPU_MEMORY`: `8Gi`, `8192`, or `8192Mi`. Model memory needed, enter `0` for CPU mode. On GPU modes (`nvidia`, `nvidia-gb10`), gpu-inject caps visible CUDA memory to this quota; tune `--gpu-memory-utilization` in ENGINE_ARGS against that budget.
+    - `VLLM_REQUIRED_GPU_MEMORY`: `8Gi`, `8192`, or `8192Mi`. Model memory needed. On GPU modes (`nvidia`, `nvidia-gb10`), gpu-inject caps visible CUDA memory to this quota; tune `--gpu-memory-utilization` in ENGINE_ARGS against that budget.
 
     **How It Works**
     First, `llm-init` downloads your model and gets it ready, then vLLM starts serving the model when it's ready. Both containers run in the same Pod and share the model directory and readiness sentinel.
@@ -61,7 +61,6 @@ spec:
     |----------------|-------------------|----------------------------------------------------------------------|
     | `nvidia`       | GPU (CUDA)        | Set `VLLM_REQUIRED_GPU_MEMORY`; tune `--gpu-memory-utilization` in ENGINE_ARGS |
     | `nvidia-gb10`  | GPU (Spark)       | Same as `nvidia`: set `VLLM_REQUIRED_GPU_MEMORY`; tune `--gpu-memory-utilization` in ENGINE_ARGS (no auto remapping) |
-    | `cpu`          | CPU only          | Uses `vllm-openai-cpu` image; no `--device cpu` (embedding: add `--runner pooling` in ENGINE_ARGS) |
 
     **Model Storage**
     All model files are stored in a shared folder at `appCommon/huggingface`, mounted as `/cache/hf/hub`. All similar apps use this location for models.
@@ -83,16 +82,8 @@ spec:
       url: https://github.com/vllm-project/vllm/blob/main/LICENSE
 
   accelerator:
-    #   cpu          — CPU-only; vllm-openai-cpu image, no gpu-inject; do not pass --device cpu
     #   nvidia       — discrete GPU; VLLM_REQUIRED_GPU_MEMORY -> gpumem
     #   nvidia-gb10  — DGX Spark unified memory; VLLM_REQUIRED_GPU_MEMORY -> gpumem
-    - mode: cpu
-      limitedCpu: "-1"
-      requiredCpu: "-1"
-      requiredDisk: 50Mi
-      limitedDisk: 500Gi
-      limitedMemory: "-1"
-      requiredMemory: "-1"
     - mode: nvidia
       limitedCpu: "-1"
       requiredCpu: "-1"
@@ -228,5 +219,5 @@ envs:
     type: string
     editable: false
     applyOnChange: false
-    description: "Example: `8Gi`, `8192`, or `8192Mi`. GPU memory required for the model. Use `0` on CPU. On GPU modes, gpu-inject caps visible CUDA memory to this value."
+    description: "Example: `8Gi`, `8192`, or `8192Mi`. GPU memory required for the model. On GPU modes, gpu-inject caps visible CUDA memory to this value."
     regex: "^[0-9]+(Gi|Mi)?$"

--- a/vllmllmbasev3/i18n/en-US/OlaresManifest.yaml
+++ b/vllmllmbasev3/i18n/en-US/OlaresManifest.yaml
@@ -14,7 +14,7 @@ spec:
     - `MODEL_SUPPORTS`: Model capability options (Vision / Tools / Thinking / None). Pick what your model supports.
     - `ENGINE_ARGS`: `--max-model-len 65536 --gpu-memory-utilization 0.9 --tensor-parallel-size 1 --max-num-batched-tokens 8192 --enable-prefix-caching --kv-cache-dtype fp8`. Extra vLLM CLI flags. Separate multiple `--key value` pairs with spaces. See https://docs.vllm.ai/en/v0.17.0/configuration/engine_args/.
     - `LOG_LEVEL`: `debug`, `info`, `warn`, or `error`. Log level for the llm-init container.
-    - `VLLM_REQUIRED_GPU_MEMORY`: `8Gi`, `8192`, or `8192Mi`. Model memory needed, enter `0` for CPU mode. On `nvidia` sets `nvidia.com/gpumem`; on `nvidia-gb10` sizes pod memory for gpu-inject.
+    - `VLLM_REQUIRED_GPU_MEMORY`: `8Gi`, `8192`, or `8192Mi`. Model memory needed. On `nvidia` sets `nvidia.com/gpumem`; on `nvidia-gb10` sizes pod memory for gpu-inject.
 
     **How It Works**
     First, `llm-init` downloads your model and gets it ready, then vLLM starts serving the model when it's ready. Both containers run in the same Pod and share the model directory and readiness sentinel.
@@ -28,7 +28,6 @@ spec:
     |----------------|-------------------|----------------------------------------------------------------------|
     | `nvidia`       | GPU (CUDA)        | Set `VLLM_REQUIRED_GPU_MEMORY`; tune `--gpu-memory-utilization` in ENGINE_ARGS |
     | `nvidia-gb10`  | GPU (Spark)       | Same as `nvidia`; `--gpu-memory-utilization` from ENGINE_ARGS (not auto-remapped) |
-    | `cpu`          | CPU only          | Uses `vllm-openai-cpu` image; no `--device cpu` (embedding: add `--runner pooling` in ENGINE_ARGS) |
 
     **Model Storage**
     All model files are stored in a shared folder at `appCommon/huggingface`, mounted as `/cache/hf/hub`. All similar apps use this location for models.

--- a/vllmllmbasev3/i18n/zh-CN/OlaresManifest.yaml
+++ b/vllmllmbasev3/i18n/zh-CN/OlaresManifest.yaml
@@ -14,7 +14,7 @@ spec:
     - `MODEL_SUPPORTS`：模型能力选项（Vision / Tools / Thinking / None）。请选择您的模型支持的功能。
     - `ENGINE_ARGS`：`--max-model-len 65536 --gpu-memory-utilization 0.9 --tensor-parallel-size 1 --max-num-batched-tokens 8192 --enable-prefix-caching --kv-cache-dtype fp8`。vLLM 额外 CLI 参数，多个 `--key value` 之间用空格分隔。详见 https://docs.vllm.ai/en/v0.17.0/configuration/engine_args/。
     - `LOG_LEVEL`：`debug`、`info`、`warn` 或 `error`。llm-init 容器的日志等级。
-    - `VLLM_REQUIRED_GPU_MEMORY`：`8Gi`、`8192` 或 `8192Mi`。模型所需显存，CPU 模式下请设置为 `0`。`nvidia` 下设置 `nvidia.com/gpumem`；`nvidia-gb10` 下设置 pod 内存供 gpu-inject 切分。
+    - `VLLM_REQUIRED_GPU_MEMORY`：`8Gi`、`8192` 或 `8192Mi`。模型所需显存。`nvidia` 下设置 `nvidia.com/gpumem`；`nvidia-gb10` 下设置 pod 内存供 gpu-inject 切分。
 
     **工作流程说明**
     首先，`llm-init` 下载并准备模型，然后 vLLM 在模型准备好后启动服务。两个容器运行在同一 Pod 内，共享模型目录与就绪 sentinel。
@@ -28,7 +28,6 @@ spec:
     |----------------|------------------|--------------------------------------------------------------|
     | `nvidia`       | GPU (CUDA)       | 需设置 `VLLM_REQUIRED_GPU_MEMORY`；可在 ENGINE_ARGS 中调整 `--gpu-memory-utilization` |
     | `nvidia-gb10`  | GPU (Spark)      | 与 `nvidia` 相同；`--gpu-memory-utilization` 由 ENGINE_ARGS 指定（不自动换算） |
-    | `cpu`          | CPU              | 使用 `vllm-openai-cpu` 镜像；勿传 `--device cpu`（embedding 请在 ENGINE_ARGS 中加 `--runner pooling`） |
 
     **模型存储**
     所有模型文件存储在共享目录 `appCommon/huggingface`（挂载为 `/cache/hf/hub`），同类应用均使用此目录。

--- a/vllmllmbasev3/templates/_helpers.tpl
+++ b/vllmllmbasev3/templates/_helpers.tpl
@@ -17,21 +17,13 @@
 {{- int $g -}}
 {{- end -}}
 {{- end -}}
-{{- /* vllmllmbasev3.engineArgs: pass ENGINE_ARGS through; CPU mode strips --device cpu
-       (vllm-openai-cpu v0.24 rejects device_ids=['cpu']). Embedding on CPU: set
-       --runner pooling in ENGINE_ARGS yourself (see llm-init integration README).
-       Usage: {{ include "vllmllmbasev3.engineArgs" (dict "Args" $engineArgs "IsCpu" $isCpuMode) }} */ -}}
+{{- /* vllmllmbasev3.engineArgs: pass ENGINE_ARGS through unchanged.
+       Usage: {{ include "vllmllmbasev3.engineArgs" (dict "Args" $engineArgs) }} */ -}}
 {{- define "vllmllmbasev3.engineArgs" -}}
 {{- $in := . -}}
-{{- $args := trim ($in.Args | default "") -}}
-{{- $isCpu := $in.IsCpu | default false -}}
-{{- if $isCpu -}}
-{{- $args = trim (replace "--device cpu" "" $args) -}}
-{{- $args = trim (replace "--device=cpu" "" $args) -}}
+{{- trim ($in.Args | default "") -}}
 {{- end -}}
-{{- $args -}}
-{{- end -}}
-{{- /* Olares GPU mode at install: cpu | nvidia | nvidia-gb10 (from .Values.gpu / .Values.GPU.Type). */ -}}
+{{- /* Olares GPU mode at install: nvidia | nvidia-gb10 (from .Values.gpu / .Values.GPU.Type). */ -}}
 {{- define "llmbase.gpuType" -}}
 {{- $gpuObj := .Values.GPU | default dict -}}
 {{- $gpuType := .Values.gpu | default "" -}}
@@ -64,13 +56,7 @@ amd64
 {{- $isGb10 := or (eq $gpuType "nvidia-gb10") (eq (include "llmbase.isGb10" .) "true") -}}
 {{- $arch := include "llmbase.hostArch" . -}}
 {{- $img := .Values.engine.images | default dict -}}
-{{- if eq $gpuType "cpu" -}}
-{{- if eq $arch "arm64" -}}
-{{- $img.cpuArm64 | default "docker.io/vllm/vllm-openai-cpu:v0.24.0-arm64" -}}
-{{- else -}}
-{{- $img.cpuAmd64 | default "docker.io/vllm/vllm-openai-cpu:v0.24.0-x86_64" -}}
-{{- end -}}
-{{- else if $isGb10 -}}
+{{- if $isGb10 -}}
 {{- $img.nvidiaGb10 | default "docker.io/vllm/vllm-openai:latest-aarch64-cu130" -}}
 {{- else if eq $arch "arm64" -}}
 {{- $img.nvidiaArm64 | default "docker.io/vllm/vllm-openai:v0.24.0-aarch64-cu129" -}}

--- a/vllmllmbasev3/templates/llm-init.yaml
+++ b/vllmllmbasev3/templates/llm-init.yaml
@@ -36,9 +36,8 @@
 {{- end -}}
 {{- $modelSupports = join "," $expandedSupports -}}
 {{- $gpuType := include "llmbase.gpuType" . -}}
-{{- $isCpuMode := eq $gpuType "cpu" -}}
 {{- $engineArgs := $oe.ENGINE_ARGS | default "" -}}
-{{- $engineArgs = include "vllmllmbasev3.engineArgs" (dict "Args" $engineArgs "IsCpu" $isCpuMode) -}}
+{{- $engineArgs = include "vllmllmbasev3.engineArgs" (dict "Args" $engineArgs) -}}
 {{- $logLevel := $oe.LOG_LEVEL | default "debug" -}}
 {{- /* HF_ENDPOINT / HF_TOKEN: OlaresManifest valueFrom injects HF_ENDPOINT from
        OLARES_SYSTEM_HUGGINGFACE_SERVICE and HF_TOKEN from the user HF account;

--- a/vllmllmbasev3/templates/vllm.yaml
+++ b/vllmllmbasev3/templates/vllm.yaml
@@ -11,10 +11,9 @@
 {{- $memLimit := trim ($oe.VLLM_MEMORY_LIMIT | default "35Gi") -}}
 {{- $gpuType := include "llmbase.gpuType" . -}}
 {{- $engineImage := include "vllmllmbasev3.engineImage" . -}}
-{{- $isCpuMode := eq $gpuType "cpu" -}}
 {{- $gb10FromNodes := eq (include "llmbase.isGb10" .) "true" -}}
 {{- $unifiedMem := or $gb10FromNodes (eq $gpuType "nvidia-gb10") -}}
-{{- $engineArgs = include "vllmllmbasev3.engineArgs" (dict "Args" $engineArgs "IsCpu" $isCpuMode) -}}
+{{- $engineArgs = include "vllmllmbasev3.engineArgs" (dict "Args" $engineArgs) -}}
 {{- /* nvidia.com/gpumem: nvidia -> explicit in chart; gb10 -> pod memory quota only,
        gpu-inject sets matching requests/limits (chart gpumem on gb10 breaks K8s
        validation: requests has gpumem but limits stripped by platform). */ -}}
@@ -41,11 +40,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     io.kompose.service: vllm
-  {{- if not $isCpuMode }}
   annotations:
     applications.app.bytetrade.io/gpu-inject: "vllm"
     vllmllmbasev3.io/engine-image: {{ $engineImage | quote }}
-  {{- end }}
 spec:
   replicas: {{ .Values.workloads.vllmllmbasev3.replicaCount }}
   selector:
@@ -105,10 +102,6 @@ spec:
             - name: VLLM_SPARK_AUTO_GPU_UTIL
               value: "false"
 {{- end }}
-{{- if $isCpuMode }}
-            - name: CUDA_VISIBLE_DEVICES
-              value: ""
-{{- end }}
           ports:
             - name: vllm
               containerPort: 8000
@@ -123,11 +116,9 @@ spec:
             - name: hf-cache
               mountPath: /cache/vllm
               subPath: vllm-cache
-{{- if not $isCpuMode }}
             - name: hf-cache
               mountPath: /root/.nv/ComputeCache
               subPath: .nv/ComputeCache
-{{- end }}
             - name: run-state
               mountPath: /run/llm-init
               readOnly: true
@@ -139,13 +130,13 @@ spec:
             requests:
               cpu: "{{ $cpuRequest }}"
               memory: "{{ $memRequest }}"
-{{- if and (not $isCpuMode) (not $unifiedMem) }}
+{{- if not $unifiedMem }}
               nvidia.com/gpumem: {{ $gpuMiB }}
 {{- end }}
             limits:
               cpu: "{{ $cpuLimit }}"
               memory: "{{ $memLimit }}"
-{{- if and (not $isCpuMode) (not $unifiedMem) }}
+{{- if not $unifiedMem }}
               nvidia.com/gpumem: {{ $gpuMiB }}
 {{- end }}
 ---

--- a/vllmllmbasev3/values.yaml
+++ b/vllmllmbasev3/values.yaml
@@ -14,5 +14,3 @@ engine:
     nvidia: docker.io/vllm/vllm-openai:v0.24.0-cu129
     nvidiaArm64: docker.io/vllm/vllm-openai:v0.24.0-aarch64-cu129
     nvidiaGb10: docker.io/vllm/vllm-openai:latest-aarch64-cu130
-    cpuAmd64: docker.io/vllm/vllm-openai-cpu:v0.24.0-x86_64
-    cpuArm64: docker.io/vllm/vllm-openai-cpu:v0.24.0-arm64


### PR DESCRIPTION
## Summary
- Remove accelerator `mode: cpu` from `OlaresManifest` / i18n (keep `nvidia` and `nvidia-gb10`).
- Drop CPU-only template branches (`\`), CPU engine images / `OLLAMA_NUM_GPU=0` / `--device cpu` / `-ngl 0` helpers.
- Always apply gpu-inject + `nvidia.com/gpumem` on non-gb10 installs.
- Bump chart / metadata version to `1.2.24`.

## Test plan
- [ ] Install on `nvidia` and confirm gpu-inject + engine starts
- [ ] Install on `nvidia-gb10` and confirm unified-memory path
- [ ] Confirm Market no longer offers CPU accelerator for this base