### PR TITLE
[UPDATE][llamacppllmbasev3][1.2.22] Drop accelerator CPU mode

### DIFF
--- a/llamacppllmbasev3/Chart.yaml
+++ b/llamacppllmbasev3/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: b9879
 description: Generic llama.cpp + llm-init base; the GGUF model is supplied at install time via env
 name: llamacppllmbasev3
 type: application
-version: 1.2.21
+version: 1.2.22

--- a/llamacppllmbasev3/OlaresManifest.yaml
+++ b/llamacppllmbasev3/OlaresManifest.yaml
@@ -7,7 +7,7 @@ metadata:
   description: "Generic llama.cpp engine base. Pick any GGUF model at install via env."
   appid: llamacppllmbasev3
   title: llama.cpp Engine Base
-  version: '1.2.21'
+  version: '1.2.22'
   categories:
     - AI
 sharedEntrances:
@@ -35,7 +35,7 @@ spec:
   onlyAdmin: true
   versionName: 'b9879'
   upgradeDescription: |
-    v1.2.21: bump llm-init to v1.3.1; llama.cpp remains server-cuda12-b9879.
+    Drop accelerator mode `cpu` (GPU-only: `nvidia` / `nvidia-gb10`). Chart 1.2.22.
   fullDescription: |
     **IMPORTANT NOTE**  
     This app is a template and cannot be used on its own. To use it, set the environment variables below to connect a specific model.
@@ -45,9 +45,9 @@ spec:
     - `MODEL_NAME`: `owner/repo:quant`. The name of your model in `owner/repo:quant` format, for example `unsloth/Qwen3.5-2B-GGUF:UD-Q4_K_XL`. This is also used as the OpenAI alias.
     - `MODEL_MODE`: `chat` or `embedding`. If you pick embedding, the chart adds `--embedding` automatically.
     - `MODEL_SUPPORTS`: Model capability options (Vision / Tools / Thinking / None). Pick what your model supports. This is required.
-    - `ENGINE_ARGS`: `-c 8192 -ngl all -fa on`. Extra llama.cpp options, like `-c 8192 -ngl all -fa on`. To fully use GPU, add `-ngl all`; for CPU, it adds `-ngl 0` automatically. You can also use values like `LLAMA_ARG_*=val`.
+    - `ENGINE_ARGS`: `-c 8192 -ngl all -fa on`. Extra llama.cpp options, like `-c 8192 -ngl all -fa on`. To fully use GPU, add `-ngl all`. You can also use values like `LLAMA_ARG_*=val`.
     - `LOG_LEVEL`: `debug`, `info`, `warn`, or `error`. Log level: choose from `debug`, `info`, `warn`, or `error`.
-    - `LLAMACPP_REQUIRED_GPU_MEMORY`: `8Gi`, `8192`, or `8192Mi`. Model memory needed (for GPU only; ignored on CPU). Accepts values like `8Gi`, `8192`, or `8192Mi`. On NVIDIA, this sets `nvidia.com/gpumem` in MiB; on Spark, sets pod memory.
+    - `LLAMACPP_REQUIRED_GPU_MEMORY`: `8Gi`, `8192`, or `8192Mi`. Model memory needed. Accepts values like `8Gi`, `8192`, or `8192Mi`. On NVIDIA, this sets `nvidia.com/gpumem` in MiB; on Spark, sets pod memory.
     
     **How It Works**
     First, `llm-init` downloads your model and gets it ready, then `llama.cpp` starts serving the model when it’s ready. These two parts run separately but share files and progress info.
@@ -61,14 +61,13 @@ spec:
     |----------------|-------------------|---------------------------------------------------------------------|
     | `nvidia`       | GPU (CUDA)        | Set `LLAMACPP_REQUIRED_GPU_MEMORY`; use `-ngl all` for full GPU use |
     | `nvidia-gb10`  | GPU (Spark)       | Like above, but memory is managed by the pod                        |
-    | `cpu`          | CPU only          | Adds `-ngl 0`; disables GPU                                         |
 
     **Model Storage**
     All model files are stored in a shared folder at `appCommon/huggingface`, mounted as `/cache/hf/hub`. All similar apps use this location for models.
 
     **Resource Tips**
     - CPU, RAM, and GPU auto-configure based on the chart; disk settings are fixed.
-    - To use the GPU, set `-ngl all` in `ENGINE_ARGS`. Without it, the model will run on CPU.
+    - To use the GPU, set `-ngl all` in `ENGINE_ARGS`. Use `-ngl all` for full GPU offload.
 
   developer: ggml-org
   website: https://llama.app/
@@ -82,16 +81,8 @@ spec:
       url: https://github.com/ggml-org/llama.cpp?tab=MIT-1-ov-file
 
   accelerator:
