### PR TITLE
[UPDATE][seatable][1.0.36] Run the official OpenResty entrance as UID/GID 1000 with writable runtime paths.

### DIFF
--- a/seatable/Chart.yaml
+++ b/seatable/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: Enterprise:6.2.12
+appVersion: Enterprise:6.2.13
 description: SeaTable is a no-code database and app-building platform.
 name: seatable
 type: application
-version: 1.0.29
+version: 1.0.36

--- a/seatable/OlaresManifest.yaml
+++ b/seatable/OlaresManifest.yaml
@@ -12,10 +12,14 @@ metadata:
   description: SeaTable is a no-code database and app-building platform.
   icon: https://app.cdn.olares.com/appstore/seatable/icon.png
   appid: seatable
-  version: '1.0.29'
+  version: '1.0.36'
   title: SeaTable
   categories:
   - Productivity_v112
+  - workspace
+  tags:
+  - data
+  - low-code
 
 entrances:
 - name: seatable
@@ -31,7 +35,7 @@ permission:
   userData:
   - Home
 spec:
-  versionName: 'Enterprise:6.2.12'
+  versionName: 'Enterprise:6.2.13'
   featuredImage: https://app.cdn.olares.com/appstore/seatable/1.webp
   promoteImage:
   - https://app.cdn.olares.com/appstore/seatable/1.webp
@@ -55,6 +59,10 @@ spec:
     - Filters, sorts, charts and pivotal tables to visualize and analyze data.
 
   upgradeDescription: |
+
+    Run the official OpenResty entrance as UID/GID 1000 with writable runtime paths.
+    v1.0.35: Upgrade image to `seatable/seatable-enterprise:6.2.13` (from 6.2.12).
+
     v1.0.29: Raise seatableweb reverse-proxy upload limit to 200MB (`client_max_body_size 200m`) so attachment uploads larger than 1MB are not rejected with HTTP 413 after the official OpenResty proxy switch.
 
     Switch the reverse-proxy image from Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) to the official OpenResty image `openresty/openresty:1.29.2.5-bookworm-fat`.
@@ -75,6 +83,11 @@ spec:
   locale:
   - en-US
   - zh-CN
+  - de-DE
+  - es-ES
+  - it-IT
+  - fr-FR
+  - ja-JP
   doc: https://docs.seatable.io/
   license:
   - text: EULA SeaTable Server Enterprise Edition

