### PR TITLE
[UPDATE][nextcloud][1.0.28] Upgrade Nextcloud from 31.0.4 to 31.0.14 (same major; existing installs run `occ upgrade` in place). User files on appData and

### DIFF
--- a/nextcloud/Chart.yaml
+++ b/nextcloud/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 31.0.14
 description: A Helm chart for Kubernetes
 name: nextcloud
 type: application
-version: 1.0.23
+version: 1.0.28

--- a/nextcloud/OlaresManifest.yaml
+++ b/nextcloud/OlaresManifest.yaml
@@ -10,7 +10,7 @@ metadata:
   description: The productivity platform that keeps you in control
   icon: https://app.cdn.olares.com/appstore/nextcloud/icon2.png
   appid: nextcloud
-  version: '1.0.23'
+  version: '1.0.28'
   title: Nextcloud
   categories:
   - Productivity_v112
@@ -45,6 +45,9 @@ spec:
     - Security with our encryption mechanisms, HackerOne bounty program and two-factor authentication.
 
   upgradeDescription: |
+    Run the OpenResty entrance as uid/gid 1000 and move its PID, logs, and
+    temporary request paths to writable locations.
+
     Upgrade Nextcloud from 31.0.4 to 31.0.14 (same major; existing installs run `occ upgrade` in place). User files on appData and the Postgres middleware are preserved. Do not skip Nextcloud majors on a running volume.
 
     Replace the app image `beclab/aboveos-zhangdangfang-nextcloud:31.0.4.2` with `beclab/harveyff-nextcloud:31.0.14.1` (official `nextcloud:31.0.14-apache`, `www-data` remapped to uid/gid 1000 for Olares hostPath). Multi-arch: amd64 and arm64.
@@ -70,6 +73,11 @@ spec:
   locale:
   - en-US
   - zh-CN
+  - de-DE
+  - es-ES
+  - it-IT
+  - fr-FR
+  - ja-JP
   requiredMemory: 1Gi
   limitedMemory: 2.5Gi
   requiredDisk: 128Mi

