### PR TITLE
[UPDATE][chromium][1.0.13] Upgrade to beclab ls44 Selkies base

### DIFF
--- a/chromium/Chart.yaml
+++ b/chromium/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: '1.0.12'
+version: '1.0.13'
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "20260527-selkies"
+appVersion: "ae9a7fca-ls44"

--- a/chromium/OlaresManifest.yaml
+++ b/chromium/OlaresManifest.yaml
@@ -9,7 +9,7 @@ metadata:
   description: The open-source projects behind the Google Chrome browser
   icon: https://app.cdn.olares.com/appstore/chromium/icon.png
   appid: chromium
-  version: '1.0.12'
+  version: '1.0.13'
   title: Chromium
   categories:
   - Utilities_v112
@@ -18,15 +18,13 @@ permission:
   appData: true
   appCache: true
 spec:
-  versionName: '20260527'
+  versionName: 'ae9a7fca-ls44'
   fullDescription: |
     **About**
     Chromium is an open-source browser project that aims to build a safer, faster, and more stable way for all users to experience the web.
 
   upgradeDescription: |
-    Storage: durable `/config` moved from `appCache` to `appData`. On first start after upgrade, an initContainer copies legacy `appCache/config` into `appData/config` when the destination is empty (marker: `.migration_from_appcache_done`). Old appCache data is left intact for rollback.
-
-    Drop legacy `sysVersion >= 1.12.3` appCache path branching; Olares minimum is now 1.12.6.
+    Upgrade base image to `beclab/harveyff-chromium:ae9a7fca-ls44` (Olares-patched ls44). Force `PIXELFLUX_WAYLAND=false` for X11 Selkies on Olares One. Chromium managed policies keep New Tab and default search on Google. TCP socket probes on port 3000 avoid HTTP 403 Unhealthy events.
 
   developer: Google
   website: https://www.chromium.org/chromium-projects/

--- a/chromium/i18n/en-US/OlaresManifest.yaml
+++ b/chromium/i18n/en-US/OlaresManifest.yaml
@@ -7,6 +7,4 @@ spec:
     Chromium is an open-source browser project that aims to build a safer, faster, and more stable way for all users to experience the web.
 
   upgradeDescription: |
-    Storage: durable `/config` moved from `appCache` to `appData`. On first start after upgrade, an initContainer copies legacy `appCache/config` into `appData/config` when the destination is empty (marker: `.migration_from_appcache_done`). Old appCache data is left intact for rollback.
-
-    Drop legacy `sysVersion >= 1.12.3` appCache path branching; Olares minimum is now 1.12.6.
+    Upgrade base image to `beclab/harveyff-chromium:ae9a7fca-ls44` (Olares-patched ls44). Force `PIXELFLUX_WAYLAND=false` for X11 Selkies on Olares One. Managed policies keep New Tab and default search on Google. TCP socket probes on port 3000 avoid HTTP 403 Unhealthy events.

--- a/chromium/i18n/zh-CN/OlaresManifest.yaml
+++ b/chromium/i18n/zh-CN/OlaresManifest.yaml
@@ -7,6 +7,4 @@ spec:
     Chromium 是一个开源浏览器项目，旨在为所有用户构建一种更安全、更快速、更稳定的网络体验方式。
 
   upgradeDescription: |
-    存储：持久数据 `/config` 从 `appCache` 迁移到 `appData`。升级后首次启动时，若 `appData/config` 为空，initContainer 会将旧 `appCache/config` 复制到 `appData/config`（标记文件：`.migration_from_appcache_done`）；旧 appCache 数据保留以便回滚。
-
-    移除针对 Olares < 1.12.3 的 appCache 路径分支逻辑；当前最低支持版本为 1.12.6。
+    基础镜像升级至 `beclab/harveyff-chromium:ae9a7fca-ls44`（Olares 适配 ls44）。Olares One 强制 `PIXELFLUX_WAYLAND=false` 走 X11 Selkies。企业策略保持新标签页与默认搜索为 Google。3000 端口 TCP 探针避免 HTTP 403 Unhealthy 事件。