--- a/seatable/i18n/de-DE/OlaresManifest.yaml
+++ b/seatable/i18n/de-DE/OlaresManifest.yaml
@@ -1,0 +1,32 @@
+metadata:
+  title: SeaTable
+  description: SeaTable ist eine No-Code-Datenbank- und App-Building-Plattform
+spec:
+  upgradeDescription: |
+    v1.0.35: Image auf `seatable/seatable-enterprise:6.2.13` (von 6.2.12) aktualisiert.
+
+    v1.0.29: Upload-Limit des seatableweb-Reverse-Proxys auf 200 MB erhöhen (`client_max_body_size 200m`), damit Anhänge größer als 1 MB nach dem Wechsel zum offiziellen OpenResty-Proxy nicht mit HTTP 413 abgelehnt werden.
+
+    Wechsel des Reverse-Proxy-Images von Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) zum offiziellen OpenResty-Image `openresty/openresty:1.29.2.5-bookworm-fat`.
+
+    Nginx-Konfigurations-Mounts und Log-Pfade an das Layout des offiziellen Images anpassen (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`) und Bitnami-spezifisches `OPENRESTY_CONF_FILE`-Wiring entfernen.
+
+    v1.0.27: Gunicorn-Boot-Crash bei leerem `EMAIL_PORT` behoben (`SEATABLE_EMAIL_PORT` muss numerisch sein oder weggelassen werden).
+    v1.0.26: Install-/Ressourcenuntergrenzen angehoben (`requiredMemory` 4Gi); `SEATABLE_EMAIL_USE_SSL` und optionale SeaDoc/AI-Schalter hinzugefügt (standardmäßig aus).
+    v1.0.25: Probes gelockert (Readiness/Liveness auf nginx :80), damit die SQL-Initialisierung beim ersten Start nicht mitten im Start abgebrochen wird.
+    v1.0.24: Image auf `seatable/seatable-enterprise:6.2.12` (von 5.2.7) aktualisiert; Secret-Migration; Verzweigung `sysVersion >= 1.12.3` entfernt.
+  fullDescription: |
+    **Bitte ändern Sie die Lizenz**
+    Dies ist die Enterprise Edition von SeaTable. Sie müssen eine gültige Enterprise-On-Premises-Lizenz von SeaTable beziehen und die Lizenzdatei importieren, bevor Sie sie nutzen.
+
+    **Übersicht**
+    SeaTable ist eine No-Code-Datenbank- und App-Building-Plattform. Auf den ersten Blick wirkt sie wie eine Online-Tabellenkalkulation ähnlich Google Sheets, doch unter der Haube bietet sie weit mehr. SeaTable hilft Ihnen, allerlei verstreute Informationen zu erfassen und zu verwalten. Nutzen Sie Filter, Sortierungen oder Gruppierungen, um mit Freunden und Kollegen zusammenzuarbeiten. Visualisieren Sie Daten mit Plugins wie Kanban, Gallery oder Calendar.
+
+    Mit APIs und SDKs können Sie schnell nach Bedarf skalieren, Datenverarbeitung automatisieren und Geschäftsprozesse automatisieren.
+
+    **Hauptfunktionen:**
+    - Tabellenartige Oberfläche zur Datenerfassung mit kollaborativem Bearbeiten.
+    - Formular-App zum Sammeln von Daten von außen.
+    - Mobilfertige UI zur Nutzung in Browsern auf Mobilgeräten zum Anzeigen und Erfassen von Daten.
+    - Umfassende API und SDK zum Hinzufügen von Erweiterungen.
+    - Filter, Sortierungen, Diagramme und Pivot-Tabellen zur Visualisierung und Analyse von Daten.

--- a/seatable/i18n/en-US/OlaresManifest.yaml
+++ b/seatable/i18n/en-US/OlaresManifest.yaml
@@ -3,6 +3,8 @@ metadata:
   description: SeaTable is a no-code database and app-building platform.
 spec:
   upgradeDescription: |
+    v1.0.35: Upgrade image to `seatable/seatable-enterprise:6.2.13` (from 6.2.12).
+
     v1.0.29: Raise seatableweb reverse-proxy upload limit to 200MB (`client_max_body_size 200m`) so attachment uploads larger than 1MB are not rejected with HTTP 413 after the official OpenResty proxy switch.
 
     Switch the reverse-proxy image from Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) to the official OpenResty image `openresty/openresty:1.29.2.5-bookworm-fat`.

--- a/seatable/i18n/es-ES/OlaresManifest.yaml
+++ b/seatable/i18n/es-ES/OlaresManifest.yaml
@@ -1,0 +1,32 @@
+metadata:
+  title: SeaTable
+  description: SeaTable es una plataforma no-code de base de datos y creación de apps
+spec:
+  upgradeDescription: |
+    v1.0.35: Actualizar imagen a `seatable/seatable-enterprise:6.2.13` (desde 6.2.12).
+
+    v1.0.29: Elevar el límite de subida del proxy inverso seatableweb a 200 MB (`client_max_body_size 200m`) para que los adjuntos mayores de 1 MB no se rechacen con HTTP 413 tras el cambio al proxy oficial OpenResty.
+
+    Cambiar la imagen del proxy inverso de Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) a la imagen oficial de OpenResty `openresty/openresty:1.29.2.5-bookworm-fat`.
+
+    Alinear los montajes de configuración de nginx y las rutas de registro con el diseño de la imagen oficial (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`) y eliminar el cableado específico de Bitnami `OPENRESTY_CONF_FILE`.
+
+    v1.0.27: Corregir el fallo de arranque de gunicorn cuando `EMAIL_PORT` está vacío (`SEATABLE_EMAIL_PORT` debe ser numérico u omitirse).
+    v1.0.26: Subir los suelos de instalación/recursos (`requiredMemory` 4Gi); añadir `SEATABLE_EMAIL_USE_SSL` y conmutadores opcionales SeaDoc/AI (desactivados por defecto).
+    v1.0.25: Suavizar probes (readiness/liveness en nginx :80) para que la inicialización SQL del primer arranque no se mate a mitad.
+    v1.0.24: Actualizar imagen a `seatable/seatable-enterprise:6.2.12` (desde 5.2.7); migración a Secret; eliminar ramificación `sysVersion >= 1.12.3`.
+  fullDescription: |
+    **Por favor, cambia la licencia**
+    Esta es la Enterprise Edition de SeaTable. Debes obtener una licencia Enterprise On-Premises válida de SeaTable e importar el archivo de licencia antes de usarla.
+
+    **Resumen**
+    SeaTable es una plataforma no-code de base de datos y creación de apps. A primera vista parece una hoja de cálculo online como Google Sheets, pero bajo el capó ofrece mucho más. SeaTable te ayuda a registrar y gestionar todo tipo de información dispersa. Usa filtros, ordenaciones o agrupaciones para colaborar con amigos y colegas. Visualiza cualquier dato con plugins como Kanban, Gallery o Calendar.
+
+    Con APIs y SDKs puedes escalar rápidamente según tus necesidades, automatizar el procesamiento de datos y automatizar procesos de negocio.
+
+    **Funciones principales:**
+    - Interfaz tipo hoja de cálculo para registrar datos con edición colaborativa.
+    - App de formularios para recopilar datos desde fuera.
+    - UI lista para móvil para usar en navegadores de sistemas móviles y ver/recoger datos.
+    - API y SDK completos para añadir extensiones.
+    - Filtros, ordenaciones, gráficos y tablas dinámicas para visualizar y analizar datos.

