### PR TITLE
[UPDATE][deerflowv2][1.0.7] Upgrade to DeerFlow v2.1.1 gateway-embedded runtime

### DIFF
--- a/deerflowv2/Chart.yaml
+++ b/deerflowv2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: "2.0.7"
+appVersion: "2.1.1"
 description: DeerFlow 2.0 - An open-source super agent harness for deep research.
 name: deerflowv2
 type: application
-version: 1.0.6
+version: 1.0.7

--- a/deerflowv2/Chart.yaml
+++ b/deerflowv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "2.1.1"
 description: DeerFlow 2.0 - An open-source super agent harness for deep research.
 name: deerflowv2
 type: application
-version: 1.0.9
+version: 1.0.7

--- a/deerflowv2/Chart.yaml
+++ b/deerflowv2/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "2.1.1"
 description: DeerFlow 2.0 - An open-source super agent harness for deep research.
 name: deerflowv2
 type: application
-version: 1.0.7
+version: 1.0.9

--- a/deerflowv2/OlaresManifest.yaml
+++ b/deerflowv2/OlaresManifest.yaml
@@ -12,7 +12,7 @@ metadata:
   description: DeerFlow 2.0 is an open-source super agent harness for deep research.
   icon: https://app.cdn.olares.com/appstore/deerflow/icon.png
   appid: deerflowv2
-  version: '1.0.6'
+  version: '1.0.7'
   title: DeerFlow 2.0
   categories:
     - Productivity_v112
@@ -36,7 +36,7 @@ middleware:
     databases:
       - name: deerflow
 spec:
-  versionName: '2.0.7'
+  versionName: '2.1.1'
   featuredImage: https://app.cdn.olares.com/appstore/deerflow/1.webp
   promoteImage:
     - https://app.cdn.olares.com/appstore/deerflow/1.webp
@@ -82,20 +82,18 @@ spec:
       - Custom skills for specialized workflows
       - Podcast script generation and audio synthesis
   upgradeDescription: |
-    **Migrate legacy conversations (one-time, optional)** — if you used DeerFlow before this upgrade, your old chat history was kept in a local SQLite file (`<appData>/deerflowv2/deer-flow/checkpoints.db`) which the new PostgreSQL backend does not read. To bring those conversations into the new sidebar:
+    Upgrade to DeerFlow **v2.1.1** (`beclab/harveyff-deerflow-backend` + `beclab/harveyff-deerflow-frontend`, multi-arch amd64/arm64). Runtime matches upstream: LangGraph runs inside the gateway (no standalone `:2024` sidecar); single `DATABASE_URL` for ORM + checkpointer.
+
+    **Migrate legacy conversations (one-time, optional)** — if you used DeerFlow before the PostgreSQL migration, old chat history may still be in `<appData>/deerflowv2/deer-flow/checkpoints.db`. To bring those conversations into the sidebar:
 
     1. Finish the upgrade and open the app, complete `/setup` to create the admin account (remember the email).
-    2. Open **Control Hub** → **Olares** → **Terminal**, then run the bundled migration script — replace `<EMAIL>` with the admin email you just created in step 1 (namespace is auto-detected):
+    2. Open **Control Hub** → **Olares** → **Terminal**, then run (replace `<EMAIL>`):
        ```
        kubectl exec -it -n $(kubectl get pods -A -l app=deerflowv2-backend -o jsonpath='{.items[0].metadata.namespace}') deploy/deerflowv2-backend -c gateway -- sh /migrate/migrate_legacy_sqlite.sh <EMAIL>
        ```
     3. Refresh the browser — old conversations appear in the admin sidebar.
 
-    The script is idempotent and opens the SQLite file read-only, so it is safe to re-run. Attachments are not migrated (chat content only). Skip this step entirely on a clean install.
-
-    Adds a PostgreSQL database backend (provisioned automatically by the Olares `middleware.postgres`) and a built-in account / authentication system. After upgrade, open the app and follow the `/setup` page to create the first admin account. Fixes "Cross-site auth request denied" 403 on `/setup` by injecting `GATEWAY_CORS_ORIGINS` (rendered from the Olares-injected entrance domain) into the backend so the CSRF middleware uses an explicit allowlist instead of reconstructing the origin from proxy headers.
-
-    Exposes subagent turn / timeout limits as environment variables on `deerflowv2-env-config`, so operators can fix `Recursion limit reached` errors without rebuilding the image. Each subagent has two knobs: `*_MAX_TURNS` (max LLM ↔ tool roundtrips before LangGraph aborts the run with `GraphRecursionError`) and `*_TIMEOUT_SECONDS` (wall-clock cap; should be ≥ `MAX_TURNS × seconds_per_turn`). Tune `GENERAL_PURPOSE_*` for the deep-research subagent (default `500` / `7200`), `BASH_*` for the shell subagent (`300` / `1800`), and `DEFAULT_*` (`200` / `1800`) only kicks in for custom subagents you declare under `subagents.custom_agents` in `config.yaml`. Symptom → action: `Recursion limit reached` → raise `*_MAX_TURNS`; subagent aborts with "timed out" → raise `*_TIMEOUT_SECONDS`; weak / heavily quantized models usually need higher limits. Edit the ConfigMap and restart the backend deployment to apply.
+    The script is idempotent. Attachments are not migrated. Skip on a clean install.
 
   developer: Bytedance Inc.
   website: https://deerflow.tech

