### PR TITLE
[UPDATE][clawdbot][1.0.19] switch ingress proxy to official OpenResty

### DIFF
--- a/clawdbot/Chart.yaml
+++ b/clawdbot/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '2026.6.9'
 description: description
 name: clawdbot
 type: application
-version: 1.0.15
+version: 1.0.19

--- a/clawdbot/OlaresManifest.yaml
+++ b/clawdbot/OlaresManifest.yaml
@@ -12,7 +12,7 @@ metadata:
   description: Personal AI Assistant with Multi-channel Inbox Support
   appid: clawdbot
   title: OpenClaw
-  version: 1.0.15
+  version: 1.0.19
   categories:
   - Productivity_v112
   - Developer Tools
@@ -69,7 +69,11 @@ spec:
     - **[Onboarding](https://docs.openclaw.ai/start/wizard) + [skills](https://docs.openclaw.ai/tools/skills)** — onboarding-driven setup with bundled/managed/workspace skills.
 
   upgradeDescription: |
-    Terminal sidecar image bumped to `beclab/terminal:v0.0.13` (was v0.0.10).
+    Switch the reverse-proxy image from Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) to the official OpenResty image `openresty/openresty:1.29.2.5-bookworm-fat`.
+
+    Align nginx config mounts and log paths with the official image layout (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`), and drop Bitnami-specific `OPENRESTY_CONF_FILE` wiring.
+
+    v1.0.15: Terminal sidecar image bumped to `beclab/terminal:v0.0.13` (was v0.0.10).
 
   developer: Peter Steinberger
   website: https://openclaw.ai/

--- a/clawdbot/i18n/en-US/OlaresManifest.yaml
+++ b/clawdbot/i18n/en-US/OlaresManifest.yaml
@@ -26,4 +26,8 @@ spec:
     - **[Onboarding](https://docs.openclaw.ai/start/wizard) + [skills](https://docs.openclaw.ai/tools/skills)** — onboarding-driven setup with bundled/managed/workspace skills.
 
 upgradeDescription: |
-    Terminal sidecar image bumped to `beclab/terminal:v0.0.13` (was v0.0.10).
+    Switch the reverse-proxy image from Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) to the official OpenResty image `openresty/openresty:1.29.2.5-bookworm-fat`.
+
+    Align nginx config mounts and log paths with the official image layout (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`), and drop Bitnami-specific `OPENRESTY_CONF_FILE` wiring.
+
+    v1.0.15: Terminal sidecar image bumped to `beclab/terminal:v0.0.13` (was v0.0.10).

--- a/clawdbot/i18n/zh-CN/OlaresManifest.yaml
+++ b/clawdbot/i18n/zh-CN/OlaresManifest.yaml
@@ -27,4 +27,8 @@ spec:
     - **[引导配置](https://docs.openclaw.ai/start/wizard) + [技能体系](https://docs.openclaw.ai/tools/skills)** —— 提供完善的引导流程，内置/可管理/可扩展的技能体系
 
   upgradeDescription: |
-    Terminal 侧车镜像升级至 `beclab/terminal:v0.0.13`（原 v0.0.10）。
+    将反向代理镜像从 Bitnami OpenResty（`beclab/aboveos-bitnami-openresty:1.25.3-2`）切换为官方 OpenResty 镜像 `openresty/openresty:1.29.2.5-bookworm-fat`。
+
+    同步调整 nginx 配置挂载与日志路径以匹配官方镜像布局（`/etc/nginx/conf.d/default.conf`、`/usr/local/openresty/nginx/logs/...`），并移除 Bitnami 专用的 `OPENRESTY_CONF_FILE` 配置。
+
+    v1.0.15: Terminal 侧车镜像升级至 `beclab/terminal:v0.0.13`（原 v0.0.10）。

--- a/clawdbot/templates/ingress.yaml
+++ b/clawdbot/templates/ingress.yaml
@@ -12,8 +12,8 @@ data:
 
     server {
       listen 8080;
-      access_log /opt/bitnami/openresty/nginx/logs/access.log;
-      error_log /opt/bitnami/openresty/nginx/logs/error.log;
+      access_log /usr/local/openresty/nginx/logs/access.log;
+      error_log /usr/local/openresty/nginx/logs/error.log;
 
       client_max_body_size 100m;
 
@@ -87,13 +87,10 @@ spec:
               path: nginx.conf
       containers:
         - name: nginx
-          image: "docker.io/beclab/aboveos-bitnami-openresty:1.25.3-2"
+          image: "docker.io/openresty/openresty:1.29.2.5-bookworm-fat"
           ports:
             - containerPort: 8080
               protocol: TCP
-          env:
-            - name: OPENRESTY_CONF_FILE
-              value: /etc/nginx/nginx.conf
           startupProbe:
             tcpSocket:
               port: 8080
@@ -117,10 +114,7 @@ spec:
               memory: 64Mi
           volumeMounts:
             - name: nginx-config
-              mountPath: /etc/nginx/nginx.conf
-              subPath: nginx.conf
-            - name: nginx-config
-              mountPath: /opt/bitnami/openresty/nginx/conf/server_blocks/nginx.conf
+              mountPath: /etc/nginx/conf.d/default.conf
               subPath: nginx.conf
 ---
 apiVersion: v1


### PR DESCRIPTION
## Summary
- Switch `clawdbotingress` from Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) to official `openresty/openresty:1.29.2.5-bookworm-fat`.
- Align nginx config mount to `/etc/nginx/conf.d/default.conf` and log paths to `/usr/local/openresty/nginx/logs/...`; remove `OPENRESTY_CONF_FILE`.

## Test plan
- [x] `olares-cli chart lint ./clawdbot` OK
- [x] Installed/upgraded `1.0.19` on hzfystt and yaotest004 (`running`)
- [x] Ingress nginx image is official OpenResty; probe `GET /` returns 200