--- a/nextcloud/i18n/de-DE/OlaresManifest.yaml
+++ b/nextcloud/i18n/de-DE/OlaresManifest.yaml
@@ -1,0 +1,34 @@
+metadata:
+  title: Nextcloud
+  description: Die Produktivitätsplattform, mit der Sie die Kontrolle behalten
+spec:
+  fullDescription: |
+    Mit Nextcloud haben Sie Ihre Daten jederzeit zur Hand und behalten die Kontrolle.
+    Speichern Sie Ihre Dokumente, Kalender, Kontakte und Fotos auf einem Server zu Hause, bei einem unserer Anbieter oder in einem Rechenzentrum Ihres Vertrauens.
+
+    **Warum ist das so großartig?**
+    - Zugriff auf Ihre Daten: Speichern Sie Dateien, Kontakte, Kalender, Unterhaltungen und mehr auf einem Server Ihrer Wahl.
+    - Synchronisieren Ihrer Daten: Halten Sie Dateien, Kontakte, Kalender und mehr auf Ihren Geräten synchron.
+    - Teilen Ihrer Daten … indem Sie anderen Zugriff auf die Inhalte gewähren, die sie sehen oder gemeinsam bearbeiten sollen.
+    - Erweiterbar mit Hunderten von Apps ... wie Calendar, Contacts, Mail, Video Chat und allen Apps, die Sie in unserem App Store entdecken können
+    - Sicherheit durch unsere Verschlüsselungsmechanismen, das HackerOne-Prämienprogramm und Zwei-Faktor-Authentifizierung.
+  upgradeDescription: |
+    Upgrade von Nextcloud von 31.0.4 auf 31.0.14 (gleiche Hauptversion; vorhandene Installationen führen `occ upgrade` direkt aus). Benutzerdateien in appData und die Postgres-Middleware bleiben erhalten. Überspringen Sie bei einem aktiven Volume keine Nextcloud-Hauptversionen.
+
+    Das App-Image `beclab/aboveos-zhangdangfang-nextcloud:31.0.4.2` durch `beclab/harveyff-nextcloud:31.0.14.1` ersetzen (offizielles `nextcloud:31.0.14-apache`, `www-data` für Olares hostPath auf uid/gid 1000 umgestellt). Multi-Arch: amd64 und arm64.
+
+    Das Upload-Limit des OpenResty-Reverse-Proxys vom Standardwert 1MB auf 512MB (`client_max_body_size`) erhöhen, entsprechend dem `PHP_UPLOAD_LIMIT` des Images. Die Proxy-Deployment neu erstellen, wenn sich die nginx ConfigMap ändert (`checksum/nginx-config`).
+
+    Der LAN-Hosts-Datei-Domain `<entrance>.<user>.olares.local` immer vertrauen (das offizielle Image wendet `NEXTCLOUD_TRUSTED_DOMAINS` nur bei der Erstinstallation an). `zz-olares.config.php` einbinden, damit vertrauenswürdige Domains und Überschreibungseinstellungen bei jedem Start angewendet werden.
+
+    HTTP `overwriteprotocol` für `*.olares.local` verwenden, damit Anmeldesitzungs-Cookies über LAN-HTTP funktionieren; HTTPS für den öffentlichen Eingang beibehalten. `TRUSTED_PROXIES` auf Cluster-CIDRs erweitern (`10.0.0.0/8`, `172.16.0.0/12`, `127.0.0.1`).
+
+    Das Reverse-Proxy-Image von Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) auf das offizielle OpenResty-Image `openresty/openresty:1.29.2.5-bookworm-fat` umstellen.
+
+    nginx-Konfigurations-Mounts und Protokollpfade an das Layout des offiziellen Images anpassen (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`) und die Bitnami-spezifische `OPENRESTY_CONF_FILE`-Verkabelung entfernen.
+
+    Korrektur-Update (v1.0.14)
+
+    Behobene Probleme
+    - Calendar, Contacts und andere CalDAV/CardDAV-Funktionen korrigiert, die beim Laden hängen blieben oder mit Fehlern wie `findAllCalendars` / `_extractAdvertisedDavFeatures` fehlschlugen
+    - Der Reverse-Proxy bricht OPTIONS-Anfragen für `/remote.php/dav/` und zugehörige API-Pfade nicht mehr vorzeitig ab; DAV-Header werden jetzt korrekt von Nextcloud durchgereicht

--- a/nextcloud/i18n/es-ES/OlaresManifest.yaml
+++ b/nextcloud/i18n/es-ES/OlaresManifest.yaml
@@ -1,0 +1,34 @@
+metadata:
+  title: Nextcloud
+  description: La plataforma de productividad que le permite mantener el control
+spec:
+  fullDescription: |
+    Nextcloud pone sus datos al alcance de su mano y bajo su control.
+    Guarde sus documentos, calendario, contactos y fotos en un servidor doméstico, con uno de nuestros proveedores o en un centro de datos de confianza.
+
+    **¿Por qué es tan fantástico?**
+    - Acceda a sus datos: puede guardar archivos, contactos, calendarios, conversaciones y mucho más en el servidor que elija.
+    - Sincronice sus datos: mantenga sincronizados sus archivos, contactos, calendarios y mucho más entre sus dispositivos.
+    - Comparta sus datos … dando acceso a otras personas al contenido que quiera que vean o en el que quiera colaborar.
+    - Ampliable con cientos de aplicaciones ... como Calendar, Contacts, Mail, Video Chat y todas las que puede descubrir en nuestro App Store
+    - Seguridad mediante nuestros mecanismos de cifrado, el programa de recompensas HackerOne y la autenticación de dos factores.
+  upgradeDescription: |
+    Actualizar Nextcloud de 31.0.4 a 31.0.14 (misma versión principal; las instalaciones existentes ejecutan `occ upgrade` en el mismo lugar). Se conservan los archivos de usuario en appData y el middleware Postgres. No omita versiones principales de Nextcloud en un volumen activo.
+
+    Sustituir la imagen de la aplicación `beclab/aboveos-zhangdangfang-nextcloud:31.0.4.2` por `beclab/harveyff-nextcloud:31.0.14.1` (`nextcloud:31.0.14-apache` oficial, con `www-data` reasignado a uid/gid 1000 para Olares hostPath). Multiarquitectura: amd64 y arm64.
+
+    Aumentar el límite de carga del proxy inverso OpenResty del valor predeterminado de 1MB a 512MB (`client_max_body_size`), de acuerdo con `PHP_UPLOAD_LIMIT` de la imagen. Volver a crear el proxy Deployment cuando cambie nginx ConfigMap (`checksum/nginx-config`).
+
+    Confiar siempre en el dominio del archivo hosts de la LAN `<entrance>.<user>.olares.local` (la imagen oficial solo aplica `NEXTCLOUD_TRUSTED_DOMAINS` en la primera instalación). Montar `zz-olares.config.php` para que los dominios de confianza y los ajustes de sobrescritura se apliquen en cada inicio.
+
+    Usar HTTP `overwriteprotocol` para `*.olares.local` de modo que las cookies de sesión de inicio de sesión funcionen mediante HTTP en la LAN; mantener HTTPS para la entrada pública. Ampliar `TRUSTED_PROXIES` a las CIDR del clúster (`10.0.0.0/8`, `172.16.0.0/12`, `127.0.0.1`).
+
+    Cambiar la imagen del proxy inverso de Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) a la imagen oficial de OpenResty `openresty/openresty:1.29.2.5-bookworm-fat`.
+
+    Alinear los montajes de configuración y las rutas de registro de nginx con la estructura de la imagen oficial (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`) y eliminar la configuración específica de Bitnami `OPENRESTY_CONF_FILE`.
+
+    Actualización correctiva (v1.0.14)
+
+    Correcciones
+    - Se corrigieron Calendar, Contacts y otras funciones CalDAV/CardDAV que se quedaban cargando o fallaban con errores como `findAllCalendars` / `_extractAdvertisedDavFeatures`
+    - El proxy inverso ya no interrumpe las solicitudes OPTIONS para `/remote.php/dav/` y rutas de API relacionadas; ahora las cabeceras DAV se transmiten correctamente desde Nextcloud