--- a/deerflowv2/OlaresManifest.yaml
+++ b/deerflowv2/OlaresManifest.yaml
@@ -12,7 +12,7 @@ metadata:
   description: DeerFlow 2.0 is an open-source super agent harness for deep research.
   icon: https://app.cdn.olares.com/appstore/deerflow/icon.png
   appid: deerflowv2
-  version: '1.0.7'
+  version: '1.0.9'
   title: DeerFlow 2.0
   categories:
     - Productivity_v112
@@ -83,6 +83,8 @@ spec:
       - Podcast script generation and audio synthesis
   upgradeDescription: |
     Upgrade to DeerFlow **v2.1.1** (`beclab/harveyff-deerflow-backend` + `beclab/harveyff-deerflow-frontend`, multi-arch amd64/arm64). Runtime matches upstream: LangGraph runs inside the gateway (no standalone `:2024` sidecar); single `DATABASE_URL` for ORM + checkpointer.
+    Switch the clientproxy reverse-proxy image from Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) to the official OpenResty image `openresty/openresty:1.29.2.5-bookworm-fat`. Align nginx config mounts and log paths with the official image layout (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`), and drop Bitnami-specific `OPENRESTY_CONF_FILE` wiring.
+
 
     **Migrate legacy conversations (one-time, optional)** — if you used DeerFlow before the PostgreSQL migration, old chat history may still be in `<appData>/deerflowv2/deer-flow/checkpoints.db`. To bring those conversations into the sidebar:
 

--- a/deerflowv2/OlaresManifest.yaml
+++ b/deerflowv2/OlaresManifest.yaml
@@ -12,7 +12,7 @@ metadata:
   description: DeerFlow 2.0 is an open-source super agent harness for deep research.
   icon: https://app.cdn.olares.com/appstore/deerflow/icon.png
   appid: deerflowv2
-  version: '1.0.9'
+  version: '1.0.7'
   title: DeerFlow 2.0
   categories:
     - Productivity_v112

--- a/deerflowv2/i18n/en-US/OlaresManifest.yaml
+++ b/deerflowv2/i18n/en-US/OlaresManifest.yaml
@@ -44,6 +44,8 @@ spec:
 
   upgradeDescription: |
     Upgrade to DeerFlow **v2.1.1** (`beclab/harveyff-deerflow-backend` + `beclab/harveyff-deerflow-frontend`, multi-arch amd64/arm64). Runtime matches upstream: LangGraph runs inside the gateway (no standalone `:2024` sidecar); single `DATABASE_URL` for ORM + checkpointer.
+    Switch the clientproxy reverse-proxy image from Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) to the official OpenResty image `openresty/openresty:1.29.2.5-bookworm-fat`. Align nginx config mounts and log paths with the official image layout (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`), and drop Bitnami-specific `OPENRESTY_CONF_FILE` wiring.
+
 
     **Migrate legacy conversations (one-time, optional)** — if old chat history is still in `<appData>/deerflowv2/deer-flow/checkpoints.db`:
 

--- a/deerflowv2/i18n/en-US/OlaresManifest.yaml
+++ b/deerflowv2/i18n/en-US/OlaresManifest.yaml
@@ -43,17 +43,15 @@ spec:
       - Podcast script generation and audio synthesis
 
   upgradeDescription: |