--- a/seatable/i18n/fr-FR/OlaresManifest.yaml
+++ b/seatable/i18n/fr-FR/OlaresManifest.yaml
@@ -1,0 +1,32 @@
+metadata:
+  title: SeaTable
+  description: SeaTable est une plateforme no-code de base de données et de création d'applications
+spec:
+  upgradeDescription: |
+    v1.0.35 : Mettre à jour l'image vers `seatable/seatable-enterprise:6.2.13` (depuis 6.2.12).
+
+    v1.0.29 : Augmenter la limite d'upload du reverse-proxy seatableweb à 200 Mo (`client_max_body_size 200m`) pour que les pièces jointes de plus de 1 Mo ne soient pas rejetées avec HTTP 413 après le passage au proxy OpenResty officiel.
+
+    Remplacer l'image du reverse-proxy Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) par l'image officielle OpenResty `openresty/openresty:1.29.2.5-bookworm-fat`.
+
+    Aligner les montages de configuration nginx et les chemins de journaux sur la disposition de l'image officielle (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`), et supprimer le câblage spécifique à Bitnami `OPENRESTY_CONF_FILE`.
+
+    v1.0.27 : Corriger le plantage de démarrage gunicorn lorsque `EMAIL_PORT` est vide (`SEATABLE_EMAIL_PORT` doit être numérique ou omis).
+    v1.0.26 : Relever les planchers d'installation/ressources (`requiredMemory` 4Gi) ; ajouter `SEATABLE_EMAIL_USE_SSL` et bascules optionnelles SeaDoc/AI (désactivées par défaut).
+    v1.0.25 : Assouplir les probes (readiness/liveness sur nginx :80) pour que l'init SQL au premier démarrage ne soit pas tuée en cours de route.
+    v1.0.24 : Mettre à jour l'image vers `seatable/seatable-enterprise:6.2.12` (depuis 5.2.7) ; migration Secret ; supprimer le branchement `sysVersion >= 1.12.3`.
+  fullDescription: |
+    **Veuillez changer la licence**
+    Il s'agit de l'édition Enterprise de SeaTable. Vous devez obtenir une licence Enterprise On-Premises valide auprès de SeaTable et importer le fichier de licence avant de l'utiliser.
+
+    **Aperçu**
+    SeaTable est une plateforme no-code de base de données et de création d'applications. Au premier regard, elle ressemble à un tableur en ligne comme Google Sheets, mais sous le capot elle offre bien plus. SeaTable vous aide à enregistrer et gérer toutes sortes d'informations dispersées. Utilisez filtres, tris ou regroupements pour collaborer avec amis et collègues. Visualisez les données avec des plugins comme Kanban, Gallery ou Calendar.
+
+    Avec les API et SDK, vous pouvez évoluer rapidement selon vos besoins, automatiser le traitement des données et automatiser les processus métier.
+
+    **Fonctionnalités principales :**
+    - Interface de type tableur pour enregistrer des données avec édition collaborative.
+    - Application de formulaires pour collecter des données de l'extérieur.
+    - UI prête pour le mobile à utiliser dans les navigateurs sur systèmes mobiles pour consulter et collecter des données.
+    - API et SDK complets pour ajouter des extensions.
+    - Filtres, tris, graphiques et tableaux croisés dynamiques pour visualiser et analyser les données.

