### PR TITLE
[UPDATE][steamheadless][1.0.43] Upgrade Steam Headless to non-root user, add Flatpak persistence and overlay networking 

### DIFF
--- a/steamheadless/Chart.yaml
+++ b/steamheadless/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: '0.2.0'
 description: description
 name: steamheadless
 type: application
-version: 1.0.36
+version: 1.0.43

--- a/steamheadless/OlaresManifest.yaml
+++ b/steamheadless/OlaresManifest.yaml
@@ -9,10 +9,13 @@ metadata:
   description: A Headless Steam Service
   icon: https://app.cdn.olares.com/appstore/steamheadless/icon.png
   appid: steamheadless
-  version: '1.0.36'
+  version: '1.0.43'
   title: Steam Headless
   categories:
   - Fun
+  - homelab
+  tags:
+  - gaming
 
 entrances:
 - name: steamheadless
@@ -38,6 +41,49 @@ entrances:
   authLevel: internal
   openMethod: window
   invisible: true
+overlayGateway:
+  enable: true
+  entrances:
+  - title: "Sunshine Web UI"
+    workload: steamheadless
+    port: 47990
+    protocol: tcp
+    description: "HTTPS interface for managing Sunshine settings, applications, and client pairing."
+  - title: "Moonlight HTTPS"
+    workload: steamheadless
+    port: 47984
+    protocol: tcp
+    description: "Secure Moonlight/GameStream endpoint for pairing, host discovery, and session negotiation."
+  - title: "Moonlight HTTP"
+    workload: steamheadless
+    port: 47989
+    protocol: tcp
+    description: "Moonlight/GameStream HTTP endpoint for host information and application discovery."
+  - title: Moonlight RTSP
+    workload: steamheadless
+    port: 48010
+    protocol: tcp
+    description: "TCP RTSP listener that establishes and negotiates a streaming session."
+  - title: "Video Stream"
+    workload: steamheadless
+    port: 47998
+    protocol: udp
+    description: "Carries the low-latency encoded video stream from Sunshine to Moonlight."
+  - title: "Control Stream"
+    workload: steamheadless
+    port: 47999
+    protocol: udp
+    description: "Carries real-time streaming control traffic between Moonlight and Sunshine."
+  - title: "Audio Stream"
+    workload: steamheadless
+    port: 48000
+    protocol: udp
+    description: "Carries the low-latency game and system audio stream from Sunshine to Moonlight."
+  - title: "Reserved Mic Audio"
+    workload: steamheadless
+    port: 48002
+    protocol: udp
+    description: "Reserved legacy GameStream port for client-to-host microphone audio, which current Sunshine normally does not use."
 ports:
 - name: tcp3
   host: steamheadless
@@ -113,12 +159,11 @@ spec:
     Root access
     Based on Debian Bookworm
   upgradeDescription: |
-    v1.0.36: Keep durable volumes on `appCache` (no appData migration); require control-plane (master) affinity; move `SUNSHINE_PASS` into Secret (`secretKeyRef`).
-
-    Storage: durable volumes c0/c1 moved from `appCache` to `appData`. On first start after upgrade, initContainers copy legacy appCache contents into appData when the destination is empty (markers: `.migration_from_appcache_c0_done`, `.migration_from_appcache_c1_done`). Old appCache data is left intact for rollback.
-
-    Update Chart Config
-    - Fix Moonlight auto discovery when change ip
+    **Changes**
+    - Updated Steam Headless version
+    - Runs as user UID 1000 instead of root for improved security.
+    - Added support for Flatpak and persistent Flatpak applications.
+    - Enabled overlay support for direct IP access.
 
   developer: Steam-Headless
   sourceCode: https://github.com/Steam-Headless/docker-steam-headless

--- a/steamheadless/i18n/en-US/OlaresManifest.yaml
+++ b/steamheadless/i18n/en-US/OlaresManifest.yaml
@@ -21,7 +21,9 @@ spec:
     Root access
     Based on Debian Bookworm
   upgradeDescription: |
