### PR TITLE
[UPDATE][tautulli][2.17.2]update to v3 format

### DIFF
--- a/tautulli/Chart.yaml
+++ b/tautulli/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: tautulli
 description: Tautulli dashboard for Plex monitoring
 type: application
-version: 2.17.1
+version: 2.17.2
 appVersion: "2.17.1"

--- a/tautulli/OlaresManifest.yaml
+++ b/tautulli/OlaresManifest.yaml
@@ -1,16 +1,17 @@
-olaresManifest.version: '0.11.0'
+olaresManifest.version: '0.12.0'
 olaresManifest.type: app
-apiVersion: v1
+apiVersion: 'v3'
 
+workloadReplicas:
+  tautulli: 1
 metadata:
   name: tautulli
   appid: tautulli
   title: Tautulli
   description: Monitoring and statistics dashboard for Plex Media Server.
   icon: https://raw.githubusercontent.com/donbodbod/apps/8818290c4b0f1292c58c16b3d77671c4d0a61fee/tautulli/icon.png
-  version: 2.17.1
+  version: 2.17.2
   categories:
-    - Utilities
     - Utilities_v112
 
 entrances:
@@ -32,7 +33,6 @@ ports:
 
 permission:
   appData: true
-  userData: []
 
 spec:
   versionName: "2.17.1"
@@ -42,6 +42,7 @@ spec:
   submitter: donbodbod
   locale:
     - en-US
+    - zh-CN
   supportArch:
     - amd64
   requiredCpu: 100m
@@ -54,4 +55,4 @@ options:
   dependencies:
     - name: olares
       type: system
-      version: ">=1.12.0"
+      version: ">=1.12.6-0"

--- a/tautulli/i18n/en-US/OlaresManifest.yaml
+++ b/tautulli/i18n/en-US/OlaresManifest.yaml
@@ -1,0 +1,3 @@
+metadata:
+  title: Tautulli
+  description: Monitoring and statistics dashboard for Plex Media Server.

--- a/tautulli/i18n/zh-CN/OlaresManifest.yaml
+++ b/tautulli/i18n/zh-CN/OlaresManifest.yaml
@@ -1,0 +1,3 @@
+metadata:
+  title: Tautulli
+  description: Plex 媒体服务器的监控与统计面板。

--- a/tautulli/templates/deployment.yaml
+++ b/tautulli/templates/deployment.yaml
@@ -15,7 +15,7 @@ metadata:
     applications.app.bytetrade.io/entrances: '[{"name":"tautulli","host":"tautulli","port":8181,"title":"Tautulli"}]'
     applications.app.bytetrade.io/default-thirdlevel-domains: '[{"appName":"tautulli","entranceName":"tautulli"}]'
 spec:
-  replicas: 1
+  replicas: {{ .Values.workloads.tautulli.replicaCount }}
   selector:
     matchLabels:
       io.kompose.service: tautulli

--- a/tautulli/values.yaml
+++ b/tautulli/values.yaml
@@ -18,3 +18,7 @@ resources:
 
 userspace:
   appData: /Data/studio/tautulli
+
+workloads:
+  tautulli:
+    replicaCount: 1


### PR DESCRIPTION
### App Title
tautulli

### Description
Upgrade Tautulli chart to OlaresManifest v3 format for Olares OS >=1.12.6.

- Bump chart/manifest version `2.17.1` → `2.17.2`
- Set `olaresManifest.version: '0.12.0'` and `apiVersion: 'v3'`
- Add `workloadReplicas.tautulli: 1`, wire `values.yaml` / Deployment replicas
- Update Olares dependency to `>=1.12.6-0`
- Remove deprecated category `Utilities` (keep `Utilities_v112`)
- Add i18n (`en-US`, `zh-CN`) for title/description

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`

Made with [Cursor](https://cursor.com)