--- a/seatable/i18n/it-IT/OlaresManifest.yaml
+++ b/seatable/i18n/it-IT/OlaresManifest.yaml
@@ -1,0 +1,32 @@
+metadata:
+  title: SeaTable
+  description: SeaTable è una piattaforma no-code di database e creazione app
+spec:
+  upgradeDescription: |
+    v1.0.35: Immagine aggiornata a `seatable/seatable-enterprise:6.2.13` (da 6.2.12).
+
+    v1.0.29: Aumentare il limite di upload del reverse proxy seatableweb a 200 MB (`client_max_body_size 200m`) così gli allegati oltre 1 MB non vengono rifiutati con HTTP 413 dopo il passaggio al proxy OpenResty ufficiale.
+
+    Passare l'immagine del reverse proxy da Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) all'immagine ufficiale OpenResty `openresty/openresty:1.29.2.5-bookworm-fat`.
+
+    Allineare i mount della configurazione nginx e i percorsi dei log al layout dell'immagine ufficiale (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`) e rimuovere il wiring specifico Bitnami `OPENRESTY_CONF_FILE`.
+
+    v1.0.27: Correzione crash di avvio gunicorn quando `EMAIL_PORT` è vuoto (`SEATABLE_EMAIL_PORT` deve essere numerico o omesso).
+    v1.0.26: Alzati i minimi di installazione/risorse (`requiredMemory` 4Gi); aggiunti `SEATABLE_EMAIL_USE_SSL` e toggle opzionali SeaDoc/AI (disattivati di default).
+    v1.0.25: Probe allentate (readiness/liveness su nginx :80) così l'init SQL al primo avvio non viene interrotto a metà.
+    v1.0.24: Immagine aggiornata a `seatable/seatable-enterprise:6.2.12` (da 5.2.7); migrazione Secret; rimossa ramificazione `sysVersion >= 1.12.3`.
+  fullDescription: |
+    **Si prega di cambiare la licenza**
+    Questa è la Enterprise Edition di SeaTable. Devi ottenere una licenza Enterprise On-Premises valida da SeaTable e importare il file di licenza prima di usarla.
+
+    **Panoramica**
+    SeaTable è una piattaforma no-code di database e creazione app. A prima vista sembra un foglio di calcolo online come Google Sheets, ma sotto il cofano offre molto di più. SeaTable ti aiuta a registrare e gestire ogni tipo di informazione sparsa. Usa filtri, ordinamenti o raggruppamenti per collaborare con amici e colleghi. Visualizza i dati con plugin come Kanban, Gallery o Calendar.
+
+    Con API e SDK puoi scalare rapidamente secondo le esigenze, automatizzare l'elaborazione dei dati e automatizzare i processi aziendali.
+
+    **Funzionalità principali:**
+    - Interfaccia simile a un foglio di calcolo per registrare dati con editing collaborativo.
+    - App form per raccogliere dati dall'esterno.
+    - UI mobile-ready da usare nei browser su dispositivi mobili per visualizzare e raccogliere dati.
+    - API e SDK completi per aggiungere estensioni.
+    - Filtri, ordinamenti, grafici e tabelle pivot per visualizzare e analizzare i dati.

--- a/seatable/i18n/ja-JP/OlaresManifest.yaml
+++ b/seatable/i18n/ja-JP/OlaresManifest.yaml
@@ -1,0 +1,32 @@
+metadata:
+  title: SeaTable
+  description: SeaTable はノーコードのデータベース＆アプリ構築プラットフォームです
+spec:
+  upgradeDescription: |
+    v1.0.35: イメージを `seatable/seatable-enterprise:6.2.13`（6.2.12 から）へ。
+
+    v1.0.29: seatableweb リバースプロキシのアップロード上限を 200MB（`client_max_body_size 200m`）に引き上げ、公式 OpenResty プロキシ切り替え後に 1MB 超の添付が HTTP 413 で拒否されないようにします。
+
+    リバースプロキシのイメージを Bitnami OpenResty（`beclab/aboveos-bitnami-openresty:1.25.3-2`）から公式 OpenResty イメージ `openresty/openresty:1.29.2.5-bookworm-fat` に切り替えます。
+
+    nginx 設定のマウントとログパスを公式イメージのレイアウト（`/etc/nginx/conf.d/default.conf`、`/usr/local/openresty/nginx/logs/...`）に合わせ、Bitnami 固有の `OPENRESTY_CONF_FILE` 配線を削除します。
+
+    v1.0.27: `EMAIL_PORT` が空のときの gunicorn 起動クラッシュを修正（`SEATABLE_EMAIL_PORT` は数値にするか省略）。
+    v1.0.26: インストール／リソース下限を引き上げ（`requiredMemory` 4Gi）；`SEATABLE_EMAIL_USE_SSL` と任意の SeaDoc/AI トグルを追加（デフォルトオフ）。
+    v1.0.25: プローブを緩和（nginx :80 の readiness/liveness）し、初回起動の SQL 初期化が途中で殺されないように。
+    v1.0.24: イメージを `seatable/seatable-enterprise:6.2.12`（5.2.7 から）へ；Secret 移行；`sysVersion >= 1.12.3` パス分岐を削除。
+  fullDescription: |
+    **ライセンスを変更してください**
+    これは SeaTable の Enterprise Edition です。利用前に SeaTable から有効な Enterprise On-Premises ライセンスを取得し、ライセンスファイルをインポートする必要があります。
+
+    **概要**
+    SeaTable はノーコードのデータベース＆アプリ構築プラットフォームです。一見 Google スプレッドシートのようなオンライン表計算に見えますが、その裏でははるかに多くの機能を提供します。散在するあらゆる情報の記録・管理を支援します。フィルター、並べ替え、グループで友人や同僚と協働。Kanban、Gallery、Calendar などのプラグインでデータを可視化できます。
+
+    API と SDK でニーズに合わせてすばやく拡張し、データ処理や業務プロセスを自動化できます。
+
+    **主な機能:**
+    - 共同編集対応のスプレッドシート風インターフェースでデータを記録。
+    - 外部からデータを収集するフォームアプリ。
+    - モバイルブラウザで閲覧・収集できるモバイル対応 UI。
+    - 拡張追加のための包括的な API と SDK。
+    - フィルター、並べ替え、チャート、ピボットテーブルでデータの可視化と分析。

