### PR TITLE
[UPDATE][vramarket][0.1.45] production audit: real metering, lease expiry, invoices, provider account, drain, reputation, GPU telemetry — E2E 30/30 

### DIFF
--- a/vramarket/Chart.yaml
+++ b/vramarket/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: vramarket
 description: DePIN P2P VRAM rental marketplace on top of Olares GPU orchestration
 type: application
-version: 0.1.44
+version: 0.1.45
 appVersion: "0.1.0"

--- a/vramarket/OlaresManifest.yaml
+++ b/vramarket/OlaresManifest.yaml
@@ -10,7 +10,7 @@ metadata:
   title: VRAMarket
   description: Peer-to-peer VRAM rental marketplace orchestrated over Olares GPU memory-slicing
   icon: https://app.cdn.olares.com/appstore/default/defaulticon.webp
-  version: 0.1.44
+  version: 0.1.45
   categories:
     - AI
 entrances:

--- a/vramarket/crds/vramarket-crds.yaml
+++ b/vramarket/crds/vramarket-crds.yaml
@@ -68,6 +68,17 @@ spec:
                       ts: {type: number}
                 failoverCount: {type: integer}
                 settleReason: {type: string}
+                # Écrits par m05/m10 : sans ces champs le schéma structurel
+                # les ÉLIMINAIT silencieusement (pruning) — la facture et la
+                # fenêtre de grâce n'étaient jamais persistées.
+                fundedAt: {type: number}
+                closedAt: {type: number}
+                graceUntil: {type: number}
+                podName: {type: string}
+                nodeName: {type: string}
+                invoice:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -178,6 +189,28 @@ spec:
                 lastHeartbeatUnix: {type: number}
                 freeVramMib: {type: integer}
                 inventoryFingerprint: {type: string}
+                # Inventaire GPU publié par le heartbeat m02 (lu par m04 pour
+                # le rang GPU) — était éliminé par le pruning structurel.
+                gpuModel: {type: string}
+                gpuUuid: {type: string}
+                vramTotalMib: {type: integer}
+                gpuCards:
+                  type: array
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                # Utilisation réelle (nvidia-smi via m01), affichée au locataire
+                gpuUtilPct: {type: number}
+                vramUsedMib: {type: integer}
+                # m08 : latences mesurées vers les autres zones (ms)
+                latencyMs:
+                  type: object
+                  additionalProperties: {type: number}
+                # m09 : score publié par le control plane à chaque événement
+                reputationScore: {type: number}
+                lastMeter:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/vramarket/values.yaml
+++ b/vramarket/values.yaml
@@ -5,7 +5,7 @@ userspace:
 olaresEnv: {}
 
 control:
-  image: ghcr.io/jeffreyturov-dev/vramarket-control:0.1.35
+  image: ghcr.io/jeffreyturov-dev/vramarket-control:0.1.36
   replicas: 1
   # Envelope plate CPU-only (pas de mode accelerator) :
   resources:
@@ -13,7 +13,7 @@ control:
     limits:   {cpu: "2", memory: 2Gi}
 
 agent:
-  image: ghcr.io/jeffreyturov-dev/vramarket-agent:0.1.26
+  image: ghcr.io/jeffreyturov-dev/vramarket-agent:0.1.27
   # spec.accelerator déclaré dans le manifest subChart agent :
   #   mode: nvidia, supportMultiCard: true, supportMultiNodes: true
   #   requiredGPUMemory: 2Gi   (= PROVIDER_RESERVE_MIB de m06)


### PR DESCRIPTION
## Production audit — 9 correctifs majeurs, E2E 30/30 sur cluster réel

Audit préventif complet du cycle de vie d'une location (matching → financement → metering → règlement → reversement). Chaque point a été implémenté **puis vérifié par un test E2E dédié** sur cluster Olares réel (RTX 5090, rail PayPal réel).

### Correctifs