-    **Migrate legacy conversations (one-time, optional)** — if you used DeerFlow before this upgrade, your old chat history was kept in a local SQLite file (`<appData>/deerflowv2/deer-flow/checkpoints.db`) which the new PostgreSQL backend does not read. To bring those conversations into the new sidebar:
-    
-    1. Finish the upgrade and open the app, complete `/setup` to create the admin account (remember the email).
-    2. Open **Control Hub** → **Olares** → **Terminal**, then run the bundled migration script — replace `<EMAIL>` with the admin email you just created in step 1 (namespace is auto-detected):
+    Upgrade to DeerFlow **v2.1.1** (`beclab/harveyff-deerflow-backend` + `beclab/harveyff-deerflow-frontend`, multi-arch amd64/arm64). Runtime matches upstream: LangGraph runs inside the gateway (no standalone `:2024` sidecar); single `DATABASE_URL` for ORM + checkpointer.
+
+    **Migrate legacy conversations (one-time, optional)** — if old chat history is still in `<appData>/deerflowv2/deer-flow/checkpoints.db`:
+
+    1. Finish the upgrade, open the app, complete `/setup` (remember the admin email).
+    2. In **Control Hub** → **Olares** → **Terminal**, run (replace `<EMAIL>`):
        ```
        kubectl exec -it -n $(kubectl get pods -A -l app=deerflowv2-backend -o jsonpath='{.items[0].metadata.namespace}') deploy/deerflowv2-backend -c gateway -- sh /migrate/migrate_legacy_sqlite.sh <EMAIL>
        ```
     3. Refresh the browser — old conversations appear in the admin sidebar.
-    
-    The script is idempotent and opens the SQLite file read-only, so it is safe to re-run. Attachments are not migrated (chat content only). Skip this step entirely on a clean install.
 
-    Adds a PostgreSQL database backend (provisioned automatically by the Olares `middleware.postgres`) and a built-in account / authentication system. After upgrade, open the app and follow the `/setup` page to create the first admin account. Fixes "Cross-site auth request denied" 403 on `/setup` by injecting `GATEWAY_CORS_ORIGINS` (rendered from the Olares-injected entrance domain) into the backend so the CSRF middleware uses an explicit allowlist instead of reconstructing the origin from proxy headers.
-
-    Exposes subagent turn / timeout limits as environment variables on `deerflowv2-env-config`, so operators can fix `Recursion limit reached` errors without rebuilding the image. Each subagent has two knobs: `*_MAX_TURNS` (max LLM ↔ tool roundtrips before LangGraph aborts the run with `GraphRecursionError`) and `*_TIMEOUT_SECONDS` (wall-clock cap; should be ≥ `MAX_TURNS × seconds_per_turn`). Tune `GENERAL_PURPOSE_*` for the deep-research subagent (default `500` / `7200`), `BASH_*` for the shell subagent (`300` / `1800`), and `DEFAULT_*` (`200` / `1800`) only kicks in for custom subagents you declare under `subagents.custom_agents` in `config.yaml`. Symptom → action: `Recursion limit reached` → raise `*_MAX_TURNS`; subagent aborts with "timed out" → raise `*_TIMEOUT_SECONDS`; weak / heavily quantized models usually need higher limits. Edit the ConfigMap and restart the backend deployment to apply.
+    The script is idempotent. Attachments are not migrated. Skip on a clean install.

--- a/deerflowv2/i18n/zh-CN/OlaresManifest.yaml
+++ b/deerflowv2/i18n/zh-CN/OlaresManifest.yaml
@@ -44,6 +44,8 @@ spec:
 
   upgradeDescription: |
     升级到 DeerFlow **v2.1.1**（`beclab/harveyff-deerflow-backend` + `beclab/harveyff-deerflow-frontend`，amd64/arm64 多架构）。与上游一致：LangGraph 内嵌在 gateway（不再有独立 `:2024` sidecar）；ORM 与 checkpointer 共用单一 `DATABASE_URL`。
+    将 clientproxy 反向代理镜像从 Bitnami OpenResty（`beclab/aboveos-bitnami-openresty:1.25.3-2`）切换为官方 OpenResty 镜像 `openresty/openresty:1.29.2.5-bookworm-fat`。同步调整 nginx 配置挂载与日志路径以匹配官方镜像布局（`/etc/nginx/conf.d/default.conf`、`/usr/local/openresty/nginx/logs/...`），并移除 Bitnami 专用的 `OPENRESTY_CONF_FILE` 配置。
+
 
     **迁移老对话记录（一次性，可选）** —— 若旧聊天仍在 `<appData>/deerflowv2/deer-flow/checkpoints.db`：
 

--- a/deerflowv2/i18n/zh-CN/OlaresManifest.yaml
+++ b/deerflowv2/i18n/zh-CN/OlaresManifest.yaml
@@ -43,17 +43,15 @@ spec:
       - 播客脚本生成和音频合成
 
   upgradeDescription: |