-    #   cpu          — CPU-only inference; chart injects -ngl 0, no GPU inject / gpumem
     #   nvidia       — discrete GPU; LLAMACPP_REQUIRED_GPU_MEMORY -> gpumem
     #   nvidia-gb10  — DGX Spark unified memory; same env -> pod memory
-    - mode: cpu
-      limitedCpu: "-1"
-      requiredCpu: "-1"
-      requiredDisk: 50Mi
-      limitedDisk: 500Gi
-      limitedMemory: "-1"
-      requiredMemory: "-1"
     - mode: nvidia
       limitedCpu: "-1"
       requiredCpu: "-1"
@@ -175,7 +166,7 @@ envs:
     type: string
     editable: true
     applyOnChange: true
-    description:  "Example: -c 8192 -ngl all -fa on. Extra llama.cpp options, to fully use GPU, add `-ngl all`, for CPU, it adds `-ngl 0` automatically. You can also use values like `LLAMA_ARG_*=val`."
+    description:  "Example: -c 8192 -ngl all -fa on. Extra llama.cpp options, to fully use GPU, add `-ngl all`. You can also use values like `LLAMA_ARG_*=val`."
   - envName: LOG_LEVEL           # single-select: debug | info | warn | error
     required: false
     type: string
@@ -230,5 +221,5 @@ envs:
     type: string
     editable: false
     applyOnChange: false
-    description:  "Example: `8Gi`, `8192`, or `8192Mi`. GPU memory required for the model. Use `0` on CPU. On NVIDIA this sets `nvidia.com/gpumem` in MiB. On Spark it sets pod memory."
+    description:  "Example: `8Gi`, `8192`, or `8192Mi`. GPU memory required for the model. On NVIDIA this sets `nvidia.com/gpumem` in MiB. On Spark it sets pod memory."
     regex: "^[0-9]+(Gi|Mi)?$"

--- a/llamacppllmbasev3/i18n/en-US/OlaresManifest.yaml
+++ b/llamacppllmbasev3/i18n/en-US/OlaresManifest.yaml
@@ -12,9 +12,9 @@ spec:
     - `MODEL_NAME`: `owner/repo:quant`. The name of your model in `owner/repo:quant` format, for example `unsloth/Qwen3.5-2B-GGUF:UD-Q4_K_XL`. This is also used as the OpenAI alias.
     - `MODEL_MODE`: `chat` or `embedding`. If you pick embedding, the chart adds `--embedding` automatically.
     - `MODEL_SUPPORTS`: Model capability options (Vision / Tools / Thinking / None). Pick what your model supports. This is required.
-    - `ENGINE_ARGS`: `-c 8192 -ngl all -fa on`. Extra llama.cpp options, like `-c 8192 -ngl all -fa on`. To fully use GPU, add `-ngl all`; for CPU, it adds `-ngl 0` automatically. You can also use values like `LLAMA_ARG_*=val`.
+    - `ENGINE_ARGS`: `-c 8192 -ngl all -fa on`. Extra llama.cpp options, like `-c 8192 -ngl all -fa on`. To fully use GPU, add `-ngl all`. You can also use values like `LLAMA_ARG_*=val`.
     - `LOG_LEVEL`: `debug`, `info`, `warn`, or `error`. Log level: choose from `debug`, `info`, `warn`, or `error`.
-    - `LLAMACPP_REQUIRED_GPU_MEMORY`: `8Gi`, `8192`, or `8192Mi`. Model memory needed (for GPU only; ignored on CPU). Accepts values like `8Gi`, `8192`, or `8192Mi`. On NVIDIA, this sets `nvidia.com/gpumem` in MiB; on Spark, sets pod memory.
+    - `LLAMACPP_REQUIRED_GPU_MEMORY`: `8Gi`, `8192`, or `8192Mi`. Model memory needed. Accepts values like `8Gi`, `8192`, or `8192Mi`. On NVIDIA, this sets `nvidia.com/gpumem` in MiB; on Spark, sets pod memory.
     
     **How It Works**
     First, `llm-init` downloads your model and gets it ready, then `llama.cpp` starts serving the model when it’s ready. These two parts run separately but share files and progress info.
@@ -28,11 +28,10 @@ spec:
     |----------------|-------------------|---------------------------------------------------------------------|
     | `nvidia`       | GPU (CUDA)        | Set `LLAMACPP_REQUIRED_GPU_MEMORY`; use `-ngl all` for full GPU use |
     | `nvidia-gb10`  | GPU (Spark)       | Like above, but memory is managed by the pod                        |
