### PR TITLE
[UPDATE][ntfy][1.0.15] Run the official OpenResty entrance as UID/GID 1000 with writable runtime paths.

### DIFF
--- a/ntfy/Chart.yaml
+++ b/ntfy/Chart.yaml
@@ -15,10 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.8
-
+version: 1.0.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.16.0"
+appVersion: "2.28.0"

--- a/ntfy/OlaresManifest.yaml
+++ b/ntfy/OlaresManifest.yaml
@@ -10,10 +10,13 @@ metadata:
   description: Push notifications made easy
   icon: https://app.cdn.olares.com/appstore/ntfy/icon.png
   appid: ntfy
-  version: '1.0.8'
-  title: ntfy
+  version: '1.0.15'
+  title: Ntfy
   categories:
   - Utilities_v112
+  - developer
+  tags:
+  - messaging
 
 permission:
   appData: true
@@ -22,10 +25,15 @@ permission:
   - Home
 spec:
   upgradeDescription: |
+    Run the official OpenResty entrance as UID/GID 1000 with writable runtime paths.
+    Upgrade ntfy from 2.16 to 2.28.0 (`binwiederhier/ntfy:v2.28.0`). Display title is now “Ntfy”.
+
+    2.17–2.28 include server, web UI, and client notification fixes. Full notes: https://github.com/binwiederhier/ntfy/releases/tag/v2.28.0
+
     Switch the reverse-proxy image from Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) to the official OpenResty image `openresty/openresty:1.29.2.5-bookworm-fat`.
 
     Align nginx config mounts and log paths with the official image layout (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`), and drop Bitnami-specific `OPENRESTY_CONF_FILE` wiring.
-  versionName: '2.16.0'
+  versionName: '2.28.0'
   promoteImage:
   - https://app.cdn.olares.com/appstore/ntfy/1.webp
   - https://app.cdn.olares.com/appstore/ntfy/2.webp
@@ -52,6 +60,11 @@ spec:
   locale:
   - en-US
   - zh-CN
+  - de-DE
+  - es-ES
+  - it-IT
+  - fr-FR
+  - ja-JP
   requiredMemory: 256Mi
   limitedMemory: 2Gi
   requiredDisk: 128Mi
@@ -77,7 +90,7 @@ entrances:
   name: ntfy
   openMethod: window
   port: 8080
-  title: ntfy
+  title: Ntfy
 envs:
 - envName: SMTP_SERVER
   required: false

--- a/ntfy/i18n/de-DE/OlaresManifest.yaml
+++ b/ntfy/i18n/de-DE/OlaresManifest.yaml
@@ -1,0 +1,26 @@
+metadata:
+  title: Ntfy
+  description: Push-Benachrichtigungen leicht gemacht
+spec:
+  upgradeDescription: |
+    ntfy von 2.16 auf 2.28.0 aktualisieren (`binwiederhier/ntfy:v2.28.0`). Anzeigetitel ist jetzt „Ntfy“.
+
+    2.17–2.28 enthalten Korrekturen an Server, Web-UI und Client-Benachrichtigungen. Hinweise: https://github.com/binwiederhier/ntfy/releases/tag/v2.28.0
+
+    Wechsel des Reverse-Proxy-Images von Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) zum offiziellen OpenResty-Image `openresty/openresty:1.29.2.5-bookworm-fat`.
+
+    Nginx-Konfigurations-Mounts und Log-Pfade an das Layout des offiziellen Images anpassen (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`) und Bitnami-spezifisches `OPENRESTY_CONF_FILE`-Wiring entfernen.
+  fullDescription: |
+    ntfy ist ein einfacher HTTP-basierter Pub-Sub-Benachrichtigungsdienst. Damit können Sie Benachrichtigungen von Skripten von jedem Computer und/oder über eine REST-API an Ihr Telefon oder den Desktop senden.
+
+    Push-Benachrichtigungen aus Ihrer App oder Ihrem Skript senden
+    - Nachrichten können per PUT oder POST veröffentlicht werden. Topics werden on-the-fly erstellt, indem man sie abonniert oder daran veröffentlicht. Wenn Sie ntfy ohne Anmeldung nutzen, ist das Topic im Wesentlichen ein Passwort — wählen Sie etwas, das nicht leicht zu erraten ist.
+
+    Benachrichtigungen auf dem Telefon empfangen
+    - Abonnieren Sie ein Topic und empfangen Sie Benachrichtigungen mit unterschiedlichen Prioritäten, Anhängen, Aktionsschaltflächen, Tags & Emojis und auch für Automatisierung.
+
+    Auf dem Computer benachrichtigt werden
+    - Sie können die Web-App ebenfalls nutzen, um Topics zu abonnieren. Dann erscheinen Benachrichtigungen als Desktop-Benachrichtigungen. Geben Sie einfach den Topic-Namen ein und klicken Sie auf Subscribe. Der Browser hält eine Verbindung offen und lauscht auf eingehende Benachrichtigungen.
+
+    Mit Ihren Lieblingstools integrieren
+    - Das Veröffentlichen von Nachrichten ist nur eine HTTP-Anfrage — nahezu alles kann mit ntfy integriert werden. Hunderte von Integrationen, Projekten oder Skripten unterstützen ntfy bereits.

