### PR TITLE
[UPDATE][ollamallmbasev3][1.3.9] Drop accelerator CPU mode

### DIFF
--- a/ollamallmbasev3/Chart.yaml
+++ b/ollamallmbasev3/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.31.2
 description: Generic Ollama + llm-init base; the model is supplied at install time via env
 name: ollamallmbasev3
 type: application
-version: 1.3.8
+version: 1.3.9

--- a/ollamallmbasev3/OlaresManifest.yaml
+++ b/ollamallmbasev3/OlaresManifest.yaml
@@ -7,7 +7,7 @@ metadata:
   description: "Generic Ollama engine base. Pick any Ollama library model at install via env."
   appid: ollamallmbasev3
   title: Ollama Engine Base
-  version: '1.3.8'
+  version: '1.3.9'
   categories:
     - AI
 sharedEntrances:
@@ -35,7 +35,7 @@ spec:
   onlyAdmin: true
   versionName: '0.31.2'
   upgradeDescription: |
-    v1.3.8: bump ollama to 0.31.2 and llm-init to v1.3.1.
+    Drop accelerator mode `cpu` (GPU-only: `nvidia` / `nvidia-gb10`). Chart 1.3.9.
   fullDescription: |
     **IMPORTANT NOTE**  
     This app is a template and cannot be used on its own. To use it, set the environment variables below to connect a specific model.
@@ -47,7 +47,7 @@ spec:
     - `MODEL_SUPPORTS`: Model capability options (Vision / Tools / Thinking / None). Pick what your model supports. Check the model page on ollama.com/library for capabilities.
     - `ENGINE_ARGS`: `OLLAMA_KEEP_ALIVE=-1 OLLAMA_CONTEXT_LENGTH=65536 OLLAMA_FLASH_ATTENTION=1 OLLAMA_KV_CACHE_TYPE=q8_0 OLLAMA_NUM_PARALLEL=1`. Extra Ollama **daemon** options (ollama pod only). Separate multiple `key=value` pairs with spaces. If `OLLAMA_KEEP_ALIVE` is omitted, the chart defaults to `-1` (keep model in VRAM forever). This is **not** forwarded to `/api/chat` by llm-init (avoids OpenAI path 400). See https://github.com/ollama/ollama/blob/main/docs/faq.mdx.
     - `LOG_LEVEL`: `debug`, `info`, `warn`, or `error`. Log level for the llm-init container.
-    - `OLLAMA_REQUIRED_GPU_MEMORY`: `8Gi`, `8192`, or `8192Mi`. Model memory needed, enter `0` for CPU mode. On NVIDIA, this sets `nvidia.com/gpumem` in MiB; on Spark, sets pod memory.
+    - `OLLAMA_REQUIRED_GPU_MEMORY`: `8Gi`, `8192`, or `8192Mi`. Model memory needed. On NVIDIA, this sets `nvidia.com/gpumem` in MiB; on Spark, sets pod memory.
 
     **How It Works**
     First, `llm-init` pulls your model from the Ollama library and gets it ready, then the Ollama daemon starts serving the model when it's ready. These two parts run separately but share files and progress info.
@@ -61,7 +61,6 @@ spec:
     |----------------|-------------------|----------------------------------------------------------------------|
     | `nvidia`       | GPU (CUDA)        | Set `OLLAMA_REQUIRED_GPU_MEMORY`; Ollama uses GPU by default         |
     | `nvidia-gb10`  | GPU (Spark)       | Like above, but memory is managed by the pod                         |
-    | `cpu`          | CPU only          | Chart injects `OLLAMA_NUM_GPU=0`; disables GPU                       |
 
     **Model Storage**
     All pulled models are stored in a shared folder at `appCommon/ollama`. All Ollama-based apps share this location, so blobs deduplicate by digest across installs.
@@ -82,16 +81,8 @@ spec:
       url: https://github.com/ollama/ollama#MIT-1-ov-file
 
   accelerator:
-    #   cpu          — CPU-only inference; chart injects OLLAMA_NUM_GPU=0, no GPU inject / gpumem
     #   nvidia       — discrete GPU; OLLAMA_REQUIRED_GPU_MEMORY -> gpumem
     #   nvidia-gb10  — DGX Spark unified memory; same env -> pod memory
-    - mode: cpu
-      limitedCpu: "-1"
-      requiredCpu: "-1"
-      requiredDisk: 50Mi
-      limitedDisk: 500Gi
-      limitedMemory: "-1"
-      requiredMemory: "-1"
     - mode: nvidia
       limitedCpu: "-1"
       requiredCpu: "-1"
@@ -217,5 +208,5 @@ envs:
     type: string
     editable: false
     applyOnChange: false
-    description: "Example: `8Gi`, `8192`, or `8192Mi`. GPU memory required for the model. Use `0` on CPU. On NVIDIA this sets `nvidia.com/gpumem` in MiB. On Spark it sets pod memory."
+    description: "Example: `8Gi`, `8192`, or `8192Mi`. GPU memory required for the model. On NVIDIA this sets `nvidia.com/gpumem` in MiB. On Spark it sets pod memory."
     regex: "^[0-9]+(Gi|Mi)?$"

--- a/ollamallmbasev3/i18n/en-US/OlaresManifest.yaml
+++ b/ollamallmbasev3/i18n/en-US/OlaresManifest.yaml
@@ -14,7 +14,7 @@ spec:
     - `MODEL_SUPPORTS`: Model capability options (Vision / Tools / Thinking / None). Pick what your model supports. Check the model page on ollama.com/library for capabilities.
     - `ENGINE_ARGS`: `OLLAMA_KEEP_ALIVE=-1 OLLAMA_CONTEXT_LENGTH=65536 ...`. Chart defaults to `-1` on the ollama daemon (forever in VRAM); not forwarded by llm-init.
     - `LOG_LEVEL`: `debug`, `info`, `warn`, or `error`. Log level for the llm-init container.
-    - `OLLAMA_REQUIRED_GPU_MEMORY`: `8Gi`, `8192`, or `8192Mi`. Model memory needed, enter `0` for CPU mode. On NVIDIA, this sets `nvidia.com/gpumem` in MiB; on Spark, sets pod memory.
+    - `OLLAMA_REQUIRED_GPU_MEMORY`: `8Gi`, `8192`, or `8192Mi`. Model memory needed. On NVIDIA, this sets `nvidia.com/gpumem` in MiB; on Spark, sets pod memory.
 
     **How It Works**
     First, `llm-init` pulls your model from the Ollama library and gets it ready, then the Ollama daemon starts serving the model when it's ready. These two parts run separately but share files and progress info.
@@ -28,7 +28,6 @@ spec:
     |----------------|-------------------|----------------------------------------------------------------------|
     | `nvidia`       | GPU (CUDA)        | Set `OLLAMA_REQUIRED_GPU_MEMORY`; Ollama uses GPU by default         |
     | `nvidia-gb10`  | GPU (Spark)       | Like above, but memory is managed by the pod                         |
-    | `cpu`          | CPU only          | Chart injects `OLLAMA_NUM_GPU=0`; disables GPU                       |
 
     **Model Storage**
     All pulled models are stored in a shared folder at `appCommon/ollama`. All Ollama-based apps share this location, so blobs deduplicate by digest across installs.

--- a/ollamallmbasev3/i18n/zh-CN/OlaresManifest.yaml
+++ b/ollamallmbasev3/i18n/zh-CN/OlaresManifest.yaml
@@ -14,7 +14,7 @@ spec:
     - `MODEL_SUPPORTS`：模型能力选项（Vision / Tools / Thinking / None）。请选择您的模型支持的功能，可在 ollama.com/library 查看模型能力。必填。
     - `ENGINE_ARGS`：`OLLAMA_KEEP_ALIVE=-1 OLLAMA_CONTEXT_LENGTH=65536 ...`。未设置时图表在 ollama 守护进程默认 `-1`（常驻显存）；llm-init 不转发此项。
     - `LOG_LEVEL`：`debug`、`info`、`warn` 或 `error`。llm-init 容器的日志等级。
