### PR TITLE
[UPDATE][hermesagent][1.3.35] bump Hermes Agent to v0.19.1 (v2026.7.30-uid1000)

### DIFF
--- a/hermesagent/Chart.yaml
+++ b/hermesagent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: '0.19.0'
+appVersion: '0.19.1'
 description: The self-improving AI agent built by Nous Research
 name: hermesagent
 type: application
-version: '1.3.33'
+version: '1.3.35'

--- a/hermesagent/Dockerfile
+++ b/hermesagent/Dockerfile
@@ -21,17 +21,17 @@
 #
 # Build (all args optional; defaults shown):
 #   docker buildx build \
-#     --build-arg HERMES_VERSION=v2026.7.20 \
+#     --build-arg HERMES_VERSION=v2026.7.30 \
 #     --build-arg TARGET_UID=1000 \
 #     --build-arg TARGET_GID=1000 \
 #     --platform linux/amd64 \
-#     -t beclab/harveyff-hermes-agent:v2026.7.20-uid1000 --push .
+#     -t beclab/harveyff-hermes-agent:v2026.7.30-uid1000 --push .
 #
 # Upgrades: just pass a newer --build-arg HERMES_VERSION and rebuild.
 # ---------------------------------------------------------------------------
 
 # Global ARG consumed by FROM. Must be declared before the first FROM.
-ARG HERMES_VERSION=v2026.7.20
+ARG HERMES_VERSION=v2026.7.30
 FROM nousresearch/hermes-agent:${HERMES_VERSION}
 
 # Re-declare after FROM to make these usable inside RUN below.

--- a/hermesagent/OlaresManifest.yaml
+++ b/hermesagent/OlaresManifest.yaml
@@ -11,7 +11,7 @@ metadata:
   description: The agent that grows with you
   appid: hermesagent
   title: Hermes Agent
-  version: '1.3.33'
+  version: '1.3.35'
   categories:
   - Productivity_v112
   - Developer Tools
@@ -38,7 +38,7 @@ entrances:
   invisible: true
   authLevel: internal
 spec:
