### PR TITLE
[UPDATE][medusa][1.0.13] Raise OpenResty reverse-proxy upload limit to 100m for product image uploads

### DIFF
--- a/medusa/Chart.yaml
+++ b/medusa/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 2.12.5
 description: Medusa
 name: medusa
 type: application
-version: 1.0.9
+version: 1.0.13

--- a/medusa/OlaresManifest.yaml
+++ b/medusa/OlaresManifest.yaml
@@ -9,11 +9,14 @@ metadata:
   description: The world's most flexible commerce platform.
   icon: https://app.cdn.olares.com/appstore/medusa/icon.png
   appid: medusa
-  version: "1.0.9"
+  version: "1.0.13"
   title: Medusa
   categories:
-
-    - Productivity_v112
+  - Productivity_v112
+  - workspace
+  tags:
+  - ecommerce
+  - website-builder
 spec:
   versionName: "2.12.5"
   promoteImage:
@@ -33,6 +36,8 @@ spec:
     - Scalable Business Support : It runs stably for both small-scale sales at the startup stage and large-scale operations with thousands of daily orders and multi-store fulfillment. It ensures smooth business growth and prevents system freezes or malfunctions caused by business expansion.
 
   upgradeDescription: |
+    Raise the OpenResty reverse-proxy upload limit to `client_max_body_size 100m` so product image uploads are not rejected with HTTP 413 (official OpenResty defaults to 1m). Roll the medusa Deployment when the nginx ConfigMap changes (`checksum/nginx-config`), because a `subPath` mount does not pick up in-place ConfigMap updates.
+
     Switch the reverse-proxy image from Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) to the official OpenResty image `openresty/openresty:1.29.2.5-bookworm-fat`.
 
     Align nginx config mounts and log paths with the official image layout (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`), and drop Bitnami-specific `OPENRESTY_CONF_FILE` wiring.

--- a/medusa/i18n/en-US/OlaresManifest.yaml
+++ b/medusa/i18n/en-US/OlaresManifest.yaml
@@ -13,6 +13,8 @@ spec:
     - Scalable Business Support : It runs stably for both small-scale sales at the startup stage and large-scale operations with thousands of daily orders and multi-store fulfillment. It ensures smooth business growth and prevents system freezes or malfunctions caused by business expansion.
 
   upgradeDescription: |
+    Raise the OpenResty reverse-proxy upload limit to `client_max_body_size 100m` so product image uploads are not rejected with HTTP 413 (official OpenResty defaults to 1m). Roll the medusa Deployment when the nginx ConfigMap changes (`checksum/nginx-config`), because a `subPath` mount does not pick up in-place ConfigMap updates.
+
     Switch the reverse-proxy image from Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) to the official OpenResty image `openresty/openresty:1.29.2.5-bookworm-fat`.
 
     Align nginx config mounts and log paths with the official image layout (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`), and drop Bitnami-specific `OPENRESTY_CONF_FILE` wiring.

--- a/medusa/i18n/zh-CN/OlaresManifest.yaml
+++ b/medusa/i18n/zh-CN/OlaresManifest.yaml
@@ -13,6 +13,8 @@ spec:
     - 可扩展业务支持：适用于小型销售起步阶段和大规模运营阶段，具备数千个每日订单和多店铺履行能力，确保业务平稳增长，防止因业务扩展导致的系统冻结或故障。
 
   upgradeDescription: |
+    将 OpenResty 反向代理上传限制提升为 `client_max_body_size 100m`，避免商品图片上传因默认 1m 限制返回 HTTP 413。nginx ConfigMap 变更时通过 `checksum/nginx-config` 滚动重建 medusa Deployment（`subPath` 挂载不会随 ConfigMap 原地更新）。
+
     将反向代理镜像从 Bitnami OpenResty（`beclab/aboveos-bitnami-openresty:1.25.3-2`）切换为官方 OpenResty 镜像 `openresty/openresty:1.29.2.5-bookworm-fat`。
 
     同步调整 nginx 配置挂载与日志路径以匹配官方镜像布局（`/etc/nginx/conf.d/default.conf`、`/usr/local/openresty/nginx/logs/...`），并移除 Bitnami 专用的 `OPENRESTY_CONF_FILE` 配置。