--- a/nextcloud/i18n/fr-FR/OlaresManifest.yaml
+++ b/nextcloud/i18n/fr-FR/OlaresManifest.yaml
@@ -1,0 +1,34 @@
+metadata:
+  title: Nextcloud
+  description: La plateforme de productivité qui vous laisse le contrôle
+spec:
+  fullDescription: |
+    Nextcloud met vos données à portée de main et sous votre contrôle.
+    Stockez vos documents, calendrier, contacts et photos sur un serveur chez vous, auprès de l'un de nos fournisseurs ou dans un centre de données de confiance.
+
+    **Pourquoi est-ce si formidable ?**
+    - Accédez à vos données : stockez vos fichiers, contacts, calendriers, conversations et bien plus encore sur le serveur de votre choix.
+    - Synchronisez vos données : gardez vos fichiers, contacts, calendriers et autres données synchronisés entre vos appareils.
+    - Partagez vos données … en donnant à d'autres personnes accès aux éléments que vous souhaitez leur montrer ou sur lesquels vous souhaitez collaborer.
+    - Extensible avec des centaines d'applications ... comme Calendar, Contacts, Mail, Video Chat et toutes celles que vous pouvez découvrir dans notre App Store
+    - Sécurité grâce à nos mécanismes de chiffrement, au programme de primes HackerOne et à l'authentification à deux facteurs.
+  upgradeDescription: |
+    Mise à niveau de Nextcloud de 31.0.4 vers 31.0.14 (même version majeure ; les installations existantes exécutent `occ upgrade` sur place). Les fichiers utilisateur dans appData et le middleware Postgres sont conservés. Ne sautez pas de versions majeures de Nextcloud sur un volume actif.
+
+    Remplacement de l'image de l'application `beclab/aboveos-zhangdangfang-nextcloud:31.0.4.2` par `beclab/harveyff-nextcloud:31.0.14.1` (`nextcloud:31.0.14-apache` officielle, avec `www-data` remappé vers uid/gid 1000 pour Olares hostPath). Multi-architecture : amd64 et arm64.
+
+    Augmentation de la limite d'importation du proxy inverse OpenResty de la valeur par défaut 1MB à 512MB (`client_max_body_size`), conformément au `PHP_UPLOAD_LIMIT` de l'image. Recréation du proxy Deployment lorsque la nginx ConfigMap change (`checksum/nginx-config`).
+
+    Toujours approuver le domaine du fichier hosts du réseau local `<entrance>.<user>.olares.local` (l'image officielle n'applique `NEXTCLOUD_TRUSTED_DOMAINS` que lors de la première installation). Monter `zz-olares.config.php` pour appliquer les domaines de confiance et les paramètres de remplacement à chaque démarrage.
+
+    Utiliser HTTP `overwriteprotocol` pour `*.olares.local` afin que les cookies de session de connexion fonctionnent via HTTP sur le réseau local ; conserver HTTPS pour l'entrée publique. Étendre `TRUSTED_PROXIES` aux CIDR du cluster (`10.0.0.0/8`, `172.16.0.0/12`, `127.0.0.1`).
+
+    Remplacement de l'image du proxy inverse Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) par l'image officielle OpenResty `openresty/openresty:1.29.2.5-bookworm-fat`.
+
+    Alignement des montages de configuration et des chemins de journaux nginx sur la structure de l'image officielle (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`) et suppression du câblage `OPENRESTY_CONF_FILE` spécifique à Bitnami.
+
+    Mise à jour corrective (v1.0.14)
+
+    Corrections
+    - Correction de Calendar, Contacts et d'autres fonctionnalités CalDAV/CardDAV qui restaient bloquées au chargement ou échouaient avec des erreurs telles que `findAllCalendars` / `_extractAdvertisedDavFeatures`
+    - Le proxy inverse ne court-circuite plus les requêtes OPTIONS pour `/remote.php/dav/` et les chemins d'API associés ; les en-têtes DAV sont désormais correctement transmis par Nextcloud