--- a/seatable/i18n/zh-CN/OlaresManifest.yaml
+++ b/seatable/i18n/zh-CN/OlaresManifest.yaml
@@ -4,6 +4,8 @@ metadata:
 
 spec:
   upgradeDescription: |
+    v1.0.35: 升级镜像至 `seatable/seatable-enterprise:6.2.13`（自 6.2.12）。
+
     v1.0.29: 将 seatableweb 反向代理上传限制设为 200MB（`client_max_body_size 200m`），避免切换官方 OpenResty 代理后因默认 1MB 限制导致附件上传返回 HTTP 413。
 
     将反向代理镜像从 Bitnami OpenResty（`beclab/aboveos-bitnami-openresty:1.25.3-2`）切换为官方 OpenResty 镜像 `openresty/openresty:1.29.2.5-bookworm-fat`。

--- a/seatable/owners
+++ b/seatable/owners
@@ -1,7 +1,3 @@
 owners:
-- 'LittleLollipop'
-- 'TShentu'
-- 'hysyeah'
-- 'pengpeng'
-- 'harveyff'
-- 'zdf-org'
+  - username: '@beclab'
+    title: 'Olares'

--- a/seatable/templates/clientproxy.yaml
+++ b/seatable/templates/clientproxy.yaml
@@ -2,9 +2,14 @@ apiVersion: v1
 data:
   nginx.conf: |
     server {
+      client_body_temp_path /tmp/client_body;
+      proxy_temp_path /tmp/proxy;
+      fastcgi_temp_path /tmp/fastcgi;
+      uwsgi_temp_path /tmp/uwsgi;
+      scgi_temp_path /tmp/scgi;
         listen 8080;
-        access_log /usr/local/openresty/nginx/logs/access.log;
-        error_log /usr/local/openresty/nginx/logs/error.log;
+        access_log /dev/stdout;
+        error_log /dev/stderr;
 
         proxy_connect_timeout 30s;
         proxy_send_timeout 60s;
@@ -68,9 +73,20 @@ spec:
             items:
               - key: nginx.conf
                 path: nginx.conf
+        - name: nginx-runtime
+          emptyDir: {}
       containers:
         - name: nginx
           image: "docker.io/openresty/openresty:1.29.2.5-bookworm-fat"
+          command:
+            - /usr/local/openresty/bin/openresty
+          args:
+            - -g
+            - "daemon off; pid /tmp/nginx.pid;"
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+
           ports:
             - containerPort: 8080
               protocol: TCP
@@ -98,6 +114,8 @@ spec:
             - name: nginx-config
               mountPath: /etc/nginx/conf.d/default.conf
               subPath: nginx.conf
+            - name: nginx-runtime
+              mountPath: /var/run/openresty
 ---
 apiVersion: v1
 kind: Service

--- a/seatable/templates/seatable.yaml
+++ b/seatable/templates/seatable.yaml
@@ -52,7 +52,7 @@ spec:
               readOnly: true
       containers:
         - name: seatable
-          image: "docker.io/seatable/seatable-enterprise:6.2.12"
+          image: "docker.io/seatable/seatable-enterprise:6.2.13"
           ports:
             - containerPort: 80
           env:


### PR DESCRIPTION
### App Title
seatable

### Description

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`