-    - `OLLAMA_REQUIRED_GPU_MEMORY`：`8Gi`、`8192` 或 `8192Mi`。模型所需显存，CPU 模式下请设置为 `0`。NVIDIA 下设置 `nvidia.com/gpumem`（MiB），Spark 下设置 pod 显存。
+    - `OLLAMA_REQUIRED_GPU_MEMORY`：`8Gi`、`8192` 或 `8192Mi`。模型所需显存。NVIDIA 下设置 `nvidia.com/gpumem`（MiB），Spark 下设置 pod 显存。
 
     **工作流程说明**
     首先，`llm-init` 从 Ollama 模型库拉取并准备模型，然后 Ollama 守护进程在模型准备好后启动服务。这两个部分独立运行但共享文件与进度信息。
@@ -28,7 +28,6 @@ spec:
     |----------------|------------------|--------------------------------------------------------------|
     | `nvidia`       | GPU (CUDA)       | 需设置 `OLLAMA_REQUIRED_GPU_MEMORY`；Ollama 默认使用 GPU     |
     | `nvidia-gb10`  | GPU (Spark)      | 类似上方，但显存由 pod 管理                                  |
-    | `cpu`          | CPU              | 图表自动注入 `OLLAMA_NUM_GPU=0`，禁用 GPU                    |
 
     **模型存储**
     所有拉取的模型存储在共享目录 `appCommon/ollama`。所有 Ollama 应用共用此目录，按 digest 去重，避免重复占用存储。

--- a/ollamallmbasev3/templates/_helpers.tpl
+++ b/ollamallmbasev3/templates/_helpers.tpl
@@ -19,13 +19,11 @@
 {{- end -}}
 {{- /* ollamallmbasev3.engineArgs: merge clone ENGINE_ARGS with chart defaults.
        OLLAMA_KEEP_ALIVE=-1 (forever in VRAM) on the ollama daemon unless set.
-       llm-init ENGINE_ARGS strips this key (see engineArgsForLlminit). CPU mode
-       adds OLLAMA_NUM_GPU=0 unless set.
-       Usage: {{ include "ollamallmbasev3.engineArgs" (dict "Args" ($oe.ENGINE_ARGS | default "") "IsCpu" $isCpuMode) }} */ -}}
+       llm-init ENGINE_ARGS strips this key (see engineArgsForLlminit).
+       Usage: {{ include "ollamallmbasev3.engineArgs" (dict "Args" ($oe.ENGINE_ARGS | default "")) }} */ -}}
 {{- define "ollamallmbasev3.engineArgs" -}}
 {{- $in := . -}}
 {{- $args := trim ($in.Args | default "") -}}
-{{- $isCpu := $in.IsCpu | default false -}}
 {{- if not (contains "OLLAMA_KEEP_ALIVE" $args) -}}
 {{- if $args -}}
 {{- $args = printf "%s OLLAMA_KEEP_ALIVE=-1" $args -}}
@@ -33,32 +31,17 @@
 {{- $args = "OLLAMA_KEEP_ALIVE=-1" -}}
 {{- end -}}
 {{- end -}}
-{{- if and $isCpu (not (contains "OLLAMA_NUM_GPU" $args)) -}}
-{{- if $args -}}
-{{- $args = printf "%s OLLAMA_NUM_GPU=0" $args -}}
-{{- else -}}
-{{- $args = "OLLAMA_NUM_GPU=0" -}}
-{{- end -}}
-{{- end -}}
 {{- $args -}}
 {{- end -}}
 {{- /* ollamallmbasev3.engineArgsForLlminit: user ENGINE_ARGS for llm-init only.
        Never inject OLLAMA_KEEP_ALIVE (llm-init forwards it on /api/chat as "-1").
-       Strip if user set it; CPU mode adds OLLAMA_NUM_GPU=0 unless set.
-       Usage: {{ include "ollamallmbasev3.engineArgsForLlminit" (dict "Args" ($oe.ENGINE_ARGS | default "") "IsCpu" $isCpuMode) }} */ -}}
+       Strip if user set it.
+       Usage: {{ include "ollamallmbasev3.engineArgsForLlminit" (dict "Args" ($oe.ENGINE_ARGS | default "")) }} */ -}}
 {{- define "ollamallmbasev3.engineArgsForLlminit" -}}
 {{- $in := . -}}
 {{- $args := trim ($in.Args | default "") -}}