-    **迁移老对话记录（一次性，可选）** —— 如果你在本次升级前用过 DeerFlow，老的聊天记录保存在本地 SQLite 文件里（`<appData>/deerflowv2/deer-flow/checkpoints.db`），新版 PostgreSQL 后端不会自动读取。要让这些对话出现在新版侧边栏：
-    
-    1. 完成升级，打开 app，按 `/setup` 流程创建 admin 账号（记住邮箱）。
-    2. 打开 **Control Hub** → **Olares** → **Terminal**，跑内置的迁移脚本 —— 把 `<EMAIL>` 换成步骤 1 里刚创建的 admin 账号邮箱（namespace 自动获取）：
+    升级到 DeerFlow **v2.1.1**（`beclab/harveyff-deerflow-backend` + `beclab/harveyff-deerflow-frontend`，amd64/arm64 多架构）。与上游一致：LangGraph 内嵌在 gateway（不再有独立 `:2024` sidecar）；ORM 与 checkpointer 共用单一 `DATABASE_URL`。
+
+    **迁移老对话记录（一次性，可选）** —— 若旧聊天仍在 `<appData>/deerflowv2/deer-flow/checkpoints.db`：
+
+    1. 完成升级，打开 app，按 `/setup` 创建 admin（记住邮箱）。
+    2. 在 **Control Hub** → **Olares** → **Terminal** 执行（替换 `<EMAIL>`）：
        ```
        kubectl exec -it -n $(kubectl get pods -A -l app=deerflowv2-backend -o jsonpath='{.items[0].metadata.namespace}') deploy/deerflowv2-backend -c gateway -- sh /migrate/migrate_legacy_sqlite.sh <EMAIL>
        ```
     3. 刷新浏览器 —— 老对话出现在 admin 侧边栏。
-    
-    脚本幂等，且以只读方式打开 SQLite 文件，可以放心重跑。附件不迁移（只迁对话内容）。全新安装可以完全跳过本步。
 
-    新增 PostgreSQL 数据库后端（由 Olares `middleware.postgres` 自动创建）以及内置账户与认证系统。升级后打开 app 会跳到 `/setup` 页面，请按提示创建首个 admin 账号。修复 `/setup` 报 403 "Cross-site auth request denied" 的问题：从 Olares 注入的入口域名渲染出 `GATEWAY_CORS_ORIGINS` 注入到后端，CSRF 中间件改为走显式白名单，不再依赖根据代理头重建 origin 的脆弱链路。
-
-    新增一组 subagent 调度上限的环境变量到 `deerflowv2-env-config`，无需重新打包镜像就能在线调整、解决 `Recursion limit reached` 报错。每个 subagent 有两个旋钮：`*_MAX_TURNS` 控制 LLM ↔ 工具最大往返轮数（超出时 LangGraph 抛 `GraphRecursionError`），`*_TIMEOUT_SECONDS` 控制墙钟上限（建议 ≥ `MAX_TURNS × 单轮耗时`）。`GENERAL_PURPOSE_*` 给深度研究子 agent 用（默认 `500` / `7200`），`BASH_*` 给 shell 子 agent 用（`300` / `1800`），`DEFAULT_*`（`200` / `1800`）只对你在 `config.yaml` 的 `subagents.custom_agents` 里自定义的子 agent 生效。常见症状对应：报 `Recursion limit reached` → 调高 `*_MAX_TURNS`；报"timed out" → 调高 `*_TIMEOUT_SECONDS`；本地小模型 / 量化重的模型通常需要更大的上限。修改 ConfigMap 后重启后端 deployment 即可生效。
+    脚本幂等。附件不迁移。全新安装可跳过。

--- a/deerflowv2/templates/clientproxy.yaml
+++ b/deerflowv2/templates/clientproxy.yaml
@@ -7,8 +7,8 @@ data:
   nginx.conf: |
     server {
         listen 8080;
-        access_log /opt/bitnami/openresty/nginx/logs/access.log;
-        error_log /opt/bitnami/openresty/nginx/logs/error.log;
+        access_log /usr/local/openresty/nginx/logs/access.log;
+        error_log /usr/local/openresty/nginx/logs/error.log;
 
         client_max_body_size 100M;
 
@@ -158,26 +158,19 @@ spec:
                 path: nginx.conf
       containers:
         - name: nginx
-          image: "docker.io/beclab/aboveos-bitnami-openresty:1.25.3-2"
+          image: "docker.io/openresty/openresty:1.29.2.5-bookworm-fat"
           ports:
             - containerPort: 8080
               protocol: TCP
-          env:
-            - name: OPENRESTY_CONF_FILE
-              value: /etc/nginx/nginx.conf
           readinessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - |
-                  http_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080)
-                  [ $http_code -ge 200 ] && [ $http_code -lt 500 ]
-            initialDelaySeconds: 10
-            timeoutSeconds: 10
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
             periodSeconds: 5
             successThreshold: 1
-            failureThreshold: 240
+            failureThreshold: 30
           resources:
             limits:
               cpu: 500m