--- a/chromium/templates/chromium-policies.yaml
+++ b/chromium/templates/chromium-policies.yaml
@@ -1,0 +1,24 @@
+{{- $homepage := "https://www.google.com" }}
+{{- if and .Values.olaresEnv .Values.olaresEnv.CHROME_HOMEPAGE }}
+{{- $homepage = .Values.olaresEnv.CHROME_HOMEPAGE }}
+{{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chromium-policies
+  namespace: {{ .Release.Namespace }}
+  labels:
+    io.kompose.service: chromium
+data:
+  olares.json: |
+    {
+      "NewTabPageLocation": {{ $homepage | quote }},
+      "DefaultSearchProviderEnabled": true,
+      "DefaultSearchProviderName": "Google",
+      "DefaultSearchProviderKeyword": "google.com",
+      "DefaultSearchProviderSearchURL": "https://www.google.com/search?q={searchTerms}",
+      "DefaultSearchProviderSuggestURL": "https://www.google.com/complete/search?output=chrome&q={searchTerms}",
+      "DefaultSearchProviderIconURL": "https://www.google.com/favicon.ico",
+      "DefaultSearchProviderEncodings": ["UTF-8"]
+    }

--- a/chromium/templates/chromium.yaml
+++ b/chromium/templates/chromium.yaml
@@ -89,7 +89,7 @@ spec:
               mountPath: /new-data
       containers:
         - name: chromium
-          image: "docker.io/beclab/harveyff-chromium:1e736296-ls34"
+          image: "docker.io/beclab/harveyff-chromium:ae9a7fca-ls44"
           {{- if $isOlaresOne }}
           securityContext:
             privileged: true
@@ -103,9 +103,12 @@ spec:
               value: Etc/UTC
             - name: DeviceName
               value: {{ .Values.deviceName }}
+            # ls44 defaults PIXELFLUX_WAYLAND=true; force X11 on Olares (Wayland mis-scales).
+            - name: PIXELFLUX_WAYLAND
+              value: "false"
             {{- if $isOlaresOne }}
             - name: CHROME_CLI
-              value: "--ignore-gpu-blocklist --enable-gpu-rasterization --enable-zero-copy --use-gl=egl --enable-features=UseOzonePlatform,VaapiVideoDecoder,VaapiVideoEncoder,CanvasOopRasterization,ReduceAcceptLanguageHeader {{ $homepage }}"
+              value: "--ignore-gpu-blocklist --enable-gpu-rasterization --enable-zero-copy --use-gl=egl --enable-features=VaapiVideoDecoder,VaapiVideoEncoder,CanvasOopRasterization,ReduceAcceptLanguageHeader {{ $homepage }}"
             - name: DRINODE
               value: /dev/dri/renderD128
             - name: DRI_NODE
@@ -134,15 +137,13 @@ spec:
             - containerPort: 8082
             {{- end }}
           startupProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: http
             periodSeconds: 3
             failureThreshold: 40
             timeoutSeconds: 3
           readinessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: http
             periodSeconds: 5
             failureThreshold: 3
@@ -156,6 +157,9 @@ spec:
           volumeMounts:
             - mountPath: /config
               name: config
+            - mountPath: /etc/chromium/policies/managed
+              name: chromium-policies
+              readOnly: true
             - mountPath: /dev/shm
               name: dshm
             {{- if $isOlaresOne }}
@@ -168,6 +172,9 @@ spec:
           hostPath:
             type: DirectoryOrCreate
             path: {{ .Values.userspace.appData }}/config
+        - name: chromium-policies
+          configMap:
+            name: chromium-policies
         - name: config-legacy
           hostPath:
             type: DirectoryOrCreate


### PR DESCRIPTION
## Summary

- Upgrade base image to `beclab/harveyff-chromium:ae9a7fca-ls44` (Olares-patched ls44, remote main was 1.0.12)
- Force `PIXELFLUX_WAYLAND=false` and drop `UseOzonePlatform` on Olares One for X11 Selkies
- Add Chromium managed policies (ConfigMap) so New Tab and default search stay Google
- Switch startup/readiness probes to TCP socket on port 3000 (avoid HTTP 403 Unhealthy events)

## Test plan

- [x] `olares-cli chart lint chromium`
- [x] Deploy / upgrade on **olarestest001** via upload source (1.0.26 local test chart, same content) -> `running`; display OK on HTTPS
- [ ] Reviewer: upgrade from 1.0.12 on test market after merge; verify New Tab is Google and no probe 403 events

Made with [Cursor](https://cursor.com)