### PR TITLE
[UPDATE][ollamallmbasev3][1.3.17] Upgrade Ollama from v0.32.15 to v0.33.1. Chart 1.3.17.

### DIFF
--- a/ollamallmbasev3/Chart.yaml
+++ b/ollamallmbasev3/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 0.32.15
+appVersion: 0.33.1
 description: Generic Ollama + llm-init base; the model is supplied at install time via env
 name: ollamallmbasev3
 type: application
-version: 1.3.16
+version: 1.3.17

--- a/ollamallmbasev3/OlaresManifest.yaml
+++ b/ollamallmbasev3/OlaresManifest.yaml
@@ -7,7 +7,7 @@ metadata:
   description: "Generic Ollama engine base. Pick any Ollama library model at install via env."
   appid: ollamallmbasev3
   title: Ollama Engine Base
-  version: '1.3.16'
+  version: '1.3.17'
   categories:
     - AI
   tags:
@@ -35,58 +35,31 @@ workloadReplicas:
   llminit: 1
 spec:
   onlyAdmin: true
-  versionName: '0.32.15'
+  versionName: '0.33.1'
   upgradeDescription: |
-    Upgrade Ollama from v0.32.12 to v0.32.15. Chart 1.3.16.
+    Upgrade Ollama from v0.32.15 to v0.33.1. Chart 1.3.17.
 
     **What's Changed** (relevant to Olares)
+
+    v0.33.1
+    - MLX: Qwen3.8 Flash Next support
+    - MLX and llama.cpp updates
+    - mlxrunner: structured output support
+    - mlxrunner: avoid Metal GPU timeouts when loading models from slow storage
+
+    v0.33.0
+    - Fixed a hang when agent clients cancel long prefills
+    - Prefill restore points now survive cancellation, so retries resume instead of restarting from scratch
+    - Resumed prefills no longer record incomplete restore points (recurrent-layer models no longer reprocess from zero)
+    - Disabled Claude Code's "tokens left" system message, which broke the KV cache on every request
+    - Fixed Linux/Windows default packaging broken by macOS-specific assumptions
+    - MLX dependency update
 
     v0.32.15
     - Caches resolved model metadata between requests, cutting time-to-first-token by roughly half
     - Fixes chat/generate wedging after a mid-stream parser error
     - Qwen 3.8 system messages are normalized so non-leading system messages are handled consistently
     - MLX and llama.cpp dependency updates
-
-    v0.32.14
-    - Transcode WebP images for llama-server (vision)
-    - Qwen renderer: tolerate non-leading system messages
-
-    v0.32.13
-    - Qwen 3.8: support developer instructions (agent / Codex-style developer role)
-
-    v0.32.12
-    - Added Qwen 3.8 27B model support (`qwen3.8:27b`)
-    - Apple Silicon optimizations for coding agents and repeated tasks
-
-    v0.32.11
-    - `ollama launch dsh` supports DeepSeek Harness
-    - `ollama launch muse` supports Muse Code
-    - OpenAI-compatible Responses API web search
-    - Muse Glimmer template updates
-
-    v0.32.10
-    - Default `repeat_penalty` is 1.0 (off) instead of 1.1
-    - Faster prefill on NVFP4 MLX models
-    - Fixed blob verification skipped when OCI config and layer share a digest
-
-    v0.32.9
-    - Added Nemotron 3 architecture (NVIDIA Nemotron 3.5 Lightning MoE support)
-    - Fixed Muse Glimmer function-calling parser boundary condition
-
-    v0.32.8
-    - Muse Glimmer now supported on NVIDIA, AMD, and additional platforms
-
-    v0.32.6
-    - `/v1/chat/completions` streaming matches OpenAI wire format (`role` on first chunk only, `finish_reason` and usage in separate chunks)
-    - Truncated responses report `finish_reason: "length"` instead of `"tool_calls"`
-
-    v0.32.4
-    - Fixed Qwen3 MoE decoding for differently-quantized experts
-
-    v0.32.3
-    - Fixed model downloads that stall before the first byte
-    - Fixed GLM tool calls silently dropped at end of generation
-    - Updated llama.cpp and MLX engines
 
     For detailed release notes, visit:
     https://github.com/ollama/ollama/releases

