### PR TITLE
[UPDATE][sglangllmbasev3][1.2.23] Drop accelerator CPU mode

### DIFF
--- a/sglangllmbasev3/Chart.yaml
+++ b/sglangllmbasev3/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.5.14-cu130
 description: Generic SGLang + llm-init base; the model is supplied at install time via env
 name: sglangllmbasev3
 type: application
-version: 1.2.22
+version: 1.2.23

--- a/sglangllmbasev3/OlaresManifest.yaml
+++ b/sglangllmbasev3/OlaresManifest.yaml
@@ -7,7 +7,7 @@ metadata:
   description: "Generic SGLang engine base. Pick any HuggingFace Safetensors model at install via env."
   appid: sglangllmbasev3
   title: SGLang Engine Base
-  version: '1.2.22'
+  version: '1.2.23'
   categories:
     - AI
 sharedEntrances:
@@ -35,7 +35,7 @@ spec:
   onlyAdmin: true
   versionName: '0.5.14-cu130'
   upgradeDescription: |
-    v1.2.22: bump llm-init to v1.3.1.
+    Drop accelerator mode `cpu` (GPU-only: `nvidia` / `nvidia-gb10`). Chart 1.2.23.
   fullDescription: |
     **IMPORTANT NOTE**  
     This app is a template and cannot be used on its own. To use it, set the environment variables below to connect a specific model.
@@ -47,7 +47,7 @@ spec:
     - `MODEL_SUPPORTS`: Model capability options (Vision / Tools / Thinking / None). Pick what your model supports.
     - `ENGINE_ARGS`: `--context-length 65536 --mem-fraction-static 0.85 --chunked-prefill-size 4096 --reasoning-parser gpt-oss --tool-call-parser gpt-oss`. Extra SGLang CLI flags. Separate multiple `--key value` pairs with spaces. Adjust `--reasoning-parser` and `--tool-call-parser` to match your model family. See https://docs.sglang.io/docs/advanced_features/server_arguments.
     - `LOG_LEVEL`: `debug`, `info`, `warn`, or `error`. Log level for the llm-init container.
-    - `SGLANG_REQUIRED_GPU_MEMORY`: `8Gi`, `8192`, or `8192Mi`. Model memory needed, enter `0` for CPU mode. On NVIDIA, this sets `nvidia.com/gpumem` in MiB; on Spark, sets pod memory.
+    - `SGLANG_REQUIRED_GPU_MEMORY`: `8Gi`, `8192`, or `8192Mi`. Model memory needed. On NVIDIA, this sets `nvidia.com/gpumem` in MiB; on Spark, sets pod memory.
 
     **How It Works**
     First, `llm-init` downloads your model and gets it ready, then SGLang starts serving the model when it's ready. These two parts run in separate Deployments but share the HF cache and run-state via App Common storage.
@@ -61,7 +61,6 @@ spec:
     |----------------|-------------------|----------------------------------------------------------------------|
     | `nvidia`       | GPU (CUDA)        | Set `SGLANG_REQUIRED_GPU_MEMORY`; tune `--mem-fraction-static` in ENGINE_ARGS |
     | `nvidia-gb10`  | GPU (Spark)       | Like above, but memory is managed by the pod                         |
-    | `cpu`          | CPU only          | Chart injects `--device cpu`; disables GPU                           |
 
     **Model Storage**
     All model files are stored in a shared folder at `appCommon/huggingface`, mounted as `/cache/hf/hub`. All similar apps use this location for models.
@@ -83,16 +82,8 @@ spec:
       url: https://github.com/sgl-project/sglang/blob/main/LICENSE
 
   accelerator:
-    #   cpu          — CPU-only inference; chart injects --device cpu, no GPU inject / gpumem
     #   nvidia       — discrete GPU; SGLANG_REQUIRED_GPU_MEMORY -> gpumem
     #   nvidia-gb10  — DGX Spark unified memory; same env -> pod memory
