### PR TITLE
[UPDATE][nofx][1.0.12] finish OpenResty migration for gateway and RSA init

### DIFF
--- a/nofx/Chart.yaml
+++ b/nofx/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "1.0.0"
 description: NOFX — official backend + frontend images (NoFxAiOS/nofx)
 name: nofx
 type: application
-version: 1.0.10
+version: 1.0.12

--- a/nofx/OlaresManifest.yaml
+++ b/nofx/OlaresManifest.yaml
@@ -13,7 +13,7 @@ metadata:
   description: Your personal AI trading assistant. Any market. Any model.
   appid: nofx
   title: NOFX
-  version: "1.0.10"
+  version: "1.0.12"
   categories:
     - Productivity_v112
     
@@ -28,9 +28,9 @@ entrances:
 
 spec:
   upgradeDescription: |
-    Switch the reverse-proxy image from Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) to the official OpenResty image `openresty/openresty:1.29.2.5-bookworm-fat`.
+    Finish OpenResty migration (chart 1.0.12): switch the `init-rsa-env` initContainer from Bitnami OpenResty to the same official image `openresty/openresty:1.29.2.5-bookworm-fat` used by the gateway (openssl for RSA key generation; runAsUser 1000), and align gateway access/error log paths with the official layout.
 
-    Align nginx config mounts and log paths with the official image layout (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`), and drop Bitnami-specific `OPENRESTY_CONF_FILE` wiring.
+    v1.0.10: Gateway proxy already on official OpenResty; config mount `/etc/nginx/conf.d/default.conf`.
   versionName: "1.0.0"
   promoteImage:
     - https://app.cdn.olares.com/appstore/nofx/1.webp

--- a/nofx/i18n/en-US/OlaresManifest.yaml
+++ b/nofx/i18n/en-US/OlaresManifest.yaml
@@ -4,9 +4,9 @@ metadata:
 
 spec:
   upgradeDescription: |
-    Switch the reverse-proxy image from Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) to the official OpenResty image `openresty/openresty:1.29.2.5-bookworm-fat`.
+    Finish OpenResty migration (chart 1.0.12): switch the `init-rsa-env` initContainer from Bitnami OpenResty to the same official image `openresty/openresty:1.29.2.5-bookworm-fat` used by the gateway (openssl for RSA key generation; runAsUser 1000), and align gateway access/error log paths with the official layout.
 
-    Align nginx config mounts and log paths with the official image layout (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`), and drop Bitnami-specific `OPENRESTY_CONF_FILE` wiring.
+    v1.0.10: Gateway proxy already on official OpenResty; config mount `/etc/nginx/conf.d/default.conf`.
   fullDescription: |
     NOFX is an open-source autonomous AI trading assistant. Unlike traditional AI tools that require you to manually configure models, manage API keys, and wire up data sources — NOFX's AI perceives markets, selects models, and fetches data entirely on its own. Zero human intervention. You set the strategy, the AI handles everything else.
 

--- a/nofx/i18n/zh-CN/OlaresManifest.yaml
+++ b/nofx/i18n/zh-CN/OlaresManifest.yaml
@@ -4,9 +4,9 @@ metadata:
 
 spec:
   upgradeDescription: |
-    将反向代理镜像从 Bitnami OpenResty（`beclab/aboveos-bitnami-openresty:1.25.3-2`）切换为官方 OpenResty 镜像 `openresty/openresty:1.29.2.5-bookworm-fat`。
+    完成 OpenResty 迁移（Chart 1.0.12）：将 `init-rsa-env` initContainer 从 Bitnami OpenResty 改为与 gateway 相同的官方镜像 `openresty/openresty:1.29.2.5-bookworm-fat`（用于 openssl 生成 RSA；runAsUser 1000），并补齐 gateway 官方布局的 access/error 日志路径。
 