-  versionName: '0.19.0'
+  versionName: '0.19.1'
   fullDescription: |
     **The self-improving AI agent built by [Nous Research](https://nousresearch.com).** It's the only agent with a built-in learning loop — it creates skills from experience, improves them during use, nudges itself to persist knowledge, searches its own past conversations, and builds a deepening model of who you are across sessions. Run it on a $5 VPS, a GPU cluster, or serverless infrastructure that costs nearly nothing when idle. It's not tied to your laptop — talk to it from Telegram while it works on a cloud VM.
 
@@ -52,23 +52,14 @@ spec:
     - **Research-ready**: Batch trajectory generation, trajectory compression for training the next generation of tool-calling models.
 
   upgradeDescription: |
-    Upgrade to Hermes Agent v0.19.0 — The Quicksilver Release (1.3.33).
-    Upstream: https://github.com/NousResearch/hermes-agent/releases/tag/v2026.7.20
+    Upgrade to Hermes Agent v0.19.1.
+    Upstream: https://github.com/NousResearch/hermes-agent/releases/tag/v2026.7.30
 
     Change Details:
-    - Image: `beclab/harveyff-hermes-agent:v2026.7.20-uid1000` (UID 1000 overlay; amd64 + arm64).
-    - Move `API_SERVER_KEY` (`HERMES_API_SERVER_KEY`) into Kubernetes Secret (`secretKeyRef`).
-    - New Olares envs (v0.19): `API_SERVER_CORS_ORIGINS`, `API_SERVER_MODEL_NAME`, `GATEWAY_ALLOW_ALL_USERS`, `GATEWAY_ALLOWED_USERS`, `TELEGRAM_ALLOWED_USERS`, `DISCORD_ALLOWED_USERS`, `HERMES_CRON_TIMEOUT`, `HERMES_CRON_MAX_PARALLEL`, `HERMES_GATEWAY_BUSY_INPUT_MODE`, `HERMES_GATEWAY_BUSY_ACK_ENABLED`.
-    - Map Olares Integration keys: `OLARES_USER_OPENAI_APIKEY` → `OPENAI_API_KEY`, `OLARES_USER_ANTHROPIC_APIKEY` → `ANTHROPIC_API_KEY` (Secret-injected when set).
-    - Performance: ~80% first-token latency cut; reasoning streams live by default; TUI incremental markdown.
-    - Smart approvals default; Bitwarden/1Password secret sources; live subagent transcripts; durable delivery ledger; profile-based gateway routing.
-    - Providers/models: Fireworks, DeepInfra, Upstage; GPT-5.6, grok-4.5, kimi-k3, Claude Sonnet/Fable 5, tencent/hy3; reasoning `max`/`ultra`.
-    - Sessions export, `/subscription` `/topup`, security hardening. Full notes: upstream release link above.
-
-    After upgrade, open Dashboard / Hermes CLI via Olares entrances. Existing `/opt/data` is preserved.
-
-    v1.3.23: Hermes Agent v0.18.0 single supervised container; Dashboard auth via Olares only.
-    Image `v2026.7.7.2-uid1000`; gateway/dashboard/CLI share one s6 pod; loopback dashboard + nginx sidecar.
+    - Image: `beclab/harveyff-hermes-agent:v2026.7.30-uid1000` (UID 1000 overlay; amd64 + arm64).
+    - Patch release rolling up ~1,000+ PRs since v0.19.0 (v2026.7.20) into a stable tagged build for Docker / hosted / fresh installs.
+    - Since v2026.7.20: large main-window salvage across gateway, voice, desktop app, and installer; platform work includes Buzz/Nostr channel, FLUX3 video generation/delivery, Telegram media reliability, and voice-mode regression fixes.
+    - Full curated feature notes for this window ship with upstream v0.20.0; compare: https://github.com/NousResearch/hermes-agent/compare/v2026.7.20...v2026.7.30
 
   developer: Nous Research
   website: https://hermes-agent.nousresearch.com
@@ -81,11 +72,11 @@ spec:
   license:
   - text: MIT
     url: https://github.com/NousResearch/hermes-agent/blob/main/LICENSE
-  requiredMemory: 5Gi
+  requiredMemory: 2.5Gi
   limitedMemory: 22Gi
   requiredDisk: 5Gi
   limitedDisk: 20Gi
-  requiredCpu: 4
+  requiredCpu: 1.5
   limitedCpu: 12
   supportArch:
   - amd64

--- a/hermesagent/i18n/en-US/OlaresManifest.yaml
+++ b/hermesagent/i18n/en-US/OlaresManifest.yaml
@@ -15,20 +15,11 @@ spec:
     - **Research-ready**: Batch trajectory generation, trajectory compression for training the next generation of tool-calling models.
 
   upgradeDescription: |
-    Upgrade to Hermes Agent v0.19.0 — The Quicksilver Release (1.3.33).
-    Upstream: https://github.com/NousResearch/hermes-agent/releases/tag/v2026.7.20
+    Upgrade to Hermes Agent v0.19.1
+    Upstream: https://github.com/NousResearch/hermes-agent/releases/tag/v2026.7.30
 
     Change Details:
-    - Image: `beclab/harveyff-hermes-agent:v2026.7.20-uid1000` (UID 1000 overlay; amd64 + arm64).
-    - Move `API_SERVER_KEY` (`HERMES_API_SERVER_KEY`) into Kubernetes Secret (`secretKeyRef`).
-    - New Olares envs (v0.19): `API_SERVER_CORS_ORIGINS`, `API_SERVER_MODEL_NAME`, `GATEWAY_ALLOW_ALL_USERS`, `GATEWAY_ALLOWED_USERS`, `TELEGRAM_ALLOWED_USERS`, `DISCORD_ALLOWED_USERS`, `HERMES_CRON_TIMEOUT`, `HERMES_CRON_MAX_PARALLEL`, `HERMES_GATEWAY_BUSY_INPUT_MODE`, `HERMES_GATEWAY_BUSY_ACK_ENABLED`.
-    - Map Olares Integration keys: `OLARES_USER_OPENAI_APIKEY` → `OPENAI_API_KEY`, `OLARES_USER_ANTHROPIC_APIKEY` → `ANTHROPIC_API_KEY` (Secret-injected when set).
-    - Performance: ~80% first-token latency cut; reasoning streams live by default; TUI incremental markdown.
-    - Smart approvals default; Bitwarden/1Password secret sources; live subagent transcripts; durable delivery ledger; profile-based gateway routing.
-    - Providers/models: Fireworks, DeepInfra, Upstage; GPT-5.6, grok-4.5, kimi-k3, Claude Sonnet/Fable 5, tencent/hy3; reasoning `max`/`ultra`.
-    - Sessions export, `/subscription` `/topup`, security hardening. Full notes: upstream release link above.
-
-    After upgrade, open Dashboard / Hermes CLI via Olares entrances. Existing `/opt/data` is preserved.
-
-    v1.3.23: Hermes Agent v0.18.0 single supervised container; Dashboard auth via Olares only.
-    Image `v2026.7.7.2-uid1000`; gateway/dashboard/CLI share one s6 pod; loopback dashboard + nginx sidecar.
+    - Image: `beclab/harveyff-hermes-agent:v2026.7.30-uid1000` (UID 1000 overlay; amd64 + arm64).
+    - Patch release rolling up ~1,000+ PRs since v0.19.0 (v2026.7.20) into a stable tagged build for Docker / hosted / fresh installs.
+    - Since v2026.7.20: large main-window salvage across gateway, voice, desktop app, and installer; platform work includes Buzz/Nostr channel, FLUX3 video generation/delivery, Telegram media reliability, and voice-mode regression fixes.
+    - Full curated feature notes for this window ship with upstream v0.20.0; compare: https://github.com/NousResearch/hermes-agent/compare/v2026.7.20...v2026.7.30

--- a/hermesagent/i18n/zh-CN/OlaresManifest.yaml
+++ b/hermesagent/i18n/zh-CN/OlaresManifest.yaml
@@ -15,20 +15,11 @@ spec:
     - **科研级功能**：支持批量生成轨迹、轨迹压缩，用于训练下一代工具调用模型。
 
   upgradeDescription: |
-    升级到 Hermes Agent v0.19.0 — Quicksilver 版本（1.3.33）。
-    上游发布说明：https://github.com/NousResearch/hermes-agent/releases/tag/v2026.7.20
+    升级到 Hermes Agent v0.19.1
+    上游发布说明：https://github.com/NousResearch/hermes-agent/releases/tag/v2026.7.30
 
     变更详情：
-    - 镜像：`beclab/harveyff-hermes-agent:v2026.7.20-uid1000`（UID 1000 叠加层；支持 amd64 与 arm64 架构）。
-    - `API_SERVER_KEY`（即 `HERMES_API_SERVER_KEY`）移入 Kubernetes Secret（`secretKeyRef`）。
-    - 新增 Olares 环境变量（v0.19）：`API_SERVER_CORS_ORIGINS`、`API_SERVER_MODEL_NAME`、`GATEWAY_ALLOW_ALL_USERS`、`GATEWAY_ALLOWED_USERS`、`TELEGRAM_ALLOWED_USERS`、`DISCORD_ALLOWED_USERS`、`HERMES_CRON_TIMEOUT`、`HERMES_CRON_MAX_PARALLEL`、`HERMES_GATEWAY_BUSY_INPUT_MODE`、`HERMES_GATEWAY_BUSY_ACK_ENABLED`。
-    - 支持 Olares 集成密钥映射：`OLARES_USER_OPENAI_APIKEY` → `OPENAI_API_KEY`，`OLARES_USER_ANTHROPIC_APIKEY` → `ANTHROPIC_API_KEY`（如设置则注入至 Secret）。
-    - 性能优化：首个 token 延迟下降约 80%；推理支持实时流式输出；终端支持增量 Markdown 呈现。
-    - 默认启用智能审批；支持 Bitwarden/1Password 密钥源；子代理运行中可实时查看日志；提供持久化投递账本；支持基于 profile 的网关路由。
-    - 新增/支持模型与供应商：Fireworks、DeepInfra、Upstage、GPT-5.6、grok-4.5、kimi-k3、Claude Sonnet/Fable 5、腾讯 hy3 等；推理力度参数支持 `max` / `ultra`。
-    - 支持会话导出、`/subscription`、`/topup`、安全性增强。完整说明见上游发布链接。
-
-    升级后，可通过 Olares 入口打开 Dashboard 或 Hermes CLI。已有 `/opt/data` 目录将被保留。
-
-    v1.3.23: Hermes Agent v0.18.0 为单一受控容器结构；Dashboard 仅支持通过 Olares 认证。
-    镜像版本 `v2026.7.7.2-uid1000`；gateway/dashboard/CLI 共用同一个 s6 pod，dashboard 本地回环并有 nginx sidecar。
+    - 镜像：`beclab/harveyff-hermes-agent:v2026.7.30-uid1000`（UID 1000 叠加层；amd64 + arm64）。
+    - 补丁版：将自 v0.19.0（v2026.7.20）以来合并的约 1000+ PR 打成稳定标签，便于 Docker / 托管部署 / 全新安装。
+    - 相对 v2026.7.20：网关、语音、桌面端与安装器等方向大量修复与加固；平台侧含 Buzz/Nostr 频道、FLUX3 视频生成与投递、Telegram 媒体可靠性，以及 voice-mode 回归修复。
+    - 本窗口完整功能说明将随上游 v0.20.0 发布；变更对比：https://github.com/NousResearch/hermes-agent/compare/v2026.7.20...v2026.7.30

--- a/hermesagent/templates/deployment.yaml
+++ b/hermesagent/templates/deployment.yaml
@@ -32,7 +32,7 @@
 # (NPM_CONFIG_PREFIX) so `npm install -g` and `npx` work and persist, and add
 # that prefix bin to PATH. Local `npm install` works from any writable cwd
 # (e.g. HOME=/opt/data). We do NOT mount over or re-open /opt/hermes.
-{{- $hermesImage := "beclab/harveyff-hermes-agent:v2026.7.20-uid1000" -}}
+{{- $hermesImage := "beclab/harveyff-hermes-agent:v2026.7.30-uid1000" -}}
 {{- $oe := .Values.olaresEnv | default dict }}
 ---
 # Loopback dashboard (no Hermes auth gate) + nginx sidecar on :9119.
@@ -383,8 +383,8 @@ spec:
               cpu: "8"
               memory: 20Gi
             requests:
-              cpu: "2"
-              memory: 4Gi
+              cpu: "1"
+              memory: 2Gi
           volumeMounts:
             - mountPath: /opt/data
               name: app-data-home


### PR DESCRIPTION
### App Title
hermesagent

### Description

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`