@@ -187,10 +180,7 @@ spec:
               memory: 64Mi
           volumeMounts:
             - name: nginx-config
-              mountPath: /etc/nginx/nginx.conf
-              subPath: nginx.conf
-            - name: nginx-config
-              mountPath: /opt/bitnami/openresty/nginx/conf/server_blocks/nginx.conf
+              mountPath: /etc/nginx/conf.d/default.conf
               subPath: nginx.conf
 ---
 apiVersion: v1

--- a/deerflowv2/templates/configmap.yaml
+++ b/deerflowv2/templates/configmap.yaml
@@ -155,7 +155,7 @@ data:
     # The version number itself is purely a "your config is outdated, run
     # config-upgrade" warning trigger in deer-flow's startup log -- it does
     # not unlock or restrict any features.
-    config_version: 8
+    config_version: 31
 
     # Logger threshold for the `deerflow` and `app` loggers. Third-party
     # libraries (uvicorn, sqlalchemy, langgraph, ...) keep their own levels.
@@ -342,10 +342,10 @@ data:
     # database provisioned automatically by the Olares postgres
     # middleware (declared in OlaresManifest.yaml as `middleware.postgres`).
     #
-    # Connection strings are built from .Values.postgres.* in deployment.yaml:
-    #   DATABASE_URL              → SQLAlchemy ORM (asyncpg) — **no** libpq-only params
-    #   CHECKPOINTER_DATABASE_URL → LangGraph checkpointer (psycopg) — TCP keepalives OK
-    # deer-flow resolves both via AppConfig.resolve_env_variables() at startup.
+    # Connection string is built from .Values.postgres.* in deployment.yaml:
+    #   DATABASE_URL → SQLAlchemy ORM (asyncpg) + LangGraph checkpointer (psycopg)
+    # Do not put libpq-only keepalive params in DATABASE_URL (asyncpg rejects them).
+    # deer-flow resolves via AppConfig.resolve_env_variables() at startup.
     #
     # To switch back to sqlite (single-tenant, no postgres dependency):
     #   1. Remove the `middleware.postgres` block from OlaresManifest.yaml
@@ -359,7 +359,6 @@ data:
     database:
       backend: postgres
       postgres_url: $DATABASE_URL
-      checkpointer_postgres_url: $CHECKPOINTER_DATABASE_URL
 
     # =============================================
     # SUBAGENT LIMITS
@@ -449,35 +448,26 @@ data:
         "\n"
         "# Auto-injected by init-container (chart >= 1.0.9). The Olares\n"
         "# `middleware.postgres` provisioner exposes connection details via\n"
-        "# DATABASE_URL (asyncpg ORM) and CHECKPOINTER_DATABASE_URL (psycopg\n"
-        "# LangGraph saver with TCP keepalives). To switch back to sqlite,\n"
-        "# remove the postgres middleware block from OlaresManifest.yaml and\n"
-        "# edit this section by hand.\n"
+        "# DATABASE_URL (SQLAlchemy + LangGraph checkpointer). To switch\n"
+        "# back to sqlite, remove the postgres middleware block from\n"
+        "# OlaresManifest.yaml and edit this section by hand.\n"
         "database:\n"
         "  backend: postgres\n"
         "  postgres_url: $DATABASE_URL\n"
-        "  checkpointer_postgres_url: $CHECKPOINTER_DATABASE_URL\n"
     )
 
 
-    def ensure_checkpointer_postgres_url(cfg: Path) -> None:
-        """Inject checkpointer_postgres_url for chart 1.0.11+ without full rewrite."""
+    def strip_checkpointer_postgres_url(cfg: Path) -> None:
+        """Remove dual-URL leftover from chart < 1.0.7."""
         text = cfg.read_text(encoding="utf-8")
-        if "checkpointer_postgres_url:" in text:
+        if "checkpointer_postgres_url:" not in text:
             return
-        if "backend: postgres" not in text or "postgres_url:" not in text:
-            return
-        lines = text.splitlines(keepends=True)
-        out: list[str] = []
-        inserted = False
-        for line in lines:
-            out.append(line)
-            if not inserted and re.match(r"^[ \t]+postgres_url:[ \t]", line):
-                out.append("  checkpointer_postgres_url: $CHECKPOINTER_DATABASE_URL\n")
-                inserted = True
-        if inserted:
-            cfg.write_text("".join(out), encoding="utf-8")
-            print(f"migrate: injected checkpointer_postgres_url into {cfg}")
+        lines = [
+            ln for ln in text.splitlines(keepends=True)
+            if "checkpointer_postgres_url:" not in ln
+        ]
+        cfg.write_text("".join(lines), encoding="utf-8")
+        print(f"migrate: removed checkpointer_postgres_url from {cfg}")
 
     # Match a top-level YAML block whose key is `database` or the legacy
     # upstream `checkpointer`. The body is any consecutive run of indented