-    - mode: cpu
-      limitedCpu: "-1"
-      requiredCpu: "-1"
-      requiredDisk: 50Mi
-      limitedDisk: 500Gi
-      limitedMemory: "-1"
-      requiredMemory: "-1"
     - mode: nvidia
       limitedCpu: "-1"
       requiredCpu: "-1"
@@ -229,5 +220,5 @@ envs:
     type: string
     editable: false
     applyOnChange: false
-    description: "Example: `8Gi`, `8192`, or `8192Mi`. GPU memory required for the model. Use `0` on CPU. On NVIDIA this sets `nvidia.com/gpumem` in MiB. On Spark it sets pod memory."
+    description: "Example: `8Gi`, `8192`, or `8192Mi`. GPU memory required for the model. On NVIDIA this sets `nvidia.com/gpumem` in MiB. On Spark it sets pod memory."
     regex: "^[0-9]+(Gi|Mi)?$"

--- a/sglangllmbasev3/i18n/en-US/OlaresManifest.yaml
+++ b/sglangllmbasev3/i18n/en-US/OlaresManifest.yaml
@@ -14,7 +14,7 @@ spec:
     - `MODEL_SUPPORTS`: Model capability options (Vision / Tools / Thinking / None). Pick what your model supports.
     - `ENGINE_ARGS`: `--context-length 65536 --mem-fraction-static 0.85 --chunked-prefill-size 4096 --reasoning-parser gpt-oss --tool-call-parser gpt-oss`. Extra SGLang CLI flags. Separate multiple `--key value` pairs with spaces. Adjust `--reasoning-parser` and `--tool-call-parser` to match your model family. See https://docs.sglang.io/docs/advanced_features/server_arguments.
     - `LOG_LEVEL`: `debug`, `info`, `warn`, or `error`. Log level for the llm-init container.
-    - `SGLANG_REQUIRED_GPU_MEMORY`: `8Gi`, `8192`, or `8192Mi`. Model memory needed, enter `0` for CPU mode. On NVIDIA, this sets `nvidia.com/gpumem` in MiB; on Spark, sets pod memory.
+    - `SGLANG_REQUIRED_GPU_MEMORY`: `8Gi`, `8192`, or `8192Mi`. Model memory needed. On NVIDIA, this sets `nvidia.com/gpumem` in MiB; on Spark, sets pod memory.
 
     **How It Works**
     First, `llm-init` downloads your model and gets it ready, then SGLang starts serving the model when it's ready. These two parts run in separate Deployments but share the HF cache and run-state via App Common storage.
@@ -28,7 +28,6 @@ spec:
     |----------------|-------------------|----------------------------------------------------------------------|
     | `nvidia`       | GPU (CUDA)        | Set `SGLANG_REQUIRED_GPU_MEMORY`; tune `--mem-fraction-static` in ENGINE_ARGS |
     | `nvidia-gb10`  | GPU (Spark)       | Like above, but memory is managed by the pod                         |
-    | `cpu`          | CPU only          | Chart injects `--device cpu`; disables GPU                           |
 
     **Model Storage**
     All model files are stored in a shared folder at `appCommon/huggingface`, mounted as `/cache/hf/hub`. All similar apps use this location for models.

--- a/sglangllmbasev3/i18n/zh-CN/OlaresManifest.yaml
+++ b/sglangllmbasev3/i18n/zh-CN/OlaresManifest.yaml
@@ -14,7 +14,7 @@ spec:
     - `MODEL_SUPPORTS`：模型能力选项（Vision / Tools / Thinking / None）。请选择您的模型支持的功能。
     - `ENGINE_ARGS`：`--context-length 65536 --mem-fraction-static 0.85 --chunked-prefill-size 4096 --reasoning-parser gpt-oss --tool-call-parser gpt-oss`。SGLang 额外 CLI 参数，多个 `--key value` 之间用空格分隔。请根据模型系列调整 `--reasoning-parser` 和 `--tool-call-parser`。详见 https://docs.sglang.io/docs/advanced_features/server_arguments。
     - `LOG_LEVEL`：`debug`、`info`、`warn` 或 `error`。llm-init 容器的日志等级。