-{{- $isCpu := $in.IsCpu | default false -}}
 {{- $args = regexReplaceAll ` ?OLLAMA_KEEP_ALIVE=[^ ]+` "" $args -}}
 {{- $args = regexReplaceAll ` +` " " $args -}}
 {{- $args = trim $args -}}
-{{- if and $isCpu (not (contains "OLLAMA_NUM_GPU" $args)) -}}
-{{- if $args -}}
-{{- $args = printf "%s OLLAMA_NUM_GPU=0" $args -}}
-{{- else -}}
-{{- $args = "OLLAMA_NUM_GPU=0" -}}
-{{- end -}}
-{{- end -}}
 {{- $args -}}
 {{- end -}}

--- a/ollamallmbasev3/templates/llm-init.yaml
+++ b/ollamallmbasev3/templates/llm-init.yaml
@@ -42,10 +42,9 @@
 {{- if not $gpuType -}}
 {{- $gpuType = .Values.GPU.Type | default "nvidia" -}}
 {{- end -}}
-{{- $isCpuMode := eq $gpuType "cpu" -}}
 {{- /* User ENGINE_ARGS for llm-init: never OLLAMA_KEEP_ALIVE (see engineArgsForLlminit).
        Empty when user leaves ENGINE_ARGS blank — keep_alive is ollama-daemon-only. */ -}}
-{{- $engineArgs := include "ollamallmbasev3.engineArgsForLlminit" (dict "Args" ($oe.ENGINE_ARGS | default "") "IsCpu" $isCpuMode) -}}
+{{- $engineArgs := include "ollamallmbasev3.engineArgsForLlminit" (dict "Args" ($oe.ENGINE_ARGS | default "")) -}}
 ---
 # llm-init Pod (no GPU). Talks to the ollama daemon via the "ollama"
 # Service on :11434 (defined in templates/ollama.yaml). llm-init derives

--- a/ollamallmbasev3/templates/ollama.yaml
+++ b/ollamallmbasev3/templates/ollama.yaml
@@ -1,16 +1,15 @@
 {{- /* ENGINE_ARGS is the v1.1.0 daemon-tuning surface: a KEY=VALUE list of
        OLLAMA_* env that the ollama.sh wrapper exports before `ollama serve`.
        Clone-configurable via olaresEnv.ENGINE_ARGS; chart defaults
-       OLLAMA_KEEP_ALIVE=-1 when omitted; CPU mode adds OLLAMA_NUM_GPU=0.
+       OLLAMA_KEEP_ALIVE=-1 when omitted.
        llm-init uses engineArgsForLlminit (same user args, no KEEP_ALIVE). */ -}}
 {{- $oe := .Values.olaresEnv | default dict -}}
 {{- $gpuType := .Values.gpu | default "" -}}
 {{- if not $gpuType -}}
 {{- $gpuType = .Values.GPU.Type | default "nvidia" -}}
 {{- end -}}
-{{- $isCpuMode := eq $gpuType "cpu" -}}
 {{- $unifiedMem := eq $gpuType "nvidia-gb10" -}}
-{{- $engineArgs := include "ollamallmbasev3.engineArgs" (dict "Args" ($oe.ENGINE_ARGS | default "") "IsCpu" $isCpuMode) -}}
+{{- $engineArgs := include "ollamallmbasev3.engineArgs" (dict "Args" ($oe.ENGINE_ARGS | default "")) -}}
 {{- $modelSource := $oe.MODEL_SOURCE | default "" -}}
 {{- $modelName := $oe.MODEL_NAME | default "" -}}
 {{- $modelMode := $oe.MODEL_MODE | default "chat" -}}
