### PR TITLE
[UPDATE][gitea][1.0.22] Upgrade to 1.27.2, security fixes, OpenResty upload limit 512MB

### DIFF
--- a/gitea/Chart.yaml
+++ b/gitea/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: "1.27.0"
+appVersion: "1.27.2"
 description: The goal of this project is to make the easiest, fastest, and most painless way of setting up a self-hosted Git service.
 name: gitea
 type: application
-version: 1.0.17
+version: 1.0.22

--- a/gitea/OlaresManifest.yaml
+++ b/gitea/OlaresManifest.yaml
@@ -10,10 +10,15 @@ metadata:
   description: Git with a cup of tea!
   icon: https://app.cdn.olares.com/appstore/gitea/icon.png
   appid: gitea
-  version: '1.0.17'
+  version: '1.0.22'
   title: Gitea
   categories:
-  - Developer Tools  
+  - Developer Tools
+  - workspace
+  - developer
+  tags:
+  - coding
+  - collaboration
 
 entrances:
 - name: gitea
@@ -29,21 +34,15 @@ permission:
   userData:
   - Home
 spec:
-  versionName: '1.27.0'
+  versionName: '1.27.2'
   upgradeDescription: |
-    Switch the reverse-proxy image from Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) to the official OpenResty image `openresty/openresty:1.29.2.5-bookworm-fat`.
+    Upgrade Gitea to 1.27.2 (`gitea/gitea:1.27.2`), the second 1.27 patch. It includes security fixes for collaborator access and HTTP signatures, external/markup rendering, pull_request_target reusable workflows, WebAuthn/OpenID second-factor checks, and API token scope; mermaid is updated to v11.16.1.
 
-    Align nginx config mounts and log paths with the official image layout (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`), and drop Bitnami-specific `OPENRESTY_CONF_FILE` wiring.
+    Also includes Actions, LFS, package, and UI fixes (workflow_dispatch inputs kept as strings, safer concurrent LFS uploads, archive downloads under a sub-path, and more). Details: https://blog.gitea.com/release-of-1.27.2/
 
-    Upgrade Gitea to 1.27.0 (`gitea/gitea:1.27.0`).
+    Raise the OpenResty reverse-proxy upload limit to 512MB (`client_max_body_size 512m`) so web uploads, git HTTP push, and typical LFS objects are not rejected with HTTP 413 after the official OpenResty default of 1MB.
 
-    Switch uid env to official `USER_UID` / `USER_GID` (replacing linuxserver-style `PUID` / `PGID`).
-
-    Move `GITEA__database__PASSWD` into a Kubernetes Secret and inject via `secretKeyRef`.
-
-    Drop legacy `sysVersion >= 1.12.3` appData path branching; always use `appData/data` (Olares minimum 1.12.6).
-
-    Remove unused empty `gitea-config` ConfigMap.
+    Roll the giteaproxy Deployment when the nginx ConfigMap changes (`checksum/nginx-config`), because a `subPath` mount does not pick up in-place ConfigMap updates.
 
   featuredImage: https://app.cdn.olares.com/appstore/gitea/1.webp
   promoteImage:

--- a/gitea/i18n/en-US/OlaresManifest.yaml
+++ b/gitea/i18n/en-US/OlaresManifest.yaml
@@ -37,16 +37,10 @@ spec:
     - Gitea provides interfaces in multiple languages, catering to users globally and promoting internationalization and localization.
 
   upgradeDescription: |
-    Switch the reverse-proxy image from Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) to the official OpenResty image `openresty/openresty:1.29.2.5-bookworm-fat`.
+    Upgrade Gitea to 1.27.2 (`gitea/gitea:1.27.2`), the second 1.27 patch. It includes security fixes for collaborator access and HTTP signatures, external/markup rendering, pull_request_target reusable workflows, WebAuthn/OpenID second-factor checks, and API token scope; mermaid is updated to v11.16.1.
 
-    Align nginx config mounts and log paths with the official image layout (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`), and drop Bitnami-specific `OPENRESTY_CONF_FILE` wiring.
+    Also includes Actions, LFS, package, and UI fixes (workflow_dispatch inputs kept as strings, safer concurrent LFS uploads, archive downloads under a sub-path, and more). Details: https://blog.gitea.com/release-of-1.27.2/
 