@@ -505,12 +495,12 @@ data:
 
         if new == original:
             print(f"migrate: {cfg} already on postgres backend; no change")
-            ensure_checkpointer_postgres_url(cfg)
+            strip_checkpointer_postgres_url(cfg)
             return 0
 
         cfg.write_text(new, encoding="utf-8")
         print(f"migrate: rewrote {cfg} database block -> postgres")
-        ensure_checkpointer_postgres_url(cfg)
+        strip_checkpointer_postgres_url(cfg)
         return 0
 
 

--- a/deerflowv2/templates/deployment.yaml
+++ b/deerflowv2/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
       terminationGracePeriodSeconds: 45
       initContainers:
         - name: init-config
-          image: docker.io/beclab/harveyff-deerflow-backend:v2.0.7-pg
+          image: docker.io/beclab/harveyff-deerflow-backend:v2.1.1
           command:
             - sh
             - -c
@@ -145,13 +145,21 @@ spec:
                     '  failure_threshold: 5' \
                     '  recovery_timeout_sec: 60' >> /config/config.yaml
                 fi
-                # Pin config_version: 8 so deer-flow stops logging the
-                # outdated-config warning on every startup.
+                # Pin config_version to match upstream config.example.yaml
+                # so deer-flow stops logging the outdated-config warning.
                 if grep -qE '^config_version:' /config/config.yaml; then
-                  sed -i 's/^config_version:.*/config_version: 8/' /config/config.yaml
+                  sed -i 's/^config_version:.*/config_version: 31/' /config/config.yaml
                 else
-                  printf '\n%s\n' 'config_version: 8  # chart 1.0.8: matches upstream config.example.yaml' >> /config/config.yaml
+                  printf '\n%s\n' 'config_version: 31  # chart 1.0.7: matches upstream config.example.yaml' >> /config/config.yaml
                 fi
+
+                # Chart 1.0.7 / deer-flow v2.1.1: drop dual checkpointer URL;
+                # gateway embeds LangGraph and uses database.postgres_url only.
+                if grep -qE 'checkpointer_postgres_url:' /config/config.yaml; then
+                  echo "Migrating /config/config.yaml: removing checkpointer_postgres_url"
+                  sed -i '/checkpointer_postgres_url:/d' /config/config.yaml
+                fi
+
               fi
 
               if [ ! -f /config/extensions_config.json ]; then
@@ -163,7 +171,6 @@ spec:
 
               mkdir -p /data/deer-flow
               mkdir -p /skills/public /skills/custom
-              mkdir -p /langgraph-api
               # Chart >= 1.0.9: db lives in postgres now, the legacy sqlite
               # dir under /data/deer-flow/db is no longer mkdir'd. We do
               # NOT delete the existing file (if any) so operators can
@@ -179,15 +186,15 @@ spec:
               mkdir -p /skills/custom/image-ocr
               cp /init-config/image-ocr-skill.md /skills/custom/image-ocr/SKILL.md
 
-              # The gateway/langgraph containers run as PUID/PGID=1000 (the
+              # The gateway container runs as PUID/PGID=1000 (the
               # image flips to a non-root account at startup). hostPath dirs
               # created here as uid 0 stay owned by root, so the runtime
               # process cannot write memory.json / per-thread user-data /
-              # .langgraph_api/ scratch files. chown unconditionally --
+              # runtime scratch files. chown unconditionally --
               # cheap, and harmless if the image actually stays as root.
               # (Database state lives in postgres now; only filesystem
               # state needs this treatment.)
-              chown -R 1000:1000 /data/deer-flow /skills /config /langgraph-api
+              chown -R 1000:1000 /data/deer-flow /skills /config
 
               echo "Init complete."
           volumeMounts:
@@ -199,17 +206,15 @@ spec:
               mountPath: /data/deer-flow
             - name: skills-volume
               mountPath: /skills
-            - name: langgraph-api-volume
-              mountPath: /langgraph-api
           securityContext:
             runAsUser: 0
       containers:
         - name: gateway
-          image: docker.io/beclab/harveyff-deerflow-backend:v2.0.7-pg
+          image: docker.io/beclab/harveyff-deerflow-backend:v2.1.1
           command:
             - sh
             - -c
-            - "cd /app/backend && PYTHONPATH=. uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001 --workers 2"
+            - "cd /app/backend && PYTHONPATH=. uv run --no-sync uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001 --workers 2"
           # Delay SIGTERM by 5s so K8s has time to (1) flip the pod's
           # readiness off, (2) propagate the endpoint removal to
           # kube-proxy / clientproxy, and (3) drain any in-flight