@@ -22,7 +21,7 @@
 {{- $memLimit := trim ($oe.OLLAMA_MEMORY_LIMIT | default "35Gi") -}}
 {{- /* Per-instance model memory quota. nvidia.com/gpumem needs a BARE MiB int;
        Spark unified memory reuses the same value as pod memory ("<MiB>Mi").
-       CPU mode (accelerator mode: cpu) skips GPU inject and gpumem. */ -}}
+       */ -}}
 {{- $gpuMiB := include "llmbase.gpuMiB" ($oe.OLLAMA_REQUIRED_GPU_MEMORY | default "4096") -}}
 {{- if $unifiedMem -}}
 {{- $memRequest = printf "%sMi" $gpuMiB -}}
@@ -46,10 +45,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     io.kompose.service: ollama
-  {{- if not $isCpuMode }}
   annotations:
     applications.app.bytetrade.io/gpu-inject: "true"
-  {{- end }}
 spec:
   replicas: {{ .Values.workloads.ollamallmbasev3.replicaCount }}
   selector:
@@ -75,14 +72,12 @@ spec:
           hostPath:
             path: "{{ .Values.userspace.appCommon }}/ollama"
             type: DirectoryOrCreate
-{{- if not $isCpuMode }}
         # CUDA JIT compile cache lives alongside the models under appCommon/ollama
         # (appCache is not available for this hostPath mount).
         - name: cuda-compute-cache
           hostPath:
             path: "{{ .Values.userspace.appCommon }}/ollama/.nv"
             type: DirectoryOrCreate
-{{- end }}
         - name: wrappers
           configMap:
             name: llm-init-wrappers
@@ -117,17 +112,8 @@ spec:
               value: "1000"
             - name: TZ
               value: Etc/UTC
-{{- if $isCpuMode }}
-            # Olares cpu accelerator may still expose /dev/nvidia* on GPU nodes;
-            # hide devices from CUDA so Ollama cannot offload despite OLLAMA_NUM_GPU=0.
-            - name: OLLAMA_NUM_GPU
-              value: "0"
-            - name: CUDA_VISIBLE_DEVICES
-              value: ""
-{{- else }}
             - name: GGML_CUDA_DISABLE_GRAPHS
               value: "1"
-{{- end }}
           ports:
             - name: ollama
               containerPort: 11434
@@ -148,11 +134,9 @@ spec:
           volumeMounts:
             - name: ollama-data
               mountPath: /root/.ollama
-{{- if not $isCpuMode }}
             - name: cuda-compute-cache
               mountPath: /root/.nv/ComputeCache
               subPath: ComputeCache
-{{- end }}
             - name: wrappers
               mountPath: /llm-init/wrappers
               readOnly: true
@@ -165,13 +149,13 @@ spec:
             requests:
               cpu: "{{ $cpuRequest }}"
               memory: "{{ $memRequest }}"
-{{- if and (not $isCpuMode) (not $unifiedMem) }}
+{{- if not $unifiedMem }}
               nvidia.com/gpumem: {{ $gpuMiB }}
 {{- end }}
             limits:
               cpu: "{{ $cpuLimit }}"
               memory: "{{ $memLimit }}"
-{{- if and (not $isCpuMode) (not $unifiedMem) }}
+{{- if not $unifiedMem }}
               nvidia.com/gpumem: {{ $gpuMiB }}
 {{- end }}
 ---


### PR DESCRIPTION
## Summary
- Remove accelerator `mode: cpu` from `OlaresManifest` / i18n (keep `nvidia` and `nvidia-gb10`).
- Drop CPU-only template branches (`\`), CPU engine images / `OLLAMA_NUM_GPU=0` / `--device cpu` / `-ngl 0` helpers.
- Always apply gpu-inject + `nvidia.com/gpumem` on non-gb10 installs.
- Bump chart / metadata version to `1.3.9`.

## Test plan
- [ ] Install on `nvidia` and confirm gpu-inject + engine starts
- [ ] Install on `nvidia-gb10` and confirm unified-memory path
- [ ] Confirm Market no longer offers CPU accelerator for this base