### PR TITLE
[SUSPEND][otmoiclp][2.5.11] suspend otmoiclp across all Olares OS versions (v2 manifest, floor >=1.10.1-0)

### DIFF
--- a/otmoiclp/Chart.yaml
+++ b/otmoiclp/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.10
+version: 2.5.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/otmoiclp/OlaresManifest.yaml
+++ b/otmoiclp/OlaresManifest.yaml
@@ -1,34 +1,49 @@
-olaresManifest.version: '0.12.0'
+olaresManifest.version: '0.10.0'
 olaresManifest.type: app
-apiVersion: 'v3'
-
-workloadReplicas:
-  lpnode-admin: 1
-  amm-amm-01: 1
-  amm-amm-01-analyze: 1
-  lpnode-dashboard: 1
-  chain-client-evm-bsc-9006: 1
-  chain-client-evm-eth-60: 1
-  chain-client-evm-op-614: 1
-  amm-graphql: 1
-  otmoiclp: 1
-  amm-market-price: 1
-  metrics-hub: 1
-  metrics: 1
-  chain-client-solana-solana-501: 1
-  traefik: 1
 metadata:
   name: otmoiclp
   description: Otmoic LP
   icon: https://app.cdn.olares.com/appstore/obridgelpnode/icon.png
   appid: otmoiclp
-  version: "2.5.10"
+  version: "2.5.11"
   title: Otmoic LP
   categories:
   - Lifestyle
-
+  - Blockchain
 permission:
   appData: true
+  sysData:
+  - dataType: secret
+    group: secret.infisical
+    version: v1
+    ops:
+    - RetrieveSecret?workspace=otmoic
+    - CreateSecret?workspace=otmoic
+    - DeleteSecret?workspace=otmoic
+    - UpdateSecret?workspace=otmoic
+    - ListSecret?workspace=otmoic
+  - dataType: key
+    group: portfolio
+    version: v1
+    ops:
+    - MarketInfo
+    - SubMarkets
+    - Depth
+    - Deal
+    - SupportAccount
+    - OpenOrder
+    - Account
+    - Trans
+    - Prices
+    - CreateOrder
+    - CancelOrder
+    - AddSubMarkets
+    - RemoveSubMarkets
+  - dataType: legacy_api
+    group: websocket.portfolio
+    version: v1
+    ops:
+    - GET
   appCache: true
   userData:
   - Home/Code
@@ -77,11 +92,11 @@ spec:
   license:
   - text: Apache-2.0
     url: https://github.com/otomic-agents/lpnode?tab=Apache-2.0-1-ov-file#readme
-  requiredMemory: 2665Mi
+  requiredMemory: 1024Mi
   limitedMemory: 16Gi
   requiredDisk: 128Mi
   limitedDisk: 256Mi
-  requiredCpu: 528m
+  requiredCpu: 0.25
   limitedCpu: 12
   supportArch:
   - amd64
@@ -97,7 +112,7 @@ options:
   dependencies:
   - name: olares
     type: system
-    version: '>=1.12.6-0'
+    version: '>=1.10.1-0'
   - name: mongodb
     version: ">=6.0.0-0"
     type: middleware

--- a/otmoiclp/OlaresManifest.yaml
+++ b/otmoiclp/OlaresManifest.yaml
@@ -9,7 +9,6 @@ metadata:
   title: Otmoic LP
   categories:
   - Lifestyle
-  - Blockchain
 permission:
   appData: true
   sysData:


### PR DESCRIPTION
### Suspended

- App: Otmoic LP (`otmoiclp`)
- PR type: SUSPEND
- Chart: 2.5.10 → 2.5.11

### Why

The previous SUSPEND (#3484) only hid otmoiclp on Olares OS **>= 1.12.6**. The per-OS catalog serves each OS the highest chart version whose `olares` dependency constraint that OS satisfies, so older OS (1.10.1–1.12.5) kept resolving to older, non-suspended chart versions (2.5.6 / 2.5.4) and the app stayed visible/installable there.

This PR re-suspends so the app is hidden on **every** Olares OS version:

- manifest reverted to the **v2 (`0.10.0`) schema** — v3 (`apiVersion: v3`) requires Olares >= 1.12.6, so a v3 manifest cannot honestly claim lower floors;
- `olares` dependency floor lowered to `>=1.10.1-0` (the lowest floor any otmoiclp release ever declared);
- version bumped 2.5.10 → 2.5.11.

### Effect

Every Olares OS version that could ever list otmoiclp (>= 1.10.1) now resolves to this suspended version, so the app is hidden everywhere. Existing installs keep working. The suspension remains reversible — a future UPDATE can drop `.suspend` and restore the v3 manifest with the real floor (>= 1.12.6-0).