-    - `SGLANG_REQUIRED_GPU_MEMORY`：`8Gi`、`8192` 或 `8192Mi`。模型所需显存，CPU 模式下请设置为 `0`。NVIDIA 下设置 `nvidia.com/gpumem`（MiB），Spark 下设置 pod 显存。
+    - `SGLANG_REQUIRED_GPU_MEMORY`：`8Gi`、`8192` 或 `8192Mi`。模型所需显存。NVIDIA 下设置 `nvidia.com/gpumem`（MiB），Spark 下设置 pod 显存。
 
     **工作流程说明**
     首先，`llm-init` 下载并准备模型，然后 SGLang 在模型准备好后启动服务。两个部分运行在不同 Deployment 中，但通过 App Common 存储共享 HF 缓存与运行状态。
@@ -28,7 +28,6 @@ spec:
     |----------------|------------------|--------------------------------------------------------------|
     | `nvidia`       | GPU (CUDA)       | 需设置 `SGLANG_REQUIRED_GPU_MEMORY`；可在 ENGINE_ARGS 中调整 `--mem-fraction-static` |
     | `nvidia-gb10`  | GPU (Spark)      | 类似上方，但显存由 pod 管理                                  |
-    | `cpu`          | CPU              | 图表自动注入 `--device cpu`，禁用 GPU                        |
 
     **模型存储**
     所有模型文件存储在共享目录 `appCommon/huggingface`（挂载为 `/cache/hf/hub`），同类应用均使用此目录。

--- a/sglangllmbasev3/templates/_helpers.tpl
+++ b/sglangllmbasev3/templates/_helpers.tpl
@@ -17,18 +17,9 @@
 {{- int $g -}}
 {{- end -}}
 {{- end -}}
-{{- /* sglangllmbasev3.engineArgs: CPU mode auto-adds --device cpu unless already set.
-       Usage: {{ include "sglangllmbasev3.engineArgs" (dict "Args" $engineArgs "IsCpu" $isCpuMode) }} */ -}}
+{{- /* sglangllmbasev3.engineArgs: pass ENGINE_ARGS through unchanged.
+       Usage: {{ include "sglangllmbasev3.engineArgs" (dict "Args" $engineArgs) }} */ -}}
 {{- define "sglangllmbasev3.engineArgs" -}}
 {{- $in := . -}}
-{{- $args := trim ($in.Args | default "") -}}
-{{- $isCpu := $in.IsCpu | default false -}}
-{{- if and $isCpu (not (contains "--device" $args)) -}}
-{{- if $args -}}
-{{- $args = printf "%s --device cpu" $args -}}
-{{- else -}}
-{{- $args = "--device cpu" -}}
-{{- end -}}
-{{- end -}}
-{{- $args -}}
+{{- trim ($in.Args | default "") -}}
 {{- end -}}

--- a/sglangllmbasev3/templates/llm-init.yaml
+++ b/sglangllmbasev3/templates/llm-init.yaml
@@ -41,9 +41,8 @@
 {{- if not $gpuType -}}
 {{- $gpuType = .Values.GPU.Type | default "nvidia" -}}
 {{- end -}}
-{{- $isCpuMode := eq $gpuType "cpu" -}}
 {{- $engineArgs := $oe.ENGINE_ARGS | default "" -}}
-{{- $engineArgs = include "sglangllmbasev3.engineArgs" (dict "Args" $engineArgs "IsCpu" $isCpuMode) -}}
+{{- $engineArgs = include "sglangllmbasev3.engineArgs" (dict "Args" $engineArgs) -}}
 {{- $logLevel := $oe.LOG_LEVEL | default "debug" -}}
 {{- $hfEndpoint := $oe.HF_ENDPOINT | default "" -}}
 {{- $hfToken := $oe.HF_TOKEN | default "" -}}