--- a/ntfy/i18n/en-US/OlaresManifest.yaml
+++ b/ntfy/i18n/en-US/OlaresManifest.yaml
@@ -1,8 +1,12 @@
 metadata:
-  title: ntfy
+  title: Ntfy
   description: Push notifications made easy
 spec:
   upgradeDescription: |
+    Upgrade ntfy from 2.16 to 2.28.0 (`binwiederhier/ntfy:v2.28.0`). Display title is now “Ntfy”.
+
+    2.17–2.28 include server, web UI, and client notification fixes. Full notes: https://github.com/binwiederhier/ntfy/releases/tag/v2.28.0
+
     Switch the reverse-proxy image from Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) to the official OpenResty image `openresty/openresty:1.29.2.5-bookworm-fat`.
 
     Align nginx config mounts and log paths with the official image layout (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`), and drop Bitnami-specific `OPENRESTY_CONF_FILE` wiring.

--- a/ntfy/i18n/es-ES/OlaresManifest.yaml
+++ b/ntfy/i18n/es-ES/OlaresManifest.yaml
@@ -1,0 +1,26 @@
+metadata:
+  title: Ntfy
+  description: Notificaciones push fáciles
+spec:
+  upgradeDescription: |
+    Actualiza ntfy de 2.16 a 2.28.0 (`binwiederhier/ntfy:v2.28.0`). El título mostrado pasa a ser “Ntfy”.
+
+    2.17–2.28 incluyen correcciones de servidor, interfaz web y notificaciones de cliente. Notas: https://github.com/binwiederhier/ntfy/releases/tag/v2.28.0
+
+    Cambiar la imagen del proxy inverso de Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) a la imagen oficial de OpenResty `openresty/openresty:1.29.2.5-bookworm-fat`.
+
+    Alinear los montajes de configuración de nginx y las rutas de registro con el diseño de la imagen oficial (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`) y eliminar el cableado específico de Bitnami `OPENRESTY_CONF_FILE`.
+  fullDescription: |
+    ntfy es un servicio sencillo de notificaciones pub-sub basado en HTTP. Te permite enviar notificaciones al teléfono o al escritorio mediante scripts desde cualquier ordenador y/o usando una API REST.
+
+    Envía notificaciones push desde tu app o script
+    - Puedes publicar mensajes mediante PUT o POST. Los topics se crean al vuelo al suscribirse o publicar en ellos. Si usas ntfy sin registro, el topic es esencialmente una contraseña, así que elige algo que no sea fácil de adivinar.
+
+    Recibe notificaciones en el teléfono
+    - Suscríbete a un topic y recibe notificaciones con distintas prioridades, adjuntos, botones de acción, etiquetas y emojis, e incluso para automatización.
+
+    Recibe avisos en el ordenador
+    - También puedes usar la app web para suscribirte a topics. Si lo haces, las notificaciones aparecerán como notificaciones de escritorio. Escribe el nombre del topic y pulsa Subscribe. El navegador mantendrá una conexión abierta y escuchará las notificaciones entrantes.
+
+    Intégralo con tus herramientas favoritas
+    - Publicar mensajes es solo una petición HTTP, así que casi cualquier cosa puede integrarse con ntfy. Cientos de integraciones, proyectos o scripts ya lo soportan.