-    v1.0.36: Keep durable volumes on `appCache` (no appData migration); require control-plane (master) affinity; move `SUNSHINE_PASS` into Secret (`secretKeyRef`).
+    **Changes**
+    - Updated Steam Headless version
+    - Runs as user UID 1000 instead of root for improved security.
+    - Added support for Flatpak and persistent Flatpak applications.
+    - Enabled overlay support for direct IP access.
 
-    Update Chart Config
-    - Fix Moonlight auto discovery when change ip

--- a/steamheadless/i18n/zh-CN/OlaresManifest.yaml
+++ b/steamheadless/i18n/zh-CN/OlaresManifest.yaml
@@ -21,7 +21,8 @@ spec:
     根权限
     基于 Debian Bookworm
   upgradeDescription: |
-    v1.0.36: 持久卷继续使用 `appCache`（不再迁移到 appData）；要求调度到 control-plane（master）；`SUNSHINE_PASS` 改为 Secret（`secretKeyRef`）。
-
-    更新安装包配置
-    - 修复 IP 变化后 Moonlight 自动发现异常
+    **变更内容**
+    - 更新了 Steam Headless 版本
+    - 现在以 UID 1000 用户身份运行，而非 root，以提升安全性
+    - 增加了对 Flatpak 及持久化 Flatpak 应用的支持
+    - 启用 Overlay 支持，实现直接 IP 访问

--- a/steamheadless/owners
+++ b/steamheadless/owners
@@ -1,8 +1,3 @@
 owners:
-- 'LittleLollipop'
-- 'TShentu'
-- 'hysyeah'
-- 'pengpeng'
-- 'harveyff'
-- 'zdf-org'
-- 'eball'
+  - username: '@beclab'
+    title: 'Olares'

--- a/steamheadless/templates/steam.yaml
+++ b/steamheadless/templates/steam.yaml
@@ -1,4 +1,5 @@
-﻿---
+﻿{{- $image := "docker.io/beclab/steam-headless:v0.1.19" -}}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -24,6 +25,7 @@ spec:
         kompose.version: 1.34.0 (HEAD)
       labels:
         io.kompose.service: steam-headless
+        applications.app.bytetrade.io/macvlan-init: "true"
     spec:
       affinity:
         nodeAffinity:
@@ -36,6 +38,32 @@ spec:
                 - linux
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
+      initContainers:
+        # The session moved from uid 0 to uid 1000, so the durable volumes have
+        # to follow. Guarded by ! -uid 1000 so re-runs cost a stat pass, and a
+        # fresh install (which scaffolds root-owned dirs) self-heals.
+        - name: init-chown-volumes
+          image: {{ $image }}
+          securityContext:
+            runAsUser: 0
+          command:
+            - sh
+            - -c
+            - |
+              for d in /chown-home /chown-games; do
+                n=$(find "$d" ! -uid 1000 -printf . 2>/dev/null | wc -c)
+                if [ "$n" -gt 0 ]; then
+                  echo "chown 1000:1000 on $n entries under $d"
+                  find "$d" ! -uid 1000 -exec chown -h 1000:1000 {} +
+                else
+                  echo "$d already uid 1000"
+                fi
+              done
+          volumeMounts:
+            - name: steam-headless-claim0
+              mountPath: /chown-home
+            - name: steam-headless-claim1
+              mountPath: /chown-games
       containers:
         - env:
             - name: NAME
@@ -51,9 +79,9 @@ spec:
             - name: DOCKER_RUNTIME
               value: nvidia
             - name: PUID
-              value: '0'
+              value: '1000'
             - name: PGID
-              value: '0'
+              value: '1000'
             - name: UMASK
               value: '000'
             - name: USER_PASSWORD
@@ -96,9 +124,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
-            - name: DBUS_SESSION_BUS_ADDRESS
-              value: unix:path=/run/dbus/session_bus_socket
-          image: docker.io/beclab/steam-headless:v0.1.16
+            - name: XDG_RUNTIME_DIR
+              value: /run/user/1000              
+          image: {{ $image }}
           livenessProbe:
             httpGet:
               path: /
@@ -167,9 +195,11 @@ spec:
                 - -c
                 - |
                   cat /dev/null > /usr/libexec/upowerd