--- a/sglangllmbasev3/templates/sglang.yaml
+++ b/sglangllmbasev3/templates/sglang.yaml
@@ -15,11 +15,10 @@
 {{- if not $gpuType -}}
 {{- $gpuType = .Values.GPU.Type | default "nvidia" -}}
 {{- end -}}
-{{- $isCpuMode := eq $gpuType "cpu" -}}
 {{- $unifiedMem := eq $gpuType "nvidia-gb10" -}}
-{{- $engineArgs = include "sglangllmbasev3.engineArgs" (dict "Args" $engineArgs "IsCpu" $isCpuMode) -}}
+{{- $engineArgs = include "sglangllmbasev3.engineArgs" (dict "Args" $engineArgs) -}}
 {{- /* nvidia.com/gpumem needs a BARE MiB int; Spark unified memory reuses the
-       same value as pod memory ("<MiB>Mi"). CPU mode skips GPU inject and gpumem. */ -}}
+       same value as pod memory ("<MiB>Mi"). */ -}}
 {{- $gpuMiB := include "llmbase.gpuMiB" ($oe.SGLANG_REQUIRED_GPU_MEMORY | default "4096") -}}
 {{- if $unifiedMem -}}
 {{- $memRequest = printf "%sMi" $gpuMiB -}}
@@ -42,10 +41,8 @@ metadata:
   namespace: '{{ .Release.Namespace }}'
   labels:
     io.kompose.service: sglang
-  {{- if not $isCpuMode }}
   annotations:
     applications.app.bytetrade.io/gpu-inject: "sglang"
-  {{- end }}
 spec:
   replicas: {{ .Values.workloads.sglangllmbasev3.replicaCount }}
   selector:
@@ -109,10 +106,6 @@ spec:
               value: "1000"
             - name: TZ
               value: Etc/UTC
-{{- if $isCpuMode }}
-            - name: CUDA_VISIBLE_DEVICES
-              value: ""
-{{- end }}
           ports:
             - name: sglang
               containerPort: 30000
@@ -123,11 +116,9 @@ spec:
             - name: hf-cache
               mountPath: /cache/sglang
               subPath: sglang-cache
-{{- if not $isCpuMode }}
             - name: hf-cache
               mountPath: /root/.nv/ComputeCache
               subPath: .nv/ComputeCache
-{{- end }}
             - name: run-state
               mountPath: /run/llm-init
               readOnly: true
@@ -139,17 +130,17 @@ spec:
             # Olares gpu-inject webhook (accelerator is -1/auto, can't carry it).
             # It's a non-overcommittable extended resource, so it must be in BOTH
             # requests and limits with the same value. Dropped on gb10 (unified
-            # memory uses pod memory instead) and cpu (no GPU inject).
+            # memory uses pod memory instead) .
             requests:
               cpu: "{{ $cpuRequest }}"
               memory: "{{ $memRequest }}"
-{{- if and (not $isCpuMode) (not $unifiedMem) }}
+{{- if not $unifiedMem }}
               nvidia.com/gpumem: {{ $gpuMiB }}
 {{- end }}
             limits:
               cpu: "{{ $cpuLimit }}"
               memory: "{{ $memLimit }}"
-{{- if and (not $isCpuMode) (not $unifiedMem) }}
+{{- if not $unifiedMem }}
               nvidia.com/gpumem: {{ $gpuMiB }}
 {{- end }}
 ---


### PR DESCRIPTION
## Summary
- Remove accelerator `mode: cpu` from `OlaresManifest` / i18n (keep `nvidia` and `nvidia-gb10`).
- Drop CPU-only template branches (`\`), CPU engine images / `OLLAMA_NUM_GPU=0` / `--device cpu` / `-ngl 0` helpers.
- Always apply gpu-inject + `nvidia.com/gpumem` on non-gb10 installs.
- Bump chart / metadata version to `1.2.23`.

## Test plan
- [ ] Install on `nvidia` and confirm gpu-inject + engine starts
- [ ] Install on `nvidia-gb10` and confirm unified-memory path
- [ ] Confirm Market no longer offers CPU accelerator for this base