-    Upgrade Gitea to 1.27.0 (`gitea/gitea:1.27.0`).
+    Raise the OpenResty reverse-proxy upload limit to 512MB (`client_max_body_size 512m`) so web uploads, git HTTP push, and typical LFS objects are not rejected with HTTP 413 after the official OpenResty default of 1MB.
 
-    Switch uid env to official `USER_UID` / `USER_GID` (replacing linuxserver-style `PUID` / `PGID`).
-
-    Move `GITEA__database__PASSWD` into a Kubernetes Secret and inject via `secretKeyRef`.
-
-    Drop legacy `sysVersion >= 1.12.3` appData path branching; always use `appData/data` (Olares minimum 1.12.6).
-
-    Remove unused empty `gitea-config` ConfigMap.
+    Roll the giteaproxy Deployment when the nginx ConfigMap changes (`checksum/nginx-config`), because a `subPath` mount does not pick up in-place ConfigMap updates.

--- a/gitea/i18n/zh-CN/OlaresManifest.yaml
+++ b/gitea/i18n/zh-CN/OlaresManifest.yaml
@@ -27,16 +27,10 @@ spec:
     多语言支持： Gitea 提供多种语言界面，适应全球范围内的用户，促进了国际化和本地化。
 
   upgradeDescription: |
-    将反向代理镜像从 Bitnami OpenResty（`beclab/aboveos-bitnami-openresty:1.25.3-2`）切换为官方 OpenResty 镜像 `openresty/openresty:1.29.2.5-bookworm-fat`。
+    升级 Gitea 至 1.27.2（`gitea/gitea:1.27.2`），1.27 系列第二个补丁版本。包含协作者权限与 HTTP 签名、外部/标记渲染、pull_request_target 可复用工作流、WebAuthn/OpenID 第二因素校验、API Token 范围等安全修复，并将 mermaid 更新到 v11.16.1。
 
-    同步调整 nginx 配置挂载与日志路径以匹配官方镜像布局（`/etc/nginx/conf.d/default.conf`、`/usr/local/openresty/nginx/logs/...`），并移除 Bitnami 专用的 `OPENRESTY_CONF_FILE` 配置。
+    同时修复 Actions、LFS、软件包与界面问题（workflow_dispatch 输入保持字符串、并发 LFS 上传更安全、子路径下归档下载等）。详见 https://blog.gitea.com/release-of-1.27.2/
 
-    升级 Gitea 至 1.27.0（`gitea/gitea:1.27.0`）。
+    将 OpenResty 反向代理上传限制提高到 512MB（`client_max_body_size 512m`），避免切换官方 OpenResty 后因默认 1MB 限制导致网页上传、Git HTTP push、常规 LFS 对象返回 HTTP 413。
 
-    将 uid 环境变量改为官方 `USER_UID` / `USER_GID`（替换 linuxserver 风格的 `PUID` / `PGID`）。
-
-    将 `GITEA__database__PASSWD` 移入 Kubernetes Secret，并通过 `secretKeyRef` 注入。
-
-    移除遗留的 `sysVersion >= 1.12.3` appData 路径分支；统一使用 `appData/data`（Olares 最低版本 1.12.6）。
-
-    删除未使用的空 `gitea-config` ConfigMap。
+    nginx ConfigMap 变更时通过 `checksum/nginx-config` 滚动重建 giteaproxy（`subPath` 挂载不会随 ConfigMap 原地更新）。

--- a/gitea/owners
+++ b/gitea/owners
@@ -1,7 +1,3 @@
 owners:
-- 'LittleLollipop'
-- 'TShentu'
-- 'hysyeah'
-- 'pengpeng'
-- 'harveyff'
-- 'zdf-org'
+  - username: '@beclab'
+    title: 'Olares'