--- a/ollamallmbasev3/i18n/en-US/OlaresManifest.yaml
+++ b/ollamallmbasev3/i18n/en-US/OlaresManifest.yaml
@@ -4,56 +4,29 @@ metadata:
 
 spec:
   upgradeDescription: |
-    Upgrade Ollama from v0.32.12 to v0.32.15. Chart 1.3.16.
+    Upgrade Ollama from v0.32.15 to v0.33.1. Chart 1.3.17.
 
     **What's Changed** (relevant to Olares)
+
+    v0.33.1
+    - MLX: Qwen3.8 Flash Next support
+    - MLX and llama.cpp updates
+    - mlxrunner: structured output support
+    - mlxrunner: avoid Metal GPU timeouts when loading models from slow storage
+
+    v0.33.0
+    - Fixed a hang when agent clients cancel long prefills
+    - Prefill restore points now survive cancellation, so retries resume instead of restarting from scratch
+    - Resumed prefills no longer record incomplete restore points (recurrent-layer models no longer reprocess from zero)
+    - Disabled Claude Code's "tokens left" system message, which broke the KV cache on every request
+    - Fixed Linux/Windows default packaging broken by macOS-specific assumptions
+    - MLX dependency update
 
     v0.32.15
     - Caches resolved model metadata between requests, cutting time-to-first-token by roughly half
     - Fixes chat/generate wedging after a mid-stream parser error
     - Qwen 3.8 system messages are normalized so non-leading system messages are handled consistently
     - MLX and llama.cpp dependency updates
-
-    v0.32.14
-    - Transcode WebP images for llama-server (vision)
-    - Qwen renderer: tolerate non-leading system messages
-
-    v0.32.13
-    - Qwen 3.8: support developer instructions (agent / Codex-style developer role)
-
-    v0.32.12
-    - Added Qwen 3.8 27B model support (`qwen3.8:27b`)
-    - Apple Silicon optimizations for coding agents and repeated tasks
-
-    v0.32.11
-    - `ollama launch dsh` supports DeepSeek Harness
-    - `ollama launch muse` supports Muse Code
-    - OpenAI-compatible Responses API web search
-    - Muse Glimmer template updates
-
-    v0.32.10
-    - Default `repeat_penalty` is 1.0 (off) instead of 1.1
-    - Faster prefill on NVFP4 MLX models
-    - Fixed blob verification skipped when OCI config and layer share a digest
-
-    v0.32.9
-    - Added Nemotron 3 architecture (NVIDIA Nemotron 3.5 Lightning MoE support)
-    - Fixed Muse Glimmer function-calling parser boundary condition
-
-    v0.32.8
-    - Muse Glimmer now supported on NVIDIA, AMD, and additional platforms
-
-    v0.32.6
-    - `/v1/chat/completions` streaming matches OpenAI wire format (`role` on first chunk only, `finish_reason` and usage in separate chunks)
-    - Truncated responses report `finish_reason: "length"` instead of `"tool_calls"`
-
-    v0.32.4
-    - Fixed Qwen3 MoE decoding for differently-quantized experts
-
-    v0.32.3
-    - Fixed model downloads that stall before the first byte
-    - Fixed GLM tool calls silently dropped at end of generation
-    - Updated llama.cpp and MLX engines
 
     For detailed release notes, visit:
     https://github.com/ollama/ollama/releases

--- a/ollamallmbasev3/i18n/zh-CN/OlaresManifest.yaml
+++ b/ollamallmbasev3/i18n/zh-CN/OlaresManifest.yaml
@@ -4,56 +4,29 @@ metadata:
 
 spec:
   upgradeDescription: |