@@ -309,120 +314,14 @@ spec:
             # Olares postgres middleware — connection details populated by
             # the Olares chart values injector at install/upgrade time.
             #
-            # DATABASE_URL — SQLAlchemy + **asyncpg** only. Do NOT add libpq
-            # query params such as keepalives_* here; asyncpg rejects them and
-            # the gateway will crash on startup (TypeError: unexpected keyword
-            # argument 'keepalives').
+            # DATABASE_URL — SQLAlchemy (asyncpg) + LangGraph checkpointer
+            # (psycopg) via the same URL. Do NOT add libpq-only query params
+            # such as keepalives_* here; asyncpg rejects them and the gateway
+            # will crash on startup. Upstream v2.1.1 pools manage reconnects.
             #
-            # CHECKPOINTER_DATABASE_URL — LangGraph AsyncPostgresSaver +
-            # **psycopg** (libpq). Same server/db as DATABASE_URL but with TCP
-            # keepalive query params so idle connections are not silently dropped
-            # by kube-proxy / NAT before psycopg's pool notices.
-            #
-            # config.yaml sets `database.postgres_url: $DATABASE_URL` and
-            # `checkpointer_postgres_url: $CHECKPOINTER_DATABASE_URL`.
+            # config.yaml sets `database.postgres_url: $DATABASE_URL`.
             - name: DATABASE_URL
               value: "postgresql://{{ .Values.postgres.username }}:{{ .Values.postgres.password }}@{{ .Values.postgres.host }}:{{ .Values.postgres.port }}/{{ .Values.postgres.databases.deerflow }}"
-            - name: CHECKPOINTER_DATABASE_URL
-              value: "postgresql://{{ .Values.postgres.username }}:{{ .Values.postgres.password }}@{{ .Values.postgres.host }}:{{ .Values.postgres.port }}/{{ .Values.postgres.databases.deerflow }}?keepalives=1&keepalives_idle=30&keepalives_interval=10&keepalives_count=5"
-          envFrom:
-            - configMapRef:
-                name: deerflowv2-env-config
-          resources:
-            requests:
-              cpu: "50m"
-              memory: 256Mi
-            limits:
-              cpu: "1"
-              memory: 1Gi
-          volumeMounts:
-            - name: config-volume
-              mountPath: /config
-            - name: data-volume
-              mountPath: /data/deer-flow
-            - name: skills-volume
-              mountPath: /app/skills
-            # On-demand legacy SQLite -> postgres migration tool. Mounted
-            # only into the gateway container (not langgraph) since the
-            # operator runs it via `kubectl exec deploy/... -c gateway`.
-            # Uses items: projection so only the two migration files
-            # appear under /migrate -- the rest of init-config (config.yaml,
-            # the OCR skill, the database backend rewriter) does not leak
-            # into the runtime filesystem. See configmap.yaml for the
-            # script source and operator usage instructions.
-            - name: migrate-vol
-              mountPath: /migrate
-        - name: langgraph
-          image: docker.io/beclab/harveyff-deerflow-backend:v2.0.7-pg
-          command:
-            - sh
-            - -c
-            - "cd /app/backend && uv run langgraph dev --no-browser --allow-blocking --no-reload --host 0.0.0.0 --port 2024"
-          # See gateway preStop for rationale.
-          lifecycle:
-            preStop:
-              exec:
-                command: ["sh", "-c", "sleep 5"]
-          ports:
-            - containerPort: 2024
-              name: langgraph
-          # See gateway readinessProbe for rationale. langgraph dev
-          # exposes /ok (not /health) -- doc'd in deer-flow's
-          # deployment-guide and operations-and-troubleshooting pages.
-          # initialDelaySeconds is higher than gateway's because
-          # `langgraph dev --no-reload --allow-blocking` does its
-          # graph compilation + checkpoint pool warmup synchronously
-          # at startup; on cold pulls this can take 20-30s before /ok
-          # responds. failureThreshold:6 (= 30s of /ok failures)
-          # tolerates a slow PG checkpointer pool initialisation.
-          readinessProbe:
-            httpGet:
-              path: /ok
-              port: 2024
-            initialDelaySeconds: 10
-            periodSeconds: 5
-            timeoutSeconds: 3
-            failureThreshold: 6
-          livenessProbe:
-            httpGet:
-              path: /ok
-              port: 2024
-            periodSeconds: 60
-            timeoutSeconds: 10
-            failureThreshold: 5
-          env:
-            - name: CI
-              value: "true"
-            - name: DEER_FLOW_HOME
-              value: "/data/deer-flow"
-            - name: DEER_FLOW_CONFIG_PATH
-              value: "/config/config.yaml"
-            - name: DEER_FLOW_EXTENSIONS_CONFIG_PATH
-              value: "/config/extensions_config.json"
-            - name: PGID
-              value: "1000"
-            - name: PUID
-              value: "1000"
-            - name: TZ
-              value: Etc/UTC
-            - name: AUTH_JWT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: deerflowv2-auth-secret
-                  key: AUTH_JWT_SECRET
-            # See gateway container for rationale.
-            - name: AUTH_TRUSTED_PROXIES
-              value: "10.233.0.0/16"
-            {{- if gt (len $gatewayOrigins) 0 }}
-            - name: GATEWAY_CORS_ORIGINS
-              value: {{ join "," $gatewayOrigins | quote }}
-            {{- end }}
-            # Mirror gateway env: plain DATABASE_URL for ORM, keepalive URL for
-            # LangGraph checkpointer. See gateway container comments above.
-            - name: DATABASE_URL
-              value: "postgresql://{{ .Values.postgres.username }}:{{ .Values.postgres.password }}@{{ .Values.postgres.host }}:{{ .Values.postgres.port }}/{{ .Values.postgres.databases.deerflow }}"
-            - name: CHECKPOINTER_DATABASE_URL
-              value: "postgresql://{{ .Values.postgres.username }}:{{ .Values.postgres.password }}@{{ .Values.postgres.host }}:{{ .Values.postgres.port }}/{{ .Values.postgres.databases.deerflow }}?keepalives=1&keepalives_idle=30&keepalives_interval=10&keepalives_count=5"
           envFrom:
             - configMapRef:
                 name: deerflowv2-env-config
