### PR TITLE
[UPDATE][otmoiclp][2.5.9] add tw7613781 to owners list

### DIFF
--- a/otmoiclp/Chart.yaml
+++ b/otmoiclp/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.8
+version: 2.5.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/otmoiclp/OlaresManifest.yaml
+++ b/otmoiclp/OlaresManifest.yaml
@@ -22,7 +22,7 @@ metadata:
   description: Otmoic LP
   icon: https://app.cdn.olares.com/appstore/obridgelpnode/icon.png
   appid: otmoiclp
-  version: "2.5.8"
+  version: "2.5.9"
   title: Otmoic LP
   categories:
   - Lifestyle

--- a/otmoiclp/owners
+++ b/otmoiclp/owners
@@ -6,3 +6,4 @@ owners:
 - 'harveyff'
 - 'zdf-org'
 - 'Magicpig'
+- 'tw7613781'


### PR DESCRIPTION
### App Title
Otmoic LP

### Description
Add `tw7613781` to the owners list of the `otmoiclp` chart so the account can maintain this app in the Olares Market.

- Bump chart/manifest version `2.5.8` → `2.5.9` (required for any chart modification)
- Add `tw7613781` to `otmoiclp/owners`

No functional changes to the chart.

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
