### PR TITLE
[UPDATE][llamacppqwen3827bggufv3][1.0.1] llm-init v1.3.10, reasoning env, llama.cpp b10548

### DIFF
--- a/llamacppqwen3827bggufv3/Chart.yaml
+++ b/llamacppqwen3827bggufv3/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: b10454
+appVersion: b10548
 description: Qwen3.8-27B (GGUF UD-Q4_K_XL) served with llama.cpp + llm-init (GPU only)
 name: llamacppqwen3827bggufv3
 type: application
-version: 1.0.0
+version: 1.0.1

--- a/llamacppqwen3827bggufv3/OlaresManifest.yaml
+++ b/llamacppqwen3827bggufv3/OlaresManifest.yaml
@@ -7,9 +7,12 @@ metadata:
   description: "Qwen3.8-27B (GGUF UD-Q4_K_XL) served with llama.cpp."
   appid: llamacppqwen3827bggufv3
   title: Qwen3.8-27B (llama.cpp)
-  version: '1.0.0'
+  version: '1.0.1'
   categories:
     - AI
+    - models
+  tags:
+    - llm
 sharedEntrances:
   - name: llamacppqwen3827bggufv3
     host: sharedentrances-api
@@ -35,7 +38,9 @@ spec:
   onlyAdmin: true
   versionName: 'unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_XL'
   upgradeDescription: |
-    v1.0.0: first release. llama.cpp `server-cuda12-b10454`, llm-init v1.3.5. Unsloth Qwen3.8-27B UD-Q4_K_XL + mmproj, 102K context (`-c 104448`), MTP `--spec-draft-n-max 4`, GPU quota `23Gi`.
+    v1.0.1: Upgrade llm-init to v1.3.10; add non-editable MODEL_REASONING_EFFORT (low,medium,xhigh) and MODEL_REASONING_EFFORT_DEFAULT (xhigh); upgrade llama.cpp to server-cuda12-b10548; lower NVIDIA host-memory reservation (engine request 21Gi to 6Gi, requiredMemory 23Gi to 7Gi). GPU quota stays 23Gi.
+
+    v1.0.0: first release. llama.cpp server-cuda12-b10454, llm-init v1.3.5. Unsloth Qwen3.8-27B UD-Q4_K_XL + mmproj, 102K context (-c 104448), MTP --spec-draft-n-max 4, GPU quota 23Gi.
 
     Serves Unsloth Qwen3.8-27B GGUF (`qwen35` architecture) with vision projector.
   fullDescription: |
@@ -58,7 +63,7 @@ spec:
     First, Model Console downloads the model and gets it ready, then `llama.cpp` starts serving the model when it's ready. These two parts run separately but share files and progress info.
 
     **Stack**
-    - **llama.cpp** (`server-cuda12-b10454`): Runs the model and serves API requests (port 8081)
+    - **llama.cpp** (`server-cuda12-b10548`): Runs the model and serves API requests (port 8081)
     - **Model Console**: Downloads the model, shows progress, and provides the OpenAI API on port 8090, proxying to `llamacpp`.
 
     **Model Storage**
@@ -83,9 +88,9 @@ spec:
       requiredCpu: "1100m"
       requiredDisk: 50Mi
       limitedDisk: 500Gi
-      # Engine MEMORY_REQUEST 21Gi + llm-init <= requiredMemory 23Gi; MEMORY_LIMIT 30Gi + llm-init 2Gi <= limitedMemory 32Gi
+      # Engine MEMORY_REQUEST 6Gi + llm-init 256Mi <= requiredMemory 7Gi; MEMORY_LIMIT 30Gi + llm-init 2Gi <= limitedMemory 32Gi
       limitedMemory: "32Gi"
-      requiredMemory: "23Gi"
+      requiredMemory: "7Gi"
       requiredGPUMemory: "23Gi"
       limitedGPUMemory: "23Gi"
     - mode: nvidia-gb10
@@ -157,6 +162,27 @@ envs:
     - title: None
       value: none
     description:  "The model capabilities. Pick what your model supports, if no extra capabilities, pick None."
+  # Not editable: which levels exist is a fact of this model and this chat
+  # template, not a preference. The template raises on anything outside
+  # low / medium / xhigh, so an extra level would turn into a failed
+  # request for whichever client read the levels off the model card.
+  - envName: MODEL_REASONING_EFFORT
+    required: false
+    type: string
+    editable: false
+    applyOnChange: false
+    default: "low,medium,xhigh"
+    description:  "The reasoning_effort levels this model accepts, published on the model card so clients can read them instead of guessing."
+  # The level llama.cpp's template already uses when a request carries no
+  # reasoning_effort. It is published, never injected: nothing in the chain
+  # writes it into a request, so it has to match the engine's real default.
+  - envName: MODEL_REASONING_EFFORT_DEFAULT
+    required: false
+    type: string
+    editable: false
+    applyOnChange: false
+    default: "xhigh"
+    description:  "The level this model uses when a request does not ask for one."
   - envName: ENGINE_ARGS
     required: true
     default: "-c 104448 -ngl all -fa on -ctk q8_0 -ctv q8_0 --jinja -np 1 --spec-type draft-mtp --spec-draft-n-max 4"