-    同步调整 nginx 配置挂载与日志路径以匹配官方镜像布局（`/etc/nginx/conf.d/default.conf`、`/usr/local/openresty/nginx/logs/...`），并移除 Bitnami 专用的 `OPENRESTY_CONF_FILE` 配置。
+    v1.0.10: Gateway 代理已切官方 OpenResty；配置挂载 `/etc/nginx/conf.d/default.conf`。
   fullDescription: |
     NOFX 是一款开源的自主 AI 交易助手。与传统 AI 工具不同，NOFX 的 AI 能够自主感知市场、选择模型、获取数据，无需人工干预。你只需设置策略，AI 将自动完成所有交易。
 

--- a/nofx/templates/nginx/deployment.yaml
+++ b/nofx/templates/nginx/deployment.yaml
@@ -9,6 +9,8 @@ data:
     server {
       listen 8080;
       server_name _;
+      access_log /usr/local/openresty/nginx/logs/access.log;
+      error_log /usr/local/openresty/nginx/logs/error.log;
 
       proxy_connect_timeout 30s;
       proxy_send_timeout 60s;

--- a/nofx/templates/trade/deployment.yaml
+++ b/nofx/templates/trade/deployment.yaml
@@ -39,15 +39,16 @@ spec:
           securityContext:
             runAsUser: 0
         # Same image:tag as templates/nginx (explicit tag; omitting tag defaults to :latest and breaks Olares mirrors).
+        # Official openresty-fat includes openssl; keep path search for portability.
         - name: init-rsa-env
-          image: "docker.io/beclab/aboveos-bitnami-openresty:1.25.3-2"
+          image: "docker.io/openresty/openresty:1.29.2.5-bookworm-fat"
           command:
             - sh
             - "-c"
             - |
               set -e
               OPENSSL_BIN=""
-              for c in openssl /usr/bin/openssl /opt/bitnami/common/bin/openssl; do
+              for c in openssl /usr/bin/openssl; do
                 if command -v "$c" >/dev/null 2>&1; then OPENSSL_BIN=$c; break; fi
                 if [ -x "$c" ]; then OPENSSL_BIN=$c; break; fi
               done
@@ -66,13 +67,13 @@ spec:
                 umask 077
                 printf 'RSA_PRIVATE_KEY=%s\n' "$RSA_PRIVATE_KEY" > /data/.env
                 chmod 600 /data/.env
-                chown 1000:1000 /data/.env
               fi
           volumeMounts:
             - name: data
               mountPath: /data
           securityContext:
-            runAsUser: 0
+            runAsUser: 1000
+            runAsGroup: 1000
       containers:
         - name: nofx-backend
           image: "docker.io/goai007/nofx-backend:20260506"

--- a/nofx/values.yaml
+++ b/nofx/values.yaml
@@ -15,8 +15,8 @@ timezone: "Etc/UTC"
 # Init container for RSA line in .env (needs openssl). Must use the same tag as templates/nginx — never leave tag empty
 # (defaults to :latest; Olares mirrors often do not mirror :latest for this image).
 initRsaImage:
-  repository: docker.io/beclab/aboveos-bitnami-openresty
-  tag: "1.25.3-2"
+  repository: docker.io/openresty/openresty
+  tag: "1.29.2.5-bookworm-fat"
 
 # hostPath: exactly userspace.appData (no extra /nofx segment). Olares already scopes per-app; appending "nofx"
 # produced nofx/nofx in the file browser. Same idea as speaches/koboldcpp: mount the injected app data root.


### PR DESCRIPTION
## Summary
- Finish OpenResty migration: gateway already on official OpenResty; switch `init-rsa-env` from Bitnami to the same `openresty/openresty:1.29.2.5-bookworm-fat` (`runAsUser: 1000` for OPA).
- Align gateway access/error log paths with the official image layout; update `values.yaml` `initRsaImage`.

## Test plan
- [x] `olares-cli chart lint ./nofx` OK
- [x] Installed/upgraded on hzfystt (`1.0.11`) and yaotest004 (`1.0.12`) → `running`
- [x] Gateway nginx image is official OpenResty; probe `GET /` returns 200
- [x] `nofx-backend` deployment `init-rsa-env` image is official OpenResty (not Bitnami)