-                  mkdir -p /run/dbus
-                  dbus-daemon --session --fork --nopidfile \
-                    --address=unix:path=/run/dbus/session_bus_socket || true
+                  mkdir -p /run/user/1000
+                  chown 1000:1000 /run/user/1000
+                  chmod 700 /run/user/1000
+                  grep -qxF 'XDG_RUNTIME_DIR=/run/user/1000' /etc/environment || \
+                    echo 'XDG_RUNTIME_DIR=/run/user/1000' >> /etc/environment
           securityContext:
             privileged: true
             runAsUser: 0
@@ -188,6 +218,18 @@ spec:
               mountPath: /dev/input/
             - name: dshm
               mountPath: /dev/shm
+            - name: flatpak-system-app
+              mountPath: /var/lib/flatpak/app
+            - name: flatpak-system-exports
+              mountPath: /var/lib/flatpak/exports
+            - name: flatpak-system-runtime
+              mountPath: /var/lib/flatpak/runtime
+            - name: supervisor-extras
+              mountPath: /etc/supervisor.d/accounts-daemon.ini
+              subPath: accounts-daemon.ini
+            - name: supervisor-extras
+              mountPath: /etc/supervisor.d/polkitd.ini
+              subPath: polkitd.ini
         {{- if and .Values.deviceName (eq .Values.deviceName "Olares One") }}
             - name: snd
               mountPath: /dev/snd
@@ -209,6 +251,21 @@ spec:
         - name: dshm
           emptyDir:
             medium: Memory
+        - name: flatpak-system-app
+          hostPath:
+            type: DirectoryOrCreate
+            path: {{ .Values.userspace.appCache }}/{{ .Release.Name }}/flatpak-system/app
+        - name: flatpak-system-exports
+          hostPath:
+            type: DirectoryOrCreate
+            path: {{ .Values.userspace.appCache }}/{{ .Release.Name }}/flatpak-system/exports
+        - name: flatpak-system-runtime
+          hostPath:
+            type: DirectoryOrCreate
+            path: {{ .Values.userspace.appCache }}/{{ .Release.Name }}/flatpak-system/runtime
+        - name: supervisor-extras
+          configMap:
+            name: steamheadless-supervisor-extras
     {{- if and .Values.deviceName (eq .Values.deviceName "Olares One") }}
         - name: snd
           hostPath:
@@ -299,3 +356,44 @@ spec:
       protocol: TCP
       port: 47990
       targetPort: 47990
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: steamheadless-supervisor-extras
+  namespace: {{ .Release.Namespace }}
+data:
+  polkitd.ini: |
+    [program:polkitd]
+    priority=17
+    autostart=true
+    autorestart=true
+    directory=/
+    user=root
+    command=/usr/lib/polkit-1/polkitd 
+    environment=HOME="/root",USER="root"
+    stopsignal=INT
+    stdout_logfile=/var/log/supervisor/polkitd.log
+    stdout_logfile_maxbytes=10MB
+    stdout_logfile_backups=7
+    stderr_logfile=/var/log/supervisor/polkitd.err.log
+    stderr_logfile_maxbytes=10MB
+    stderr_logfile_backups=7
+
+  accounts-daemon.ini: |
+    [program:accounts-daemon]
+    priority=20
+    autostart=true
+    autorestart=true
+    directory=/
+    user=root
+    command=/usr/libexec/accounts-daemon
+    environment=HOME="/root",USER="root"
+    stopsignal=INT
+    stdout_logfile=/var/log/supervisor/accounts-daemon.log
+    stdout_logfile_maxbytes=10MB
+    stdout_logfile_backups=7
+    stderr_logfile=/var/log/supervisor/accounts-daemon.err.log
+    stderr_logfile_maxbytes=10MB
+    stderr_logfile_backups=7


### PR DESCRIPTION
### App Title
steamheadless

### Description
- Updated Steam Headless version
- Runs as user UID 1000 instead of root for improved security.
- Added support for Flatpak and persistent Flatpak applications.
- Enabled overlay support for direct IP access.
 
### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`