### PR TITLE
[UPDATE][louter][0.2.1]Upgrade to OlaresManifest v3 format (0.12.0) & fix supported arch

### DIFF
--- a/louter/Chart.yaml
+++ b/louter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: louter
 description: Local LLM gateway with hybrid inference and distillation
 type: application
-version: '0.2.0'
+version: '0.2.1'
 appVersion: '2.0.0'

--- a/louter/OlaresManifest.yaml
+++ b/louter/OlaresManifest.yaml
@@ -64,7 +64,6 @@ spec:
   requiredCpu: 0.1
   limitedCpu: 2
   supportArch:
-    - amd64
     - arm64
 
 options:

--- a/louter/OlaresManifest.yaml
+++ b/louter/OlaresManifest.yaml
@@ -1,16 +1,19 @@
-olaresManifest.version: '0.10.0'
+olaresManifest.version: '0.12.0'
 olaresManifest.type: app
+apiVersion: 'v3'
 
+workloadReplicas:
+  louter: 1
 metadata:
   name: louter
   description: Local LLM gateway with hybrid inference and distillation. Route AI agents to the right model — cloud or local — with automatic training data collection.
   icon: https://raw.githubusercontent.com/Drlucaslu/louter/main/web/public/icon.png
   appid: louter
-  version: '0.2.0'
+  version: '0.2.1'
   title: Louter
   categories:
-    - Productivity
-    - Utilities
+  - Productivity_v112
+  - Utilities_v112
 
 entrances:
   - name: louter-web
@@ -50,6 +53,7 @@ spec:
   submitter: Drlucaslu
   locale:
     - en-US
+    - zh-CN
   license:
     - text: MIT
       url: https://github.com/Drlucaslu/louter/blob/main/LICENSE
@@ -67,4 +71,4 @@ options:
   dependencies:
     - name: olares
       type: system
-      version: '>=1.11.0-0'
+      version: '>=1.12.6-0'

--- a/louter/i18n/en-US/OlaresManifest.yaml
+++ b/louter/i18n/en-US/OlaresManifest.yaml
@@ -1,0 +1,21 @@
+metadata:
+  title: Louter
+  description: Local LLM gateway with hybrid inference and distillation. Route AI agents to the right model — cloud or local — with automatic training data collection.
+spec:
+  fullDescription: |
+    Louter is a single-binary LLM API gateway that sits between your AI agents and LLM providers.
+
+    Features:
+    - One endpoint for all providers (OpenAI, Anthropic, Azure, DeepSeek, Ollama)
+    - Hybrid inference: route simple requests to local model, complex ones to cloud
+    - Per-key routing mode: choose "rules", "hybrid", or "smart" per API key
+    - Distillation pipeline: collect cloud responses, fine-tune local model, deploy
+    - Session-aware routing: same model throughout a conversation
+    - Tool call normalizer: parse Hermes/Qwen/ReAct formats to OpenAI standard
+    - Implicit feedback: detect agent retries to label training data
+    - Runtime tuning: adjust routing thresholds via API without restart
+    - Built-in Web UI for management and monitoring
+  upgradeDescription: |
+    - Per-key routing mode: choose rules, hybrid, or smart per API key
+    - Simplified distillation: direct Ollama safetensors import, no GGUF needed
+    - Dead code cleanup and documentation updates

--- a/louter/i18n/zh-CN/OlaresManifest.yaml
+++ b/louter/i18n/zh-CN/OlaresManifest.yaml
@@ -1,0 +1,21 @@
+metadata:
+  title: Louter
+  description: 本地 LLM 网关，支持混合推理与蒸馏。将 AI Agent 请求路由到合适的模型（云端或本地），并自动采集训练数据。
+spec:
+  fullDescription: |
+    Louter 是一款单二进制 LLM API 网关，位于 AI Agent 与各大 LLM 提供方之间。
+
+    **主要功能：**
+    - 统一接入所有提供方（OpenAI、Anthropic、Azure、DeepSeek、Ollama）
+    - 混合推理：简单请求走本地模型，复杂请求走云端
+    - 按密钥选择路由模式：rules / hybrid / smart
+    - 蒸馏流水线：采集云端回答、微调本地模型并部署
+    - 会话感知路由：同一对话全程使用同一模型
+    - 工具调用归一化：将 Hermes / Qwen / ReAct 格式解析为 OpenAI 标准
+    - 隐式反馈：检测 Agent 重试以标注训练数据
+    - 运行时可调优：无需重启即可通过 API 调整路由阈值
+    - 内置 Web UI，便于管理与监控
+  upgradeDescription: |
+    - 按密钥选择路由模式：rules / hybrid / smart
+    - 简化蒸馏流程：直接导入 Ollama safetensors，无需 GGUF
+    - 清理无用代码并更新文档

--- a/louter/templates/deployment.yaml
+++ b/louter/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: louter
 spec:
-  replicas: 1
+  replicas: {{ .Values.workloads.louter.replicaCount }}
   strategy:
     type: Recreate
   selector:

--- a/louter/values.yaml
+++ b/louter/values.yaml
@@ -5,3 +5,7 @@ image:
 userspace:
   appData: ""
   appCache: ""
+
+workloads:
+  louter:
+    replicaCount: 1


### PR DESCRIPTION
### App Title
louter

### Description
Upgrade to OlaresManifest v3 format (0.12.0).
Remove amd64 support as only arm64 image is provided for [sixwings740/louter:0.2.0](https://hub.docker.com/layers/sixwings740/louter/0.2.0/images/sha256-bebd5880ea337c5b9e4f78d059f50a8febb093249341cd4071ae61e638a8fb44)

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`

Made with [Cursor](https://cursor.com)