### PR TITLE
[UPDATE][llamacppqwen35a3b][1.0.3]Upgrade to OlaresManifest (0.12.0) format

### DIFF
--- a/llamacppqwen35a3b/Chart.yaml
+++ b/llamacppqwen35a3b/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '1.0.2'
 description: Qwen3.5 35B-A3B served via llama.cpp
 name: llamacppqwen35a3b
 type: application
-version: '1.0.2'
+version: '1.0.3'

--- a/llamacppqwen35a3b/OlaresManifest.yaml
+++ b/llamacppqwen35a3b/OlaresManifest.yaml
@@ -1,13 +1,16 @@
----
-olaresManifest.version: '0.11.0'
+olaresManifest.version: '0.12.0'
 olaresManifest.type: app
+apiVersion: 'v3'
+
+workloadReplicas:
+  llamacppqwen35a3b: 1
 metadata:
   name: llamacppqwen35a3b
-  icon: https://app.cdn.olares.com/appstore/llm/ollama/llm/qwen3-14b.png
+  icon: https://app.cdn.olares.com/appstore/llm/llamacpp/llm/qwen.png
   description: "Qwen3.5 35B-A3B served via llama.cpp"
   appid: llamacppqwen35a3b
   title: Qwen3.5 35B-A3B Q4_K_M (lcpp)
-  version: '1.0.2'
+  version: '1.0.3'
   categories:
     - AI
 entrances:
@@ -15,7 +18,7 @@ entrances:
     port: 8080
     host: llamacppqwen35a3b
     title: Qwen 35B-A3B llamacpp
-    icon: https://app.cdn.olares.com/appstore/llm/ollama/llm/qwen3-14b.png
+    icon: https://app.cdn.olares.com/appstore/llm/llamacpp/llm/qwen.png
     openMethod: window
     authLevel: internal
 spec:
@@ -31,18 +34,21 @@ spec:
   submitter: aamsellem
   locale:
     - en-US
+    - zh-CN
   license:
     - text: MIT
       url: https://github.com/ggerganov/llama.cpp/blob/master/LICENSE
 
-  limitedCpu: 8000m
-  requiredCpu: 1000m
-  requiredDisk: 25Gi
-  limitedDisk: 50Gi
-  limitedMemory: 16Gi
-  requiredMemory: 4Gi
-  requiredGpu: 1Gi
-  limitedGpu: 16Gi
+  accelerator:
+    - mode: nvidia
+      limitedCpu: 8000m
+      requiredCpu: 1000m
+      requiredDisk: 25Gi
+      limitedDisk: 50Gi
+      limitedMemory: 16Gi
+      requiredMemory: 4Gi
+      requiredGPUMemory: 1Gi
+      limitedGPUMemory: 16Gi
 
   supportArch:
     - amd64
@@ -52,5 +58,5 @@ options:
   apiTimeout: 0
   dependencies:
     - name: olares
-      version: '>=1.12.3-0'
+      version: '>=1.12.6-0'
       type: system

--- a/llamacppqwen35a3b/i18n/en-US/OlaresManifest.yaml
+++ b/llamacppqwen35a3b/i18n/en-US/OlaresManifest.yaml
@@ -1,7 +1,6 @@
 metadata:
   title: Qwen3.5 35B-A3B Q4_K_M (lcpp)
   description: "Qwen3.5 35B-A3B served via llama.cpp"
-
 spec:
   fullDescription: |
     Qwen3.5 35B-A3B (MoE, 3B active) served via llama.cpp with Q4_K_M quantization.

--- a/llamacppqwen35a3b/i18n/zh-CN/OlaresManifest.yaml
+++ b/llamacppqwen35a3b/i18n/zh-CN/OlaresManifest.yaml
@@ -1,0 +1,8 @@
+metadata:
+  title: Qwen3.5 35B-A3B Q4_K_M (lcpp)
+  description: "通过 llama.cpp 提供 Qwen3.5 35B-A3B 服务"
+spec:
+  fullDescription: |
+    通过 llama.cpp 以 Q4_K_M 量化提供 Qwen3.5 35B-A3B（MoE，约 3B 激活参数）服务。
+    首次启动时下载 GGUF 模型并缓存。
+    在 8080 端口暴露兼容 OpenAI 的 API。

--- a/llamacppqwen35a3b/templates/deployment.yaml
+++ b/llamacppqwen35a3b/templates/deployment.yaml
@@ -23,7 +23,7 @@ metadata:
   annotations:
     applications.app.bytetrade.io/gpu-inject: "true"
 spec:
-  replicas: 1
+  replicas: {{ .Values.workloads.llamacppqwen35a3b.replicaCount }}
   selector:
     matchLabels:
       io.kompose.service: llamacppqwen35a3b

--- a/llamacppqwen35a3b/values.yaml
+++ b/llamacppqwen35a3b/values.yaml
@@ -5,3 +5,7 @@ userspace:
   appData: ""
   appCache: ""
   userData: ""
+
+workloads:
+  llamacppqwen35a3b:
+    replicaCount: 1


### PR DESCRIPTION
### App Title
llamacppqwen35a3b

### Description
Upgrade llamacppqwen35a3b chart to OlaresManifest v3 format for Olares OS >=1.12.6.

- Bump chart/manifest version `1.0.2` → `1.0.3`
- Set `olaresManifest.version: '0.12.0'` and `apiVersion: 'v3'`
- Add `workloadReplicas.llamacppqwen35a3b: 1`, wire `values.yaml` / Deployment replicas
- Update Olares dependency to `>=1.12.6-0`
- Move CPU/memory/disk/GPU resource fields into `spec.accelerator` (`mode: nvidia`)
- Update app/entrance icon to `https://app.cdn.olares.com/appstore/llm/llamacpp/llm/qwen.png`
- Add `zh-CN` i18n (keep `en-US`)

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`

Made with [Cursor](https://cursor.com)