@@ -197,7 +223,7 @@ envs:
     applyOnChange: false
   - envName: LLAMACPP_MEMORY_REQUEST
     required: true
-    default: "21Gi"
+    default: "6Gi"
     type: string
     editable: false
     applyOnChange: false

--- a/llamacppqwen3827bggufv3/i18n/en-US/OlaresManifest.yaml
+++ b/llamacppqwen3827bggufv3/i18n/en-US/OlaresManifest.yaml
@@ -3,6 +3,10 @@ metadata:
   title: Qwen3.8-27B (llama.cpp)
 
 spec:
+  upgradeDescription: |
+    v1.0.1: Upgrade llm-init to v1.3.10; add non-editable MODEL_REASONING_EFFORT (low,medium,xhigh) and MODEL_REASONING_EFFORT_DEFAULT (xhigh); upgrade llama.cpp to server-cuda12-b10548; lower NVIDIA host-memory reservation (engine request 21Gi to 6Gi, requiredMemory 23Gi to 7Gi). GPU quota stays 23Gi.
+
+    v1.0.0: first release. llama.cpp server-cuda12-b10454, llm-init v1.3.5. Unsloth Qwen3.8-27B UD-Q4_K_XL + mmproj, 102K context (-c 104448), MTP --spec-draft-n-max 4, GPU quota 23Gi.
   fullDescription: |
     **Model Overview**
     Qwen3.8-27B is a vision-language model from the Qwen series (Alibaba), built on the Qwen3.5 architecture. It supports thinking, tool-calling, and native image/video understanding, with a 256K context window. This app serves the `UD-Q4_K_XL` GGUF build from `unsloth/Qwen3.8-27B-GGUF` via llama.cpp.
@@ -23,7 +27,7 @@ spec:
     First, Model Console downloads the model and gets it ready, then `llama.cpp` starts serving the model when it's ready. These two parts run separately but share files and progress info.
 
     **Stack**
-    - **llama.cpp** (`server-cuda12-b10454`): Runs the model and serves API requests (port 8081)
+    - **llama.cpp** (`server-cuda12-b10548`): Runs the model and serves API requests (port 8081)
     - **Model Console**: Downloads the model, shows progress, and provides the OpenAI API on port 8090, proxying to `llamacpp`.
 
     **Model Storage**

--- a/llamacppqwen3827bggufv3/i18n/zh-CN/OlaresManifest.yaml
+++ b/llamacppqwen3827bggufv3/i18n/zh-CN/OlaresManifest.yaml
@@ -3,6 +3,10 @@ metadata:
   title: Qwen3.8-27B (llama.cpp)
 
 spec:
+  upgradeDescription: |
+    v1.0.1: 升级 llm-init 至 v1.3.10；新增不可编辑的 MODEL_REASONING_EFFORT（low,medium,xhigh）与 MODEL_REASONING_EFFORT_DEFAULT（xhigh）；升级 llama.cpp 至 server-cuda12-b10548；下调 NVIDIA 主机内存预留（引擎 request 21Gi 至 6Gi，requiredMemory 23Gi 至 7Gi）。显存配额仍为 23Gi。
+
+    v1.0.0: 首发。llama.cpp server-cuda12-b10454，llm-init v1.3.5。Unsloth Qwen3.8-27B UD-Q4_K_XL + mmproj，102K 上下文（-c 104448），MTP --spec-draft-n-max 4，显存配额 23Gi。
   fullDescription: |
     **模型简介**
     Qwen3.8-27B 是阿里巴巴 Qwen 系列的视觉语言模型，基于 Qwen3.5 架构，开箱即用支持思考、工具调用与原生图像/视频理解，上下文窗口 256K。本应用通过 llama.cpp 运行 `unsloth/Qwen3.8-27B-GGUF` 的 `UD-Q4_K_XL` GGUF 量化版本。
@@ -23,7 +27,7 @@ spec:
     首先，Model Console 下载并准备模型，然后 `llama.cpp` 在模型准备好后启动服务。这两个部分独立运行但共享文件与进度信息。
 
     **技术栈说明**
-    - **llama.cpp**（`server-cuda12-b10454`）：运行模型并通过 8081 端口提供 API 服务
+    - **llama.cpp**（`server-cuda12-b10548`）：运行模型并通过 8081 端口提供 API 服务
     - **Model Console**：下载模型，展示进度，并通过 8090 端口提供 OpenAI API，代理到 `llamacpp`
 
     **模型存储**

