### PR TITLE
[SUSPEND][otmoiclp][2.5.10] suspend otmoiclp

### DIFF
--- a/otmoiclp/Chart.yaml
+++ b/otmoiclp/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.9
+version: 2.5.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/otmoiclp/OlaresManifest.yaml
+++ b/otmoiclp/OlaresManifest.yaml
@@ -22,7 +22,7 @@ metadata:
   description: Otmoic LP
   icon: https://app.cdn.olares.com/appstore/obridgelpnode/icon.png
   appid: otmoiclp
-  version: "2.5.9"
+  version: "2.5.10"
   title: Otmoic LP
   categories:
   - Lifestyle


### PR DESCRIPTION
### App Title
Otmoic LP

### Description
Suspend `otmoiclp` distribution on the Olares Market.

- Add empty `.suspend` control file
- Bump chart/manifest version `2.5.9` → `2.5.10` (required by the suspend rule)

After merge, `otmoiclp` will no longer be discoverable/installable in the Market; already-installed users are unaffected. Distribution can be resumed later via an UPDATE that removes `.suspend`.

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`