--- a/nextcloud/i18n/it-IT/OlaresManifest.yaml
+++ b/nextcloud/i18n/it-IT/OlaresManifest.yaml
@@ -1,0 +1,34 @@
+metadata:
+  title: Nextcloud
+  description: La piattaforma di produttività che ti lascia il controllo
+spec:
+  fullDescription: |
+    Nextcloud mette i tuoi dati a portata di mano e sotto il tuo controllo.
+    Archivia documenti, calendario, contatti e foto su un server domestico, presso uno dei nostri provider o in un data center di cui ti fidi.
+
+    **Perché è così straordinario?**
+    - Accedi ai tuoi dati: puoi archiviare file, contatti, calendari, conversazioni e altro ancora su un server a tua scelta.
+    - Sincronizza i tuoi dati: mantieni sincronizzati file, contatti, calendari e altro tra i tuoi dispositivi.
+    - Condividi i tuoi dati … consentendo ad altri di accedere ai contenuti che vuoi mostrare o sui quali vuoi collaborare.
+    - Espandibile con centinaia di app ... come Calendar, Contacts, Mail, Video Chat e tutte quelle disponibili nel nostro App Store
+    - Sicurezza grazie ai nostri meccanismi di crittografia, al programma di ricompense HackerOne e all'autenticazione a due fattori.
+  upgradeDescription: |
+    Aggiornamento di Nextcloud da 31.0.4 a 31.0.14 (stessa versione principale; le installazioni esistenti eseguono `occ upgrade` sul posto). I file utente in appData e il middleware Postgres vengono conservati. Non saltare versioni principali di Nextcloud su un volume in uso.
+
+    Sostituzione dell'immagine dell'app `beclab/aboveos-zhangdangfang-nextcloud:31.0.4.2` con `beclab/harveyff-nextcloud:31.0.14.1` (`nextcloud:31.0.14-apache` ufficiale, con `www-data` rimappato a uid/gid 1000 per Olares hostPath). Multi-arch: amd64 e arm64.
+
+    Incremento del limite di upload del reverse proxy OpenResty dal valore predefinito di 1MB a 512MB (`client_max_body_size`), in linea con `PHP_UPLOAD_LIMIT` dell'immagine. Ricreazione del proxy Deployment quando cambia nginx ConfigMap (`checksum/nginx-config`).
+
+    Considerare sempre attendibile il dominio del file hosts LAN `<entrance>.<user>.olares.local` (l'immagine ufficiale applica `NEXTCLOUD_TRUSTED_DOMAINS` solo alla prima installazione). Montare `zz-olares.config.php` affinché i domini attendibili e le impostazioni di sovrascrittura vengano applicati a ogni avvio.
+
+    Usare HTTP `overwriteprotocol` per `*.olares.local` affinché i cookie della sessione di accesso funzionino tramite HTTP sulla LAN; mantenere HTTPS per l'ingresso pubblico. Estendere `TRUSTED_PROXIES` alle CIDR del cluster (`10.0.0.0/8`, `172.16.0.0/12`, `127.0.0.1`).
+
+    Sostituzione dell'immagine reverse proxy Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) con l'immagine OpenResty ufficiale `openresty/openresty:1.29.2.5-bookworm-fat`.
+
+    Allineamento dei mount di configurazione e dei percorsi di log di nginx al layout dell'immagine ufficiale (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`) e rimozione del collegamento `OPENRESTY_CONF_FILE` specifico di Bitnami.
+
+    Aggiornamento correttivo (v1.0.14)
+
+    Correzioni
+    - Risolti Calendar, Contacts e altre funzionalità CalDAV/CardDAV che rimanevano in caricamento o non funzionavano con errori come `findAllCalendars` / `_extractAdvertisedDavFeatures`
+    - Il reverse proxy non interrompe più le richieste OPTIONS per `/remote.php/dav/` e i relativi percorsi API; le intestazioni DAV ora vengono trasmesse correttamente da Nextcloud

--- a/nextcloud/i18n/ja-JP/OlaresManifest.yaml
+++ b/nextcloud/i18n/ja-JP/OlaresManifest.yaml
@@ -1,0 +1,34 @@
+metadata:
+  title: Nextcloud
+  description: データを自分で管理できる生産性プラットフォーム
+spec:
+  fullDescription: |
+    Nextcloud は、データをいつでも手元に置き、自分で管理できるようにします。
+    ドキュメント、カレンダー、連絡先、写真を、自宅のサーバー、当社のプロバイダー、または信頼できるデータセンターに保存できます。
+
+    **優れている理由**
+    - データへのアクセス：ファイル、連絡先、カレンダー、会話などを、選択したサーバーに保存できます。
+    - データの同期：ファイル、連絡先、カレンダーなどをデバイス間で同期できます。
+    - データの共有 … 見せたいものや共同作業したいものへのアクセスを他の人に許可できます。
+    - 数百種類のアプリで拡張可能 ... Calendar、Contacts、Mail、Video Chat など、App Store で見つかるすべてのアプリ
+    - 暗号化メカニズム、HackerOne 報奨金プログラム、二要素認証によるセキュリティ。
+  upgradeDescription: |
+    Nextcloud を 31.0.4 から 31.0.14 にアップグレード（同じメジャーバージョン。既存のインストールではその場で `occ upgrade` を実行）。appData のユーザーファイルと Postgres ミドルウェアは保持されます。使用中のボリュームで Nextcloud のメジャーバージョンを飛ばさないでください。
+
+    アプリイメージ `beclab/aboveos-zhangdangfang-nextcloud:31.0.4.2` を `beclab/harveyff-nextcloud:31.0.14.1` に置換（公式 `nextcloud:31.0.14-apache`、Olares hostPath 用に `www-data` を uid/gid 1000 に再マッピング）。マルチアーキテクチャ：amd64 および arm64。
+
+    OpenResty リバースプロキシのアップロード上限をデフォルトの 1MB から 512MB (`client_max_body_size`) に引き上げ、イメージの `PHP_UPLOAD_LIMIT` と一致させます。nginx ConfigMap が変更された場合は、プロキシ Deployment を再作成します (`checksum/nginx-config`)。
+
+    LAN の hosts ファイルドメイン `<entrance>.<user>.olares.local` を常に信頼します（公式イメージが `NEXTCLOUD_TRUSTED_DOMAINS` を適用するのは初回インストール時のみ）。`zz-olares.config.php` をマウントし、信頼するドメインと上書き設定を起動のたびに適用します。
+
+    `*.olares.local` には HTTP `overwriteprotocol` を使用し、LAN HTTP 経由でログインセッション Cookie が機能するようにします。公開入口では HTTPS を維持します。`TRUSTED_PROXIES` をクラスター CIDR (`10.0.0.0/8`、`172.16.0.0/12`、`127.0.0.1`) に拡張します。
+
+    リバースプロキシイメージを Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) から公式 OpenResty イメージ `openresty/openresty:1.29.2.5-bookworm-fat` に変更します。
+
+    nginx の設定マウントとログパスを公式イメージのレイアウト（`/etc/nginx/conf.d/default.conf`、`/usr/local/openresty/nginx/logs/...`）に合わせ、Bitnami 固有の `OPENRESTY_CONF_FILE` 設定を削除します。
+
+    修正アップデート (v1.0.14)
+
+    修正内容
+    - Calendar、Contacts、およびその他の CalDAV/CardDAV 機能が読み込み中のままになったり、`findAllCalendars` / `_extractAdvertisedDavFeatures` などのエラーで失敗したりする問題を修正
+    - リバースプロキシが `/remote.php/dav/` と関連 API パスへの OPTIONS リクエストを途中で処理しなくなることはなくなり、DAV ヘッダーが Nextcloud から正しく渡されるようになりました