--- a/medusa/owners
+++ b/medusa/owners
@@ -1,8 +1,3 @@
 owners:
-- "LittleLollipop"
-- "TShentu"
-- "hysyeah"
-- "pengpeng"
-- "harveyff"
-- "zdf-org"
-- "aby913"
+  - username: '@beclab'
+    title: 'Olares'

--- a/medusa/templates/_helpers.tpl
+++ b/medusa/templates/_helpers.tpl
@@ -1,0 +1,41 @@
+{{/*
+Nginx reverse proxy config for the medusa sidecar.
+Referenced by deployment.yaml; checksum in Deployment triggers rollout on change.
+*/}}
+{{- define "medusa.nginx.conf" -}}
+server {
+
+  listen 8080;
+
+  absolute_redirect off;
+
+  access_log /usr/local/openresty/nginx/logs/access.log;
+  error_log /usr/local/openresty/nginx/logs/error.log;
+
+  # Official OpenResty defaults to 1m; product image uploads need more.
+  client_max_body_size 100m;
+
+  proxy_connect_timeout 30s;
+  proxy_send_timeout 60s;
+  proxy_read_timeout 300s;
+  proxy_set_header host $host;
+  proxy_set_header x-forwarded-host $http_host;
+  proxy_http_version 1.1;
+  proxy_set_header upgrade $http_upgrade;
+  proxy_set_header connection "upgrade";
+
+  location = / {
+    return 302 /app/;
+  }
+
+  location / {
+    proxy_hide_header Access-Control-Allow-Origin;
+    proxy_hide_header Access-Control-Allow-Methods;
+    proxy_hide_header Access-Control-Allow-Headers;
+    add_header Access-Control-Allow-Origin *;
+    add_header Access-Control-Allow-Methods GET,POST,PUT,DELETE,OPTIONS;
+
+    proxy_pass http://localhost:9000;
+  }
+}
+{{- end -}}

--- a/medusa/templates/deployment.yaml
+++ b/medusa/templates/deployment.yaml
@@ -1,39 +1,7 @@
 apiVersion: v1
 data:
   nginx.conf: |
-    server {
-
-      listen 8080;
-
-      absolute_redirect off;
-
-      access_log /usr/local/openresty/nginx/logs/access.log;
-      error_log /usr/local/openresty/nginx/logs/error.log;
-
-      proxy_connect_timeout 30s;
-      proxy_send_timeout 60s;
-      proxy_read_timeout 300s;
-      proxy_set_header host $host;
-      proxy_set_header x-forwarded-host $http_host;
-      proxy_http_version 1.1;
-      proxy_set_header upgrade $http_upgrade;
-      proxy_set_header connection "upgrade";
-
-      location = / {
-        return 302 /app/;
-      }
-
-      location / {
-        proxy_hide_header Access-Control-Allow-Origin;
-        proxy_hide_header Access-Control-Allow-Methods;
-        proxy_hide_header Access-Control-Allow-Headers;
-        add_header Access-Control-Allow-Origin *;
-        add_header Access-Control-Allow-Methods GET,POST,PUT,DELETE,OPTIONS;
-
-        proxy_pass http://localhost:9000;
-      }
-    }
-
+{{ include "medusa.nginx.conf" . | indent 4 }}
 kind: ConfigMap
 metadata:
   name: nginx-config
@@ -57,6 +25,8 @@ spec:
     metadata:
       labels:
         app: medusa
+      annotations:
+        checksum/nginx-config: {{ include "medusa.nginx.conf" . | sha256sum }}
     spec:
       containers:
         - name: nginx


### PR DESCRIPTION
### App Title
medusa

### Description

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`