-    将 Ollama 从 v0.32.12 升级至 v0.32.15。Chart 1.3.16。
+    将 Ollama 从 v0.32.15 升级至 v0.33.1。Chart 1.3.17。
 
     **更新内容**（与 Olares 相关）
+
+    v0.33.1
+    - MLX：支持 Qwen3.8 Flash Next
+    - 更新 MLX 与 llama.cpp
+    - mlxrunner：支持结构化输出
+    - mlxrunner：从慢速存储加载模型时避免 Metal GPU 超时
+
+    v0.33.0
+    - 修复 Agent 客户端取消长预填充时卡住
+    - 预填充恢复点在取消后仍保留，重试从中断处继续而非从头开始
+    - 恢复的预填充不再记录不完整的恢复点（循环层模型不再从零重算）
+    - 禁用 Claude Code 的 “tokens left” 系统消息，此前会在每次请求破坏 KV cache
+    - 修复 macOS 假设导致 Linux/Windows 默认打包损坏
+    - 更新 MLX 依赖
 
     v0.32.15
     - 缓存已解析的模型元数据，首 token 延迟大约减半
     - 修复流式解析中途出错后 chat/generate 卡住
     - Qwen 3.8 会规范化非开头的 system 消息
     - 更新 MLX 与 llama.cpp 依赖
-
-    v0.32.14
-    - llama-server 会转码 WebP 图片（视觉）
-    - Qwen 渲染器容忍非开头的 system 消息
-
-    v0.32.13
-    - Qwen 3.8 支持 developer 指令（Agent / Codex 风格的 developer role）
-
-    v0.32.12
-    - 新增 Qwen 3.8 27B 模型支持（`qwen3.8:27b`）
-    - Apple Silicon 针对编程 Agent 与重复任务的优化
-
-    v0.32.11
-    - `ollama launch dsh` 支持 DeepSeek Harness
-    - `ollama launch muse` 支持 Muse Code
-    - OpenAI 兼容 Responses API 支持网页搜索
-    - Muse Glimmer 模板更新
-
-    v0.32.10
-    - 未设置时 `repeat_penalty` 默认 1.0（关闭），不再是 1.1
-    - NVFP4 MLX 模型预填充更快
-    - 修复 OCI config 与 layer 共享 digest 时跳过 blob 校验
-
-    v0.32.9
-    - 新增 Nemotron 3 架构（支持 NVIDIA Nemotron 3.5 Lightning MoE）
-    - 修复 Muse Glimmer 工具调用解析器的边界条件
-
-    v0.32.8
-    - Muse Glimmer 现已支持 NVIDIA、AMD 及其他平台
-
-    v0.32.6
-    - `/v1/chat/completions` 流式输出对齐 OpenAI 格式（`role` 仅首块、`finish_reason` 与 usage 独立分块）
-    - 截断响应的 `finish_reason` 由 `"tool_calls"` 修正为 `"length"`
-
-    v0.32.4
-    - 修复 Qwen3 MoE 不同量化 expert 的解码问题
-
-    v0.32.3
-    - 修复模型下载在首字节前卡住的问题
-    - 修复 GLM 工具调用在生成末尾被静默丢弃
-    - 更新 llama.cpp 与 MLX 引擎
 
     详细发布说明请访问：
     https://github.com/ollama/ollama/releases

--- a/ollamallmbasev3/templates/ollama.yaml
+++ b/ollamallmbasev3/templates/ollama.yaml
@@ -84,7 +84,7 @@ spec:
             defaultMode: 0555
       containers:
         - name: ollama
-          image: docker.io/ollama/ollama:0.32.15
+          image: docker.io/ollama/ollama:0.33.1
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh", "/llm-init/wrappers/ollama.sh"]
           env:


### PR DESCRIPTION
### App Title
ollamallmbasev3

### Description

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`