--- a/nextcloud/templates/_helpers.tpl
+++ b/nextcloud/templates/_helpers.tpl
@@ -5,8 +5,14 @@ Referenced by nginx-configmap.yaml; checksum in Deployment triggers rollout on c
 {{- define "nextcloud.nginx.conf" -}}
 server {
     listen 8080;
-    access_log /usr/local/openresty/nginx/logs/access.log;
-    error_log /usr/local/openresty/nginx/logs/error.log;
+    access_log /dev/stdout;
+    error_log /dev/stderr;
+
+    client_body_temp_path /tmp/client_body;
+    proxy_temp_path /tmp/proxy;
+    fastcgi_temp_path /tmp/fastcgi;
+    uwsgi_temp_path /tmp/uwsgi;
+    scgi_temp_path /tmp/scgi;
 
     client_max_body_size 512m;
 

--- a/nextcloud/templates/clientproxy.yaml
+++ b/nextcloud/templates/clientproxy.yaml
@@ -28,9 +28,19 @@ spec:
             items:
               - key: nginx.conf
                 path: nginx.conf
+        - name: nginx-runtime
+          emptyDir: {}
       containers:
         - name: nginx
           image: "docker.io/openresty/openresty:1.29.2.5-bookworm-fat"
+          command:
+            - /usr/local/openresty/bin/openresty
+          args:
+            - -g
+            - "daemon off; pid /tmp/nginx.pid;"
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
           ports:
             - containerPort: 8080
               protocol: TCP
@@ -63,6 +73,8 @@ spec:
             - name: nginx-config
               mountPath: /etc/nginx/conf.d/default.conf
               subPath: nginx.conf
+            - name: nginx-runtime
+              mountPath: /var/run/openresty
 ---
 apiVersion: v1
 kind: Service

--- a/nextcloud/templates/deployment.yaml
+++ b/nextcloud/templates/deployment.yaml
@@ -26,6 +26,78 @@ spec:
     spec:
       securityContext:
         runAsUser: 0
+      initContainers:
+        # subPath file mount creates config/ as root; www-data must own it to write config.php
+        - name: init-config-permissions
+          image: "docker.io/beclab/harveyff-nextcloud:31.0.14.1"
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            runAsUser: 0
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              value: "{{ .Values.postgres.databases.nextcloud }}"
+            - name: POSTGRES_USER
+              value: "{{ .Values.postgres.username }}"
+            - name: POSTGRES_HOST
+              value: "{{ .Values.postgres.host }}"
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              mkdir -p /var/www/html/config /var/www/html/data
+              chown 1000:1000 /var/www/html/config /var/www/html/data
+              if [ ! -f /var/www/html/config/config.php ]; then
+                table_count="$(php -r '
+                  $dsn = "pgsql:host=" . getenv("POSTGRES_HOST") . ";dbname=" . getenv("POSTGRES_DB");
+                  $pdo = new PDO($dsn, getenv("POSTGRES_USER"), getenv("POSTGRES_PASSWORD"));
+                  echo $pdo->query("SELECT count(*) FROM pg_tables WHERE schemaname = '\''public'\''")->fetchColumn();
+                ')"
+                if [ "$table_count" != "0" ]; then
+                  echo >&2 "config.php is missing, but PostgreSQL contains $table_count public tables; refusing destructive automatic recovery"
+                  exit 1
+                fi
+
+                cp /usr/src/nextcloud/config/CAN_INSTALL /var/www/html/config/CAN_INSTALL
+                for f in /usr/src/nextcloud/config/*.php; do
+                  b=$(basename "$f")
+                  case "$b" in
+                    autoconfig.php|config.sample.php) continue ;;
+                  esac
+                  if [ ! -e "/var/www/html/config/$b" ]; then
+                    cp "$f" "/var/www/html/config/$b"
+                  fi
+                done
+                chown 1000:1000 /var/www/html/config /var/www/html/config/CAN_INSTALL
+                for f in /var/www/html/config/*.php; do
+                  [ -f "$f" ] || continue
+                  chown 1000:1000 "$f"
+                done
+
+                # A failed 1.0.23+ fresh install leaves the copied version.php
+                # behind even though PostgreSQL is empty. Remove only that
+                # false installation marker and the fallback SQLite files so
+                # the official entrypoint performs maintenance:install again.
+                rm -f /var/www/html/version.php
+                rm -f /var/www/html/data/owncloud.db \
+                      /var/www/html/data/owncloud.db-shm \
+                      /var/www/html/data/owncloud.db-wal
+              fi
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          volumeMounts:
+            - name: data
+              mountPath: /var/www/html
       containers:
         - name: nextcloud
           image: "docker.io/beclab/harveyff-nextcloud:31.0.14.1"


### PR DESCRIPTION
### App Title
nextcloud

### Description

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`