--- a/gitea/templates/_helpers.tpl
+++ b/gitea/templates/_helpers.tpl
@@ -1,0 +1,40 @@
+{{/*
+Nginx reverse proxy config for giteaproxy (clientproxy).
+Referenced by clientproxy.yaml; checksum in Deployment triggers rollout on change.
+*/}}
+{{- define "gitea.nginx.conf" -}}
+server {
+    listen 8080;
+    access_log /usr/local/openresty/nginx/logs/access.log;
+    error_log /usr/local/openresty/nginx/logs/error.log;
+
+    # Official OpenResty defaults to 1m; Gitea docs recommend 512M
+    # so web uploads, git HTTP push, and typical LFS objects are not 413'd.
+    client_max_body_size 512m;
+
+    proxy_connect_timeout 30s;
+    proxy_send_timeout 60s;
+    proxy_read_timeout 300s;
+    proxy_set_header host $host;
+    proxy_set_header x-forwarded-host $http_host;
+    proxy_http_version 1.1;
+    proxy_set_header upgrade $http_upgrade;
+    proxy_set_header connection "upgrade";
+
+    location / {
+        proxy_hide_header Access-Control-Allow-Origin;
+        proxy_hide_header Access-Control-Allow-Methods;
+        proxy_hide_header Access-Control-Allow-Headers;
+        add_header Access-Control-Allow-Origin *;
+        add_header Access-Control-Allow-Methods GET,POST,PUT,DELETE,OPTIONS;
+        add_header Access-Control-Allow-Headers "deviceType,token, authorization, content-type,x-csrftoken";
+        if ($request_method = 'OPTIONS') {
+            add_header Access-Control-Allow-Origin *;
+            add_header Access-Control-Allow-Methods GET,POST,PUT,DELETE,OPTIONS;
+            add_header Access-Control-Allow-Headers "deviceType,token, authorization, content-type,x-csrftoken";
+            return 204;
+        }
+        proxy_pass http://gitea-svc:3000;
+    }
+}
+{{- end -}}

--- a/gitea/templates/clientproxy.yaml
+++ b/gitea/templates/clientproxy.yaml
@@ -6,37 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   nginx.conf: |
-    server {
-        listen 8080;
-        access_log /usr/local/openresty/nginx/logs/access.log;
-        error_log /usr/local/openresty/nginx/logs/error.log;
-
-        proxy_connect_timeout 30s;
-        proxy_send_timeout 60s;
-        proxy_read_timeout 300s;
-        proxy_set_header host $host;
-        proxy_set_header x-forwarded-host $http_host;
-        proxy_http_version 1.1;
-        proxy_set_header upgrade $http_upgrade;
-        proxy_set_header connection "upgrade";
-
-     
-        location / {
-            proxy_hide_header Access-Control-Allow-Origin;
-            proxy_hide_header Access-Control-Allow-Methods;
-            proxy_hide_header Access-Control-Allow-Headers;
-            add_header Access-Control-Allow-Origin *;
-            add_header Access-Control-Allow-Methods GET,POST,PUT,DELETE,OPTIONS;
-            add_header Access-Control-Allow-Headers "deviceType,token, authorization, content-type,x-csrftoken";
-            if ($request_method = 'OPTIONS') {
-                add_header Access-Control-Allow-Origin *;
-                add_header Access-Control-Allow-Methods GET,POST,PUT,DELETE,OPTIONS;
-                add_header Access-Control-Allow-Headers "deviceType,token, authorization, content-type,x-csrftoken";
-                return 204;
-            }
-            proxy_pass http://gitea-svc:3000;
-        }
-    }
+{{ include "gitea.nginx.conf" . | indent 4 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -57,6 +27,8 @@ spec:
       labels:
         io.kompose.network/chrome-default: "true"
         io.kompose.service: giteaweb
+      annotations:
+        checksum/nginx-config: {{ include "gitea.nginx.conf" . | sha256sum }}
     spec:
       volumes:
         - name: nginx-config

--- a/gitea/templates/deployment.yaml
+++ b/gitea/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: gitea
-          image: "docker.io/gitea/gitea:1.27.0"
+          image: "docker.io/gitea/gitea:1.27.2"
           ports:
             - containerPort: 3000
             - containerPort: 22


### PR DESCRIPTION
### App Title
gitea

### Description

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`