-    | `cpu`          | CPU only          | Adds `-ngl 0`; disables GPU                                         |
 
     **Model Storage**
     All model files are stored in a shared folder at `appCommon/huggingface`, mounted as `/cache/hf/hub`. All similar apps use this location for models.
 
     **Resource Tips**
     - CPU, RAM, and GPU auto-configure based on the chart; disk settings are fixed.
-    - To use the GPU, set `-ngl all` in `ENGINE_ARGS`. Without it, the model will run on CPU.
+    - To use the GPU, set `-ngl all` in `ENGINE_ARGS`. Use `-ngl all` for full GPU offload.

--- a/llamacppllmbasev3/i18n/zh-CN/OlaresManifest.yaml
+++ b/llamacppllmbasev3/i18n/zh-CN/OlaresManifest.yaml
@@ -12,7 +12,7 @@ spec:
     - `MODEL_NAME`：`owner/repo:quant`。您的模型名称，格式如 `owner/repo:quant`，例如 `unsloth/Qwen3.5-2B-GGUF:UD-Q4_K_XL`。此项也作为 OpenAI 别名。
     - `MODEL_MODE`：`chat` 或 `embedding`。如选 embedding，图表会自动添加 `--embedding` 参数。
     - `MODEL_SUPPORTS`：模型能力选项（Vision / Tools / Thinking / None）。请选择您的模型支持的功能，必填。
-    - `ENGINE_ARGS`：`-c 8192 -ngl all -fa on`。如需完全利用 GPU，请加 `-ngl all`，如只用 CPU 会自动加入 `-ngl 0`。也可用如 `LLAMA_ARG_*=val` 的参数。
+    - `ENGINE_ARGS`：`-c 8192 -ngl all -fa on`。如需完全利用 GPU，请加 `-ngl all`。也可用如 `LLAMA_ARG_*=val` 的参数。
     - `LOG_LEVEL`：`debug`、`info`、`warn` 或 `error`。日志等级，请从上述选项中选择。
     - `LLAMACPP_REQUIRED_GPU_MEMORY`：`8Gi`、`8192` 或 `8192Mi`。模型（仅 GPU 模式）所需显存。支持 `8Gi`、`8192`、`8192Mi` 等格式；NVIDIA 下设置 `nvidia.com/gpumem`（MiB），Spark 下设置 pod 显存。
 
@@ -28,12 +28,11 @@ spec:
     |----------------|------------------|--------------------------------------------------------------|
     | `nvidia`       | GPU (CUDA)       | 需设置 `LLAMACPP_REQUIRED_GPU_MEMORY`，用 `-ngl all` 完全利用 GPU |
     | `nvidia-gb10`  | GPU (Spark)      | 类似上方，但显存由 pod 管理                                  |
-    | `cpu`          | CPU              | 自动加入 `-ngl 0`，禁用 GPU                                  |
 
     **模型存储**
     所有模型文件存储在共享目录 `appCommon/huggingface`（挂载为 `/cache/hf/hub`），同类应用均使用此目录。
 
     **资源建议**
     - CPU、内存和 GPU 数量随图表自动配置，磁盘配额为固定
-    - 如需 GPU 推理，请在 `ENGINE_ARGS` 中加入 `-ngl all`，否则默认仅使用 CPU
+    - 如需 GPU 推理，请在 `ENGINE_ARGS` 中加入 `-ngl all`，请使用 `-ngl all` 以充分利用 GPU
 

--- a/llamacppllmbasev3/templates/_helpers.tpl
+++ b/llamacppllmbasev3/templates/_helpers.tpl
@@ -17,18 +17,9 @@
 {{- int $g -}}
 {{- end -}}
 {{- end -}}
-{{- /* llamacppllmbasev3.engineArgs: CPU mode auto-adds -ngl 0 unless user set -ngl.
-       Usage: {{ include "llamacppllmbasev3.engineArgs" (dict "Args" $engineArgs "IsCpu" $isCpuMode) }} */ -}}
+{{- /* llamacppllmbasev3.engineArgs: pass ENGINE_ARGS through unchanged.
+       Usage: {{ include "llamacppllmbasev3.engineArgs" (dict "Args" $engineArgs) }} */ -}}
 {{- define "llamacppllmbasev3.engineArgs" -}}
 {{- $in := . -}}
-{{- $args := trim ($in.Args | default "") -}}
-{{- $isCpu := $in.IsCpu | default false -}}
-{{- if and $isCpu (not (contains "-ngl" $args)) -}}
-{{- if $args -}}
-{{- $args = printf "%s -ngl 0" $args -}}
-{{- else -}}
-{{- $args = "-ngl 0" -}}
-{{- end -}}
-{{- end -}}
-{{- $args -}}
+{{- trim ($in.Args | default "") -}}
 {{- end -}}

