### PR TITLE
[UPDATE][hermesagent][1.3.37] bump Hermes Agent to v0.20.0 with certbot init defaults

### DIFF
--- a/hermesagent/Chart.yaml
+++ b/hermesagent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: '0.19.1'
+appVersion: '0.20.0'
 description: The self-improving AI agent built by Nous Research
 name: hermesagent
 type: application
-version: '1.3.35'
+version: '1.3.37'

--- a/hermesagent/Dockerfile
+++ b/hermesagent/Dockerfile
@@ -21,17 +21,17 @@
 #
 # Build (all args optional; defaults shown):
 #   docker buildx build \
-#     --build-arg HERMES_VERSION=v2026.7.30 \
+#     --build-arg HERMES_VERSION=v2026.8.3 \
 #     --build-arg TARGET_UID=1000 \
 #     --build-arg TARGET_GID=1000 \
 #     --platform linux/amd64 \
-#     -t beclab/harveyff-hermes-agent:v2026.7.30-uid1000 --push .
+#     -t beclab/harveyff-hermes-agent:v2026.8.3-uid1000 --push .
 #
 # Upgrades: just pass a newer --build-arg HERMES_VERSION and rebuild.
 # ---------------------------------------------------------------------------
 
 # Global ARG consumed by FROM. Must be declared before the first FROM.
-ARG HERMES_VERSION=v2026.7.30
+ARG HERMES_VERSION=v2026.8.3
 FROM nousresearch/hermes-agent:${HERMES_VERSION}
 
 # Re-declare after FROM to make these usable inside RUN below.

--- a/hermesagent/OlaresManifest.yaml
+++ b/hermesagent/OlaresManifest.yaml
@@ -11,7 +11,7 @@ metadata:
   description: The agent that grows with you
   appid: hermesagent
   title: Hermes Agent
-  version: '1.3.35'
+  version: '1.3.37'
   categories:
   - Productivity_v112
   - Developer Tools
@@ -38,7 +38,7 @@ entrances:
   invisible: true
   authLevel: internal
 spec:
-  versionName: '0.19.1'
+  versionName: '0.20.0'
   fullDescription: |
     **The self-improving AI agent built by [Nous Research](https://nousresearch.com).** It's the only agent with a built-in learning loop — it creates skills from experience, improves them during use, nudges itself to persist knowledge, searches its own past conversations, and builds a deepening model of who you are across sessions. Run it on a $5 VPS, a GPU cluster, or serverless infrastructure that costs nearly nothing when idle. It's not tied to your laptop — talk to it from Telegram while it works on a cloud VM.
 
@@ -52,14 +52,23 @@ spec:
     - **Research-ready**: Batch trajectory generation, trajectory compression for training the next generation of tool-calling models.
 
   upgradeDescription: |
-    Upgrade to Hermes Agent v0.19.1.
-    Upstream: https://github.com/NousResearch/hermes-agent/releases/tag/v2026.7.30
+    Upgrade to Hermes Agent v0.20.0 (The Herald Release).
+    Upstream: https://github.com/NousResearch/hermes-agent/releases/tag/v2026.8.3
 
-    Change Details:
-    - Image: `beclab/harveyff-hermes-agent:v2026.7.30-uid1000` (UID 1000 overlay; amd64 + arm64).
-    - Patch release rolling up ~1,000+ PRs since v0.19.0 (v2026.7.20) into a stable tagged build for Docker / hosted / fresh installs.
-    - Since v2026.7.20: large main-window salvage across gateway, voice, desktop app, and installer; platform work includes Buzz/Nostr channel, FLUX3 video generation/delivery, Telegram media reliability, and voice-mode regression fixes.
-    - Full curated feature notes for this window ship with upstream v0.20.0; compare: https://github.com/NousResearch/hermes-agent/compare/v2026.7.20...v2026.7.30
+    Olares packaging:
+    - Runtime image: `beclab/harveyff-hermes-agent:v2026.8.3-uid1000` (UID 1000 overlay; amd64 + arm64).
+    - Brew base: `beclab/harveyff-openclaw-brew-base:2026.8.7-cli` (adds `certbot` for custom-domain TLS workflows).
+    - Init seeds certbot user config under `/opt/data/.config/letsencrypt/cli.ini` (writable paths + RSA default; non-root `certbot` works without extra flags).
+
+    Upstream highlights since v0.19.1:
+    - **Voice & speech**: streaming conversational TTS with barge-in, on-device wake words, voice notes on WhatsApp/Feishu/DingTalk/LINE/QQ and other gateway platforms; configurable STT/TTS.
+    - **Gateway & integrations**: Buzz (Nostr) platform adapter, outbound signed webhooks, A2A v1.0 agent-to-agent protocol, Relay parity (media, interactive prompts, thread lifecycle).
+    - **CLI power commands**: `!` shell mode, `/init`, `/diff`, `/context`, `/focus`, mid-turn redirects without restarting the session.
+    - **Smarter agent loop**: tool self-recovery (truncation spill, patch no-op detection, search recovery), default iteration limit 90 → 500, smarter context compression.
+    - **Research**: grounded-citations skill with verifiable sources and fact-checking mode.
+    - **Performance**: prompt caching improvements, cold-start and config-read optimizations.
+
+    Full release notes: https://github.com/NousResearch/hermes-agent/releases/tag/v2026.8.3
 
   developer: Nous Research
   website: https://hermes-agent.nousresearch.com

--- a/hermesagent/i18n/en-US/OlaresManifest.yaml
+++ b/hermesagent/i18n/en-US/OlaresManifest.yaml
@@ -15,11 +15,20 @@ spec:
     - **Research-ready**: Batch trajectory generation, trajectory compression for training the next generation of tool-calling models.
 
   upgradeDescription: |
-    Upgrade to Hermes Agent v0.19.1
-    Upstream: https://github.com/NousResearch/hermes-agent/releases/tag/v2026.7.30
+    Upgrade to Hermes Agent v0.20.0 (The Herald Release).
+    Upstream: https://github.com/NousResearch/hermes-agent/releases/tag/v2026.8.3
 
-    Change Details:
-    - Image: `beclab/harveyff-hermes-agent:v2026.7.30-uid1000` (UID 1000 overlay; amd64 + arm64).
-    - Patch release rolling up ~1,000+ PRs since v0.19.0 (v2026.7.20) into a stable tagged build for Docker / hosted / fresh installs.
-    - Since v2026.7.20: large main-window salvage across gateway, voice, desktop app, and installer; platform work includes Buzz/Nostr channel, FLUX3 video generation/delivery, Telegram media reliability, and voice-mode regression fixes.
-    - Full curated feature notes for this window ship with upstream v0.20.0; compare: https://github.com/NousResearch/hermes-agent/compare/v2026.7.20...v2026.7.30
+    Olares packaging:
+    - Runtime image: `beclab/harveyff-hermes-agent:v2026.8.3-uid1000` (UID 1000 overlay; amd64 + arm64).
+    - Brew base: `beclab/harveyff-openclaw-brew-base:2026.8.7-cli` (adds `certbot` for custom-domain TLS workflows).
+    - Init seeds certbot user config under `/opt/data/.config/letsencrypt/cli.ini` (writable paths + RSA default; non-root `certbot` works without extra flags).
+
+    Upstream highlights since v0.19.1:
+    - **Voice & speech**: streaming conversational TTS with barge-in, on-device wake words, voice notes on WhatsApp/Feishu/DingTalk/LINE/QQ and other gateway platforms; configurable STT/TTS.
+    - **Gateway & integrations**: Buzz (Nostr) platform adapter, outbound signed webhooks, A2A v1.0 agent-to-agent protocol, Relay parity (media, interactive prompts, thread lifecycle).
+    - **CLI power commands**: `!` shell mode, `/init`, `/diff`, `/context`, `/focus`, mid-turn redirects without restarting the session.
+    - **Smarter agent loop**: tool self-recovery (truncation spill, patch no-op detection, search recovery), default iteration limit 90 → 500, smarter context compression.
+    - **Research**: grounded-citations skill with verifiable sources and fact-checking mode.
+    - **Performance**: prompt caching improvements, cold-start and config-read optimizations.
+
+    Full release notes: https://github.com/NousResearch/hermes-agent/releases/tag/v2026.8.3

--- a/hermesagent/i18n/zh-CN/OlaresManifest.yaml
+++ b/hermesagent/i18n/zh-CN/OlaresManifest.yaml
@@ -15,11 +15,20 @@ spec:
     - **科研级功能**：支持批量生成轨迹、轨迹压缩，用于训练下一代工具调用模型。
 
   upgradeDescription: |
-    升级到 Hermes Agent v0.19.1
-    上游发布说明：https://github.com/NousResearch/hermes-agent/releases/tag/v2026.7.30
+    升级到 Hermes Agent v0.20.0（The Herald Release）。
+    上游发布说明：https://github.com/NousResearch/hermes-agent/releases/tag/v2026.8.3
 
-    变更详情：
-    - 镜像：`beclab/harveyff-hermes-agent:v2026.7.30-uid1000`（UID 1000 叠加层；amd64 + arm64）。
-    - 补丁版：将自 v0.19.0（v2026.7.20）以来合并的约 1000+ PR 打成稳定标签，便于 Docker / 托管部署 / 全新安装。
-    - 相对 v2026.7.20：网关、语音、桌面端与安装器等方向大量修复与加固；平台侧含 Buzz/Nostr 频道、FLUX3 视频生成与投递、Telegram 媒体可靠性，以及 voice-mode 回归修复。
-    - 本窗口完整功能说明将随上游 v0.20.0 发布；变更对比：https://github.com/NousResearch/hermes-agent/compare/v2026.7.20...v2026.7.30
+    Olares 打包变更：
+    - 运行时镜像：`beclab/harveyff-hermes-agent:v2026.8.3-uid1000`（UID 1000 叠加层；amd64 + arm64）。
+    - Brew 基础镜像：`beclab/harveyff-openclaw-brew-base:2026.8.7-cli`（新增 `certbot`，用于自定义域名 TLS 流程）。
+    - Init 在 `/opt/data/.config/letsencrypt/cli.ini` 写入 certbot 默认配置（可写目录 + RSA 默认；非 root 可直接运行 certbot）。
+
+    相对 v0.19.1 的上游亮点：
+    - **语音与对话**：流式 TTS、可打断（barge-in）、设备端唤醒词；WhatsApp/飞书/钉钉/LINE/QQ 等平台语音消息转录与回复；可配置 STT/TTS。
+    - **网关与集成**：Buzz（Nostr）平台适配、出站签名 Webhook、A2A v1.0 代理间协议、Relay 能力补齐（媒体、交互提示、线程生命周期）。
+    - **CLI 增强**：`!` shell 模式、`/init`、`/diff`、`/context`、`/focus`；会话中途可重定向而无需重启。
+    - **更智能的 Agent 循环**：工具自愈（截断溢出、patch 已应用检测、搜索恢复），默认迭代上限 90 → 500，上下文压缩优化。
+    - **研究能力**：grounded-citations 技能，可验证引用与事实核查模式。
+    - **性能**：Prompt 缓存、冷启动与配置读取优化。
+
+    完整发布说明：https://github.com/NousResearch/hermes-agent/releases/tag/v2026.8.3

--- a/hermesagent/templates/deployment.yaml
+++ b/hermesagent/templates/deployment.yaml
@@ -32,7 +32,7 @@
 # (NPM_CONFIG_PREFIX) so `npm install -g` and `npx` work and persist, and add
 # that prefix bin to PATH. Local `npm install` works from any writable cwd
 # (e.g. HOME=/opt/data). We do NOT mount over or re-open /opt/hermes.
-{{- $hermesImage := "beclab/harveyff-hermes-agent:v2026.7.30-uid1000" -}}
+{{- $hermesImage := "beclab/harveyff-hermes-agent:v2026.8.3-uid1000" -}}
 {{- $oe := .Values.olaresEnv | default dict }}
 ---
 # Loopback dashboard (no Hermes auth gate) + nginx sidecar on :9119.
@@ -122,6 +122,21 @@ spec:
               mkdir -p /opt/data/.olares-cli/data
               # Writable npm global prefix on the data volume (npm install -g / npx).
               mkdir -p /opt/data/npm-global/lib/node_modules /opt/data/npm-global/bin
+              # certbot (brew-base): non-root defaults under $HOME=/opt/data; Olares TLS needs RSA.
+              mkdir -p /opt/data/.config/letsencrypt \
+                       /opt/data/letsencrypt/config \
+                       /opt/data/letsencrypt/work \
+                       /opt/data/letsencrypt/logs
+              if [ ! -f /opt/data/.config/letsencrypt/cli.ini ]; then
+                printf '%s\n' \
+                  '# Olares hermesagent: certbot paths for non-root (hermes) use.' \
+                  'config-dir = /opt/data/letsencrypt/config' \
+                  'work-dir = /opt/data/letsencrypt/work' \
+                  'logs-dir = /opt/data/letsencrypt/logs' \
+                  'key-type = rsa' \
+                  > /opt/data/.config/letsencrypt/cli.ini
+                echo "[init] seeded certbot cli.ini under /opt/data/.config/letsencrypt"
+              fi
               chown -R 1000:1000 /opt/data || true
               chmod -R u+rwX,g+rwX /opt/data || true
               # Hook interactive shells into drop-to-hermes (kubectl exec is root).
@@ -159,7 +174,7 @@ spec:
 
         # Materialize Linuxbrew + olares-cli + CLI shims onto the brew-volume.
         - name: init-install-brew
-          image: "beclab/harveyff-openclaw-brew-base:2026.7.6-cli"
+          image: "beclab/harveyff-openclaw-brew-base:2026.8.7-cli"
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0
@@ -216,7 +231,7 @@ spec:
         # Flatten olares-* skills from the brew-base image (/skills-staging) into
         # /opt/data/skills (per-dir refresh; skipped if /skills-staging absent).
         - name: init-skills
-          image: "beclab/harveyff-openclaw-brew-base:2026.7.6-cli"
+          image: "beclab/harveyff-openclaw-brew-base:2026.8.7-cli"
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsUser: 0


### PR DESCRIPTION
## Summary
- Upgrade Hermes Agent to upstream v2026.8.3 (app v0.20.0); runtime image `beclab/harveyff-hermes-agent:v2026.8.3-uid1000`.
- Bump brew-base init image to `beclab/harveyff-openclaw-brew-base:2026.8.7-cli` (includes certbot).
- Seed non-root certbot defaults in init: `/opt/data/.config/letsencrypt/cli.ini` with writable paths and RSA key type.
- Refresh upgrade notes (en-US / zh-CN) for v0.20.0 highlights.

## Test plan
- [x] `olares-cli chart lint ./hermesagent` passes
- [x] Uploaded and upgraded on olarestest001 (upload source); app state `running` at 1.3.37
- [ ] GitBot checks pass on draft PR
- [ ] After merge, verify chart appears on test/public market index


Made with [Cursor](https://cursor.com)