--- a/llamacppqwen3827bggufv3/owners
+++ b/llamacppqwen3827bggufv3/owners
@@ -1,4 +1,4 @@
-owners:
+﻿owners:
 - 'LittleLollipop'
 - 'TShentu'
 - 'hysyeah'

--- a/llamacppqwen3827bggufv3/templates/llamacpp.yaml
+++ b/llamacppqwen3827bggufv3/templates/llamacpp.yaml
@@ -10,7 +10,7 @@
 {{- $hfEndpoint := $oe.HF_ENDPOINT | default "" -}}
 {{- $hfToken := $oe.HF_TOKEN | default "" -}}
 {{- $cpuRequest := trim ($oe.LLAMACPP_CPU_REQUEST | default "200m") -}}
-{{- $memRequest := trim ($oe.LLAMACPP_MEMORY_REQUEST | default "21Gi") -}}
+{{- $memRequest := trim ($oe.LLAMACPP_MEMORY_REQUEST | default "6Gi") -}}
 {{- $cpuLimit := trim ($oe.LLAMACPP_CPU_LIMIT | default "6") -}}
 {{- $memLimit := trim ($oe.LLAMACPP_MEMORY_LIMIT | default "30Gi") -}}
 {{- $gpuType := .Values.gpu | default "" -}}
@@ -73,7 +73,7 @@ spec:
             defaultMode: 0555
       containers:
         - name: llamacpp
-          image: docker.io/beclab/ggml-org-llama.cpp:server-cuda12-b10454
+          image: docker.io/beclab/ggml-org-llama.cpp:server-cuda12-b10548
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh", "/llm-init/wrappers/llamacpp.sh"]
           env:

--- a/llamacppqwen3827bggufv3/templates/llm-init.yaml
+++ b/llamacppqwen3827bggufv3/templates/llm-init.yaml
@@ -42,6 +42,12 @@
 {{- if not $gpuType -}}
 {{- $gpuType = .Values.GPU.Type | default "nvidia" -}}
 {{- end -}}
+{{- /* The reasoning_effort levels this model's chat template accepts, and
+       the one it uses when a request names none. llm-init turns these into
+       the card's parameter rule, which is what Router publishes; unknown
+       levels fail at boot rather than reaching a client as options. */ -}}
+{{- $reasoningEffort := $oe.MODEL_REASONING_EFFORT | default "" -}}
+{{- $reasoningEffortDefault := $oe.MODEL_REASONING_EFFORT_DEFAULT | default "" -}}
 {{- $engineArgs := $oe.ENGINE_ARGS | default "" -}}
 {{- /* Keep ENGINE_ARGS symmetric with the engine Deployment: embedding
        mode must seed --embedding onto the model card / handoff, or the
@@ -109,7 +115,8 @@ spec:
           # v1.2.4 defaults to the stable LFS download path (hf_xet disabled
           # unless HF_ENABLE_XET=true); LFS streams each file to disk with a
           # bounded RAM footprint, avoiding the hf_xet OOM (huggingface_hub#3300).
-          image: docker.io/beclab/llm-init:v1.3.5
+          # v1.3.10 reads MODEL_REASONING_EFFORT.
+          image: docker.io/beclab/llm-init:v1.3.10
           imagePullPolicy: IfNotPresent
           env:
             - name: ENGINE_KIND
@@ -123,6 +130,14 @@ spec:
 {{- if $modelSupports }}
             - name: MODEL_SUPPORTS
               value: "{{ $modelSupports }}"
+{{- end }}
+{{- if $reasoningEffort }}
+            - name: MODEL_REASONING_EFFORT
+              value: "{{ $reasoningEffort }}"
+{{- end }}
+{{- if $reasoningEffortDefault }}
+            - name: MODEL_REASONING_EFFORT_DEFAULT
+              value: "{{ $reasoningEffortDefault }}"
 {{- end }}
             - name: ENGINE_ARGS
               value: "{{ $engineArgs }}"


### PR DESCRIPTION
## Summary

- Bump chart from beclab main 1.0.0 to 1.0.1 for test market (market.test)
- Upgrade llm-init to v1.3.10
- Add non-editable env vars MODEL_REASONING_EFFORT=low,medium,xhigh and MODEL_REASONING_EFFORT_DEFAULT=xhigh
- Upgrade llama.cpp engine image to beclab/ggml-org-llama.cpp:server-cuda12-b10548
- Lower NVIDIA host-memory reservation (engine request 21Gi to 6Gi, requiredMemory 23Gi to 7Gi)

## Test plan

- [ ] GitBot checks pass
- [ ] Install from market.test on olarestest001
- [ ] Model download completes and Model Console reaches ready
- [ ] Router lists reasoning_effort options on /v1/models