--- a/llamacppllmbasev3/templates/llamacpp.yaml
+++ b/llamacppllmbasev3/templates/llamacpp.yaml
@@ -17,11 +17,10 @@
 {{- if not $gpuType -}}
 {{- $gpuType = .Values.GPU.Type | default "nvidia" -}}
 {{- end -}}
-{{- $isCpuMode := eq $gpuType "cpu" -}}
 {{- $unifiedMem := eq $gpuType "nvidia-gb10" -}}
-{{- $engineArgs = include "llamacppllmbasev3.engineArgs" (dict "Args" $engineArgs "IsCpu" $isCpuMode) -}}
+{{- $engineArgs = include "llamacppllmbasev3.engineArgs" (dict "Args" $engineArgs) -}}
 {{- /* nvidia.com/gpumem needs a BARE MiB int; Spark unified memory reuses the
-       same value as pod memory ("<MiB>Mi"). CPU mode skips GPU inject and gpumem. */ -}}
+       same value as pod memory ("<MiB>Mi"). */ -}}
 {{- $gpuMiB := include "llmbase.gpuMiB" ($oe.LLAMACPP_REQUIRED_GPU_MEMORY | default "4096") -}}
 {{- if $unifiedMem -}}
 {{- $memRequest = printf "%sMi" $gpuMiB -}}
@@ -43,10 +42,8 @@ metadata:
   namespace: '{{ .Release.Namespace }}'
   labels:
     io.kompose.service: llamacpp
-  {{- if not $isCpuMode }}
   annotations:
     applications.app.bytetrade.io/gpu-inject: "llamacpp"
-  {{- end }}
 spec:
   replicas: {{ .Values.workloads.llamacppllmbasev3.replicaCount }}
   selector:
@@ -108,10 +105,6 @@ spec:
               value: "1000"
             - name: TZ
               value: Etc/UTC
-{{- if $isCpuMode }}
-            - name: CUDA_VISIBLE_DEVICES
-              value: ""
-{{- end }}
           ports:
             - name: llamacpp
               containerPort: 8081
@@ -130,17 +123,17 @@ spec:
             # Olares gpu-inject webhook (accelerator is -1/auto, can't carry it).
             # It's a non-overcommittable extended resource, so it must be in BOTH
             # requests and limits with the same value. Dropped on gb10 (unified
-            # memory uses pod memory instead) and cpu (no GPU inject).
+            # memory uses pod memory instead) .
             requests:
               cpu: "{{ $cpuRequest }}"
               memory: "{{ $memRequest }}"
-{{- if and (not $isCpuMode) (not $unifiedMem) }}
+{{- if not $unifiedMem }}
               nvidia.com/gpumem: {{ $gpuMiB }}
 {{- end }}
             limits:
               cpu: "{{ $cpuLimit }}"
               memory: "{{ $memLimit }}"
-{{- if and (not $isCpuMode) (not $unifiedMem) }}
+{{- if not $unifiedMem }}
               nvidia.com/gpumem: {{ $gpuMiB }}
 {{- end }}
 ---

--- a/llamacppllmbasev3/templates/llm-init.yaml
+++ b/llamacppllmbasev3/templates/llm-init.yaml
@@ -42,9 +42,8 @@
 {{- if not $gpuType -}}
 {{- $gpuType = .Values.GPU.Type | default "nvidia" -}}
 {{- end -}}
-{{- $isCpuMode := eq $gpuType "cpu" -}}
 {{- $engineArgs := $oe.ENGINE_ARGS | default "" -}}
-{{- $engineArgs = include "llamacppllmbasev3.engineArgs" (dict "Args" $engineArgs "IsCpu" $isCpuMode) -}}
+{{- $engineArgs = include "llamacppllmbasev3.engineArgs" (dict "Args" $engineArgs) -}}
 {{- $logLevel := $oe.LOG_LEVEL | default "debug" -}}
 {{- $hfEndpoint := $oe.HF_ENDPOINT | default "" -}}
 {{- $hfToken := $oe.HF_TOKEN | default "" -}}


### PR DESCRIPTION
## Summary
- Remove accelerator `mode: cpu` from `OlaresManifest` / i18n (keep `nvidia` and `nvidia-gb10`).
- Drop CPU-only template branches (`\`), CPU engine images / `OLLAMA_NUM_GPU=0` / `--device cpu` / `-ngl 0` helpers.
- Always apply gpu-inject + `nvidia.com/gpumem` on non-gb10 installs.
- Bump chart / metadata version to `1.2.22`.

## Test plan
- [ ] Install on `nvidia` and confirm gpu-inject + engine starts
- [ ] Install on `nvidia-gb10` and confirm unified-memory path
- [ ] Confirm Market no longer offers CPU accelerator for this base