--- a/ntfy/i18n/fr-FR/OlaresManifest.yaml
+++ b/ntfy/i18n/fr-FR/OlaresManifest.yaml
@@ -1,0 +1,26 @@
+metadata:
+  title: Ntfy
+  description: Les notifications push en toute simplicité
+spec:
+  upgradeDescription: |
+    Mise à jour de ntfy de 2.16 vers 2.28.0 (`binwiederhier/ntfy:v2.28.0`). Le titre affiché est désormais « Ntfy ».
+
+    2.17–2.28 incluent des correctifs serveur, interface web et notifications client. Notes : https://github.com/binwiederhier/ntfy/releases/tag/v2.28.0
+
+    Remplacer l'image du reverse-proxy Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) par l'image officielle OpenResty `openresty/openresty:1.29.2.5-bookworm-fat`.
+
+    Aligner les montages de configuration nginx et les chemins de journaux sur la disposition de l'image officielle (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`), et supprimer le câblage spécifique à Bitnami `OPENRESTY_CONF_FILE`.
+  fullDescription: |
+    ntfy est un service de notifications pub-sub simple basé sur HTTP. Il vous permet d'envoyer des notifications vers votre téléphone ou votre bureau via des scripts depuis n'importe quel ordinateur, et/ou via une API REST.
+
+    Envoyez des notifications push depuis votre appli ou script
+    - La publication de messages peut se faire via PUT ou POST. Les topics sont créés à la volée en s'y abonnant ou en y publiant. Si vous utilisez ntfy sans inscription, le topic est essentiellement un mot de passe — choisissez quelque chose de difficile à deviner.
+
+    Recevez des notifications sur votre téléphone
+    - Abonnez-vous à un topic et recevez des notifications avec différentes priorités, pièces jointes, boutons d'action, tags et emojis, y compris pour l'automatisation.
+
+    Soyez notifié sur votre ordinateur
+    - Vous pouvez aussi utiliser l'appli web pour vous abonner à des topics. Les notifications apparaîtront alors comme notifications de bureau. Saisissez simplement le nom du topic et cliquez sur Subscribe. Le navigateur maintiendra une connexion ouverte et écoutera les notifications entrantes.
+
+    Intégrez avec vos outils préférés
+    - Publier des messages n'est qu'une requête HTTP, donc presque tout peut s'intégrer à ntfy. Des centaines d'intégrations, projets ou scripts le prennent déjà en charge.

--- a/ntfy/i18n/it-IT/OlaresManifest.yaml
+++ b/ntfy/i18n/it-IT/OlaresManifest.yaml
@@ -1,0 +1,26 @@
+metadata:
+  title: Ntfy
+  description: Notifiche push rese semplici
+spec:
+  upgradeDescription: |
+    Aggiorna ntfy da 2.16 a 2.28.0 (`binwiederhier/ntfy:v2.28.0`). Il titolo visualizzato è ora “Ntfy”.
+
+    2.17–2.28 includono correzioni a server, interfaccia web e notifiche client. Note: https://github.com/binwiederhier/ntfy/releases/tag/v2.28.0
+
+    Passare l'immagine del reverse proxy da Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) all'immagine ufficiale OpenResty `openresty/openresty:1.29.2.5-bookworm-fat`.
+
+    Allineare i mount della configurazione nginx e i percorsi dei log al layout dell'immagine ufficiale (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`) e rimuovere il wiring specifico Bitnami `OPENRESTY_CONF_FILE`.
+  fullDescription: |
+    ntfy è un semplice servizio di notifiche pub-sub basato su HTTP. Ti permette di inviare notifiche al telefono o al desktop tramite script da qualsiasi computer e/o usando una REST API.
+
+    Invia notifiche push dalla tua app o script
+    - La pubblicazione dei messaggi può avvenire via PUT o POST. I topic vengono creati al volo sottoscrivendoli o pubblicandovi. Se usi ntfy senza registrazione, il topic è essenzialmente una password: scegli qualcosa di non facilmente indovinabile.
+
+    Ricevi notifiche sul telefono
+    - Sottoscrivi un topic e ricevi notifiche con priorità diverse, allegati, pulsanti di azione, tag ed emoji, anche per l'automazione.
+
+    Ricevi avvisi sul computer
+    - Puoi usare anche la web app per sottoscrivere topic. In tal caso le notifiche appariranno come notifiche desktop. Digita il nome del topic e clicca Subscribe. Il browser terrà aperta una connessione e ascolterà le notifiche in arrivo.
+
+    Integra con i tuoi strumenti preferiti
+    - Pubblicare messaggi è solo una richiesta HTTP, quindi praticamente tutto può integrarsi con ntfy. Centinaia di integrazioni, progetti o script già lo supportano.