1. **Metering réel rebranché** — la facturation temps réel (accrual à la ms) tourne désormais en boucle dans le control plane à partir des heartbeats CRD des agents, avec crédit SLA automatique quand le nœud est SUSPECT/DOWN. Avant : le compteur restait à 0 pendant toute la location. *Test : `metering : spent > 0`.*
2. **Expiration des baux** — un bail arrivé à `durationS` se clôt automatiquement (`SETTLING`, `settleReason=duration_elapsed`). Avant : un locataire qui ne clique jamais « clôturer » bloquait la VRAM et l'escrow indéfiniment.
3. **Facture finale persistée + historique UI** — la facture m05 (montant dû provider, fee 3 %, remboursement locataire, txs) est persistée dans le status du bail et affichée dans les deux dashboards (nouveau composant `InvoiceHistory`). *Test : `facture persistée (providerDue > 0)`.*
4. **Compte provider + reversements documentés** — `GET /v1/account` (solde comptable double-entrée), carte « Solde à reverser » dans le dashboard Fournisseur, et `docs/REVERSEMENTS.md` : procédure de batch payout PayPal hebdomadaire (le MCP PayPal n'expose aucun payout — 4 outils seulement), avec point d'extension isolé vers l'API Payouts.
5. **Réputation & latence alimentées** — le moteur m09 reçoit enfin des événements réels (heartbeats liveness 1/s, clôtures de baux, échantillons de latence m08 publiés via CRD) et m04 note avec la réputation/latence réelles au lieu de constantes neutres. *Test : `réputation alimentée (score != 0.5)`.*
6. **GC des CRDs** — baux CLOSED/SLASHED > 30 j et objets de carnet MATCHED/CANCELLED > 7 j supprimés, avec garde : jamais d'objet référencé par un bail vivant. Avant : croissance etcd non bornée.
7. **Utilisation GPU réelle remontée** — l'agent mesure via nvidia-smi (collecteur m01) et publie `gpuUtilPct`/`vramUsedMib` dans le status du nœud à chaque heartbeat ; exposé dans `GET /v1/leases/{id}`, le WS live et une colonne « GPU réel » des dashboards. Anti-fraude : la carte mesure, le provider ne déclare pas. *Test E2E : `nodeUtil={'gpuUtilPct': 0, 'vramUsedMib': 741, 'model': 'NVIDIA GeForce RTX 5090 Laptop GPU'}`.*
8. **Rebuild du billing au boot** — après un restart du control, les baux FUNDED/RUNNING sont reconstruits en mémoire (curseur de metering réinitialisé proprement) au lieu de disparaître du règlement.
9. **Drain provider (maintenance)** — `POST /v1/nodes/mine/drain` : un provider en maintenance n'accepte plus AUCUN nouveau match (gardes dans la création d'offre, le matchmaker et la liveness) tandis que les baux en cours sont honorés. Bouton « Maintenance (drain) » dans le dashboard. *Tests : cycle DRAINING → offre refusée (409) → undrain → ACTIVE.*

### Fix structurel découvert en test

**Pruning CRD** : les schémas structuralSchema éliminaient silencieusement les champs non déclarés du status (`invoice`, `fundedAt`, `gpuModel`, `reputationScore`, `latencyMs`, `nodeUtil`…). Les données étaient écrites puis jetées par l'API server. Schémas CRD corrigés — **attention, Helm ne met pas à jour `crds/` sur upgrade** : `kubectl apply -f vramarket/crds/vramarket-crds.yaml` nécessaire pour les installs existantes.

+ fix `score()` division par zéro quand `maxLatencyMs=0`.

### Vérification

- E2E selftest étendu (30 étapes) exécuté dans le pod sur cluster réel : **30/30 PASS** (cycle complet : offre → enchère → match → funding PayPal réel → RUNNING → metering > 0 → nodeUtil réel → close → settle → facture → compte provider → drain/undrain).
- Tests offline : 8/8 (accrual metering, expiration auto, crédit SLA, conservation des fonds, rails x402/PayPal).
- Images : `ghcr.io/jeffreyturov-dev/vramarket-control:0.1.36`, `ghcr.io/jeffreyturov-dev/vramarket-agent:0.1.27` (publiques, poussées).

Note : en date du 28/07, GHCR renvoie par intermittence un 403 sur les pulls **anonymes** des packages du compte (pulls authentifiés OK, packages bien `public` côté API — comportement côté GitHub, signalé dans le corps de PR pour transparence si le check d'install échoue sur la résolution d'image).