@@ -440,8 +339,16 @@ spec:
               mountPath: /data/deer-flow
             - name: skills-volume
               mountPath: /app/skills
-            - name: langgraph-api-volume
-              mountPath: /app/backend/.langgraph_api
+            # On-demand legacy SQLite -> postgres migration tool. Mounted
+            # into the gateway container; the operator runs it via
+            # `kubectl exec deploy/... -c gateway`.
+            # Uses items: projection so only the two migration files
+            # appear under /migrate -- the rest of init-config (config.yaml,
+            # the OCR skill, the database backend rewriter) does not leak
+            # into the runtime filesystem. See configmap.yaml for the
+            # script source and operator usage instructions.
+            - name: migrate-vol
+              mountPath: /migrate
       volumes:
         - name: init-config-vol
           configMap:
@@ -473,10 +380,6 @@ spec:
           hostPath:
             path: '{{ .Values.userspace.appData }}/skills'
             type: DirectoryOrCreate
-        - name: langgraph-api-volume
-          hostPath:
-            path: '{{ .Values.userspace.appData }}/langgraph_api'
-            type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: Service
@@ -490,7 +393,4 @@ spec:
     - name: gateway
       port: 8001
       targetPort: 8001
-    - name: langgraph
-      port: 2024
-      targetPort: 2024
   type: ClusterIP

--- a/deerflowv2/templates/frontend.yaml
+++ b/deerflowv2/templates/frontend.yaml
@@ -49,15 +49,9 @@ spec:
             - '-it'
             - 'deerflowv2-backend-svc:8001'
           resources: {}
-        - name: wait-for-langgraph
-          image: "docker.io/beclab/wait-for:0.1.0"
-          args:
-            - '-it'
-            - 'deerflowv2-backend-svc:2024'
-          resources: {}
       containers:
         - name: deerflowv2-frontend
-          image: docker.io/beclab/harveyff-deerflow-frontend:v2.0.3
+          image: docker.io/beclab/harveyff-deerflow-frontend:v2.1.1
           ports:
             - containerPort: 3000
           env:


### PR DESCRIPTION
## Summary
- Bump chart `1.0.6` → `1.0.7` (remote +1) and app to DeerFlow **v2.1.1** (`beclab/harveyff-deerflow-backend` / `beclab/harveyff-deerflow-frontend`).
- Align runtime with upstream: LangGraph runs inside the gateway; remove standalone `:2024` sidecar and frontend wait-for-2024.
- Simplify Postgres wiring to a single `DATABASE_URL` (drop dual checkpointer URL); bump `config_version` to 31.
- Switch clientproxy from Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) to official `openresty/openresty:1.29.2.5-bookworm-fat` (config/log paths + drop `OPENRESTY_CONF_FILE`).

## Test plan
- [x] `olares-cli chart lint deerflowv2`
- [x] Install / upgrade on olarestest001 → `running`, pods Ready, `/health` 200
- [x] Clientproxy container image is `docker.io/openresty/openresty:1.29.2.5-bookworm-fat`
- [ ] GitBot checks on this draft PR