--- a/ntfy/i18n/ja-JP/OlaresManifest.yaml
+++ b/ntfy/i18n/ja-JP/OlaresManifest.yaml
@@ -1,0 +1,26 @@
+metadata:
+  title: Ntfy
+  description: 簡単に使えるプッシュ通知
+spec:
+  upgradeDescription: |
+    ntfy を 2.16 から 2.28.0 にアップグレードします（`binwiederhier/ntfy:v2.28.0`）。表示タイトルは “Ntfy” です。
+
+    2.17–2.28 ではサーバー、Web UI、クライアント通知の修正があります。詳細: https://github.com/binwiederhier/ntfy/releases/tag/v2.28.0
+
+    リバースプロキシのイメージを Bitnami OpenResty（`beclab/aboveos-bitnami-openresty:1.25.3-2`）から公式 OpenResty イメージ `openresty/openresty:1.29.2.5-bookworm-fat` に切り替えます。
+
+    nginx 設定のマウントとログパスを公式イメージのレイアウト（`/etc/nginx/conf.d/default.conf`、`/usr/local/openresty/nginx/logs/...`）に合わせ、Bitnami 固有の `OPENRESTY_CONF_FILE` 配線を削除します。
+  fullDescription: |
+    ntfy はシンプルな HTTP ベースの pub-sub 通知サービスです。任意のコンピュータからのスクリプトや REST API を使って、スマートフォンやデスクトップへ通知を送れます。
+
+    アプリやスクリプトからプッシュ通知を送信
+    - PUT または POST でメッセージを公開できます。トピックは購読または公開時にその場で作成されます。サインアップなしで ntfy を使う場合、トピックは実質パスワードなので、推測されにくいものを選んでください。
+
+    スマートフォンで通知を受信
+    - トピックを購読すると、優先度、添付、アクションボタン、タグ＆絵文字付きの通知を受け取れ、自動化にも使えます。
+
+    コンピュータで通知を受け取る
+    - Web アプリでもトピックを購読できます。その場合、通知はデスクトップ通知として表示されます。トピック名を入力して Subscribe をクリックするだけです。ブラウザは接続を維持し、着信通知を待ち受けます。
+
+    お気に入りのツールと統合
+    - メッセージ公開は単なる HTTP リクエストなので、ほとんど何でも ntfy と統合できます。すでに数百の統合・プロジェクト・スクリプトが ntfy をサポートしています。

--- a/ntfy/i18n/zh-CN/OlaresManifest.yaml
+++ b/ntfy/i18n/zh-CN/OlaresManifest.yaml
@@ -1,8 +1,12 @@
 metadata:
-  title: ntfy
+  title: Ntfy
   description: Push notifications made easy
 spec:
   upgradeDescription: |
+    将 ntfy 从 2.16 升级到 2.28.0（`binwiederhier/ntfy:v2.28.0`）。展示标题改为 “Ntfy”。
+
+    2.17–2.28 包含服务端、Web 界面与客户端通知相关修复。完整说明：https://github.com/binwiederhier/ntfy/releases/tag/v2.28.0
+
     将反向代理镜像从 Bitnami OpenResty（`beclab/aboveos-bitnami-openresty:1.25.3-2`）切换为官方 OpenResty 镜像 `openresty/openresty:1.29.2.5-bookworm-fat`。
 
     同步调整 nginx 配置挂载与日志路径以匹配官方镜像布局（`/etc/nginx/conf.d/default.conf`、`/usr/local/openresty/nginx/logs/...`），并移除 Bitnami 专用的 `OPENRESTY_CONF_FILE` 配置。

--- a/ntfy/owners
+++ b/ntfy/owners
@@ -1,8 +1,3 @@
 owners:
-- 'LittleLollipop'
-- 'TShentu'
-- 'hysyeah'
-- 'pengpeng'
-- 'harveyff'
-- 'zdf-org'
-- 'lovehunter9'
+  - username: '@beclab'
+    title: 'Olares'

--- a/ntfy/templates/ingress.yaml
+++ b/ntfy/templates/ingress.yaml
@@ -6,9 +6,14 @@ metadata:
 data:
   nginx.conf: |
     server {
+      client_body_temp_path /tmp/client_body;
+      proxy_temp_path /tmp/proxy;
+      fastcgi_temp_path /tmp/fastcgi;
+      uwsgi_temp_path /tmp/uwsgi;
+      scgi_temp_path /tmp/scgi;
       listen 8080;
-      access_log /usr/local/openresty/nginx/logs/access.log;
-      error_log /usr/local/openresty/nginx/logs/error.log;
+      access_log /dev/stdout;
+      error_log /dev/stderr;
 
       # Support large file uploads
       client_max_body_size 100m;
@@ -68,9 +73,20 @@ spec:
             items:
             - key: nginx.conf
               path: nginx.conf
+        - name: nginx-runtime
+          emptyDir: {}
       containers:
         - name: nginx
           image: "docker.io/openresty/openresty:1.29.2.5-bookworm-fat"
+          command:
+            - /usr/local/openresty/bin/openresty
+          args:
+            - -g
+            - "daemon off; pid /tmp/nginx.pid;"
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+
           ports:
             - containerPort: 8080
               protocol: TCP
@@ -99,6 +115,8 @@ spec:
             - name: nginx-config
               mountPath: /etc/nginx/conf.d/default.conf
               subPath: nginx.conf
+            - name: nginx-runtime
+              mountPath: /var/run/openresty
 ---
 apiVersion: v1
 kind: Service

--- a/ntfy/templates/ntfy.yaml
+++ b/ntfy/templates/ntfy.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: ntfy
-          image: docker.io/beclab/binwiederhier-ntfy:v2.16.0
+          image: docker.io/binwiederhier/ntfy:v2.28.0
           args: [ "serve" ]
           envFrom:
             - configMapRef:


### PR DESCRIPTION
### App Title
ntfy

### Description

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`