### PR TITLE
[UPDATE][opendesign][0.0.17] Fixed access to user-configured model endpoints on private networks. The provider hostname is allowed for its requests only; asset download

### DIFF
--- a/opendesign/Chart.yaml
+++ b/opendesign/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opendesign
 description: Local-first design studio powered by coding agents.
 type: application
-version: 0.0.14
-appVersion: "0.19.2"
+version: 0.0.17
+appVersion: "0.22.1"

--- a/opendesign/Dockerfile
+++ b/opendesign/Dockerfile
@@ -1,0 +1,155 @@
+# Open Design on Olares, based on upstream open-design-v0.22.1 deploy/Dockerfile.
+# Build context: this chart directory; source is fetched in a separate stage.
+# Adds pinned OpenCode and request-scoped support for user-configured providers.
+# docker buildx build --platform linux/amd64,linux/arm64 -t <registry>/opendesign:<new-tag> --load .
+# Smoke-test both architectures before pushing the new tag.
+
+ARG NODE_IMAGE=docker.io/library/node:24-alpine
+ARG RUNTIME_IMAGE=docker.io/library/node:24-alpine
+
+ARG OD_GIT_REF=open-design-v0.22.1
+
+# Source files are architecture-independent; fetch once on the build host.
+FROM --platform=$BUILDPLATFORM ${NODE_IMAGE} AS source
+ARG OD_GIT_REF
+RUN apk add --no-cache git
+WORKDIR /src
+RUN git clone --depth 1 --branch "${OD_GIT_REF}" https://github.com/nexu-io/open-design.git .
+
+FROM ${NODE_IMAGE} AS build
+
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+ARG NO_PROXY
+
+ENV HTTP_PROXY=${HTTP_PROXY}
+ENV HTTPS_PROXY=${HTTPS_PROXY}
+ENV http_proxy=${http_proxy}
+ENV https_proxy=${https_proxy}
+ENV no_proxy=${no_proxy}
+ENV NO_PROXY=${NO_PROXY}
+ENV CI=true
+
+RUN apk add --no-cache python3 make g++
+
+WORKDIR /app
+COPY --from=source /src/package.json /src/pnpm-lock.yaml /src/pnpm-workspace.yaml ./
+COPY --from=source /src/scripts/postinstall.mjs ./scripts/postinstall.mjs
+COPY --from=source /src/packages ./packages
+COPY --from=source /src/tools ./tools
+COPY --from=source /src/apps/daemon/package.json ./apps/daemon/package.json
+COPY --from=source /src/apps/web/package.json ./apps/web/package.json
+COPY --from=source /src/e2e/package.json ./e2e/package.json
+# This Olares app does not request a GPU; keep ONNX CPU binaries and skip
+# downloading the optional CUDA provider during dependency installation.
+RUN corepack enable && \
+    corepack prepare pnpm@10.33.2 --activate && \
+    ONNXRUNTIME_NODE_INSTALL_CUDA=skip pnpm install --frozen-lockfile
+
+COPY --from=source /src/apps ./apps
+COPY patches/apply-provider-hosts.mjs /tmp/apply-provider-hosts.mjs
+RUN node /tmp/apply-provider-hosts.mjs /app
+RUN pnpm --filter @open-design/daemon build && \
+    pnpm --filter @open-design/web build && \
+    pnpm --filter @open-design/daemon deploy --legacy --prod /app/deploy/daemon && \
+    pnpm store prune && \
+    rm -rf \
+      /root/.cache \
+      /root/.local/share/pnpm/store \
+      /app/deploy/daemon/node_modules/.cache \
+      /app/deploy/daemon/node_modules/@types \
+      /app/deploy/daemon/node_modules/.pnpm/@types+* \
+      /app/deploy/daemon/node_modules/.pnpm/better-sqlite3@*/node_modules/better-sqlite3/deps \
+      /app/deploy/daemon/node_modules/.pnpm/better-sqlite3@*/node_modules/better-sqlite3/src && \
+    find /app/deploy/daemon/node_modules -type d \( \
+      -name test -o \
+      -name tests -o \
+      -name "__tests__" -o \
+      -name docs -o \
+      -name doc -o \
+      -name example -o \
+      -name examples -o \
+      -name ".github" \
+    \) -prune -exec rm -rf '{}' + && \
+    find /app/deploy/daemon/node_modules -type f \( \
+      -name "*.md" -o \
+      -name "*.markdown" -o \
+      -name "*.d.ts" -o \
+      -name "*.d.cts" -o \
+      -name "*.d.mts" -o \
+      -name "*.map" -o \
+      -name "*.tsbuildinfo" -o \
+      -name "binding.gyp" \
+    \) -delete
+
+# Stage-2 assets — copied into the build stage so the runtime stage
+# can pull them via --from=build instead of reaching back into the
+# build context.  This lets the Dockerfile work when the build context
+# differs from the repo root (Railway, CI runners with a subdirectory
+# context, etc.).
+COPY --from=source /src/skills ./skills
+COPY --from=source /src/design-systems ./design-systems
+COPY --from=source /src/craft ./craft
+COPY --from=source /src/prompt-templates ./prompt-templates
+COPY --from=source /src/assets ./assets
+# `data/plugin-previews/manifest.json` is committed by the bake pipeline and is
+# what `resolvePluginPreviewsDir()` looks for at runtime. Without it in the
+# image, `loadManifest()` returns `{}` and every plugin silently falls back to
+# the live-iframe preview path — the exact cost the bakes exist to avoid.
+COPY --from=source /src/data ./data
+COPY --from=source /src/plugins/_official ./plugins/_official
+
+FROM ${RUNTIME_IMAGE}
+
+# node:24-alpine already supplies node with UID/GID 1000.
+ARG OPENCODE_VERSION=1.18.30
+RUN apk add --no-cache tini poppler-utils bash git && \
+    test "$(id -u node)" = 1000 && test "$(id -g node)" = 1000 && \
+    npm install --global --prefix /opt/opencode "opencode-ai@${OPENCODE_VERSION}" && \
+    npm cache clean --force
+
+# New npm versions may skip dependency lifecycle scripts. OpenCode ships a
+# placeholder until its pinned postinstall selects and verifies the native binary.
+RUN node /opt/opencode/lib/node_modules/opencode-ai/postinstall.mjs
+
+WORKDIR /app
+COPY --from=build --chown=node:node /app/deploy/daemon ./apps/daemon
+COPY --from=build --chown=node:node /app/apps/web/out ./apps/web/out
+COPY --from=build --chown=node:node /app/skills ./skills
+COPY --from=build --chown=node:node /app/design-systems ./design-systems
+COPY --from=build --chown=node:node /app/craft ./craft
+COPY --from=build --chown=node:node /app/prompt-templates ./prompt-templates
+COPY --from=build --chown=node:node /app/data ./data
+COPY --from=build --chown=node:node /app/assets/frames ./assets/frames
+COPY --from=build --chown=node:node /app/assets/community-pets ./assets/community-pets
+# Plan §3.J4 / spec §23.3.5 — bundled atom plugins registered on
+# daemon boot. The directory contains `plugins/_official/atoms/<atom>/`
+# pairs (SKILL.md + open-design.json); registerBundledPlugins() walks
+# it on startup so the container ships with first-party atoms reachable
+# via the same registry path third-party plugins use.
+COPY --from=build --chown=node:node /app/plugins/_official ./plugins/_official
+
+RUN mkdir -p /app/.od && \
+    chown -R node:node /app
+
+ENV NODE_ENV=production
+ENV NODE_OPTIONS=--max-old-space-size=192
+ENV OD_BIND_HOST=0.0.0.0
+ENV OD_PORT=7456
+
+EXPOSE 7456
+
+ENV HOME=/app/.od
+ENV PATH=/opt/opencode/bin:$PATH
+ENV OD_DATA_DIR=/app/.od
+
+USER node
+# Verify the selected native binary works as the actual non-root runtime user.
+RUN opencode --version
+COPY --chown=node:node patches/provider-hosts.test.mjs /tmp/provider-hosts.test.mjs
+RUN node --test /tmp/provider-hosts.test.mjs
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["node", "apps/daemon/dist/cli.js", "--no-open"]

--- a/opendesign/OlaresManifest.yaml
+++ b/opendesign/OlaresManifest.yaml
@@ -8,9 +8,9 @@ metadata:
   name: opendesign
   appid: opendesign
   title: Open Design
-  description: Local-first AI design studio for slides, prototypes, and decks on Olares.
+  description: Local-first AI design studio for slides, prototypes, and decks on Olares
   icon: https://cdn.olares.com/images/2026/08/919ec8a2cbd0b0285ee33e455376c90b.png
-  version: 0.0.14
+  version: 0.0.17
   categories:
   - Creativity
   - agents
@@ -20,7 +20,7 @@ metadata:
   - design
 
 spec:
-  versionName: '0.19.2'
+  versionName: '0.22.1'
   featuredImage: https://cdn.olares.com/images/2026/08/0021804b205933301ee29bb63136a996.png
   promoteImage:
   - https://cdn.olares.com/images/2026/08/0021804b205933301ee29bb63136a996.png
@@ -50,17 +50,28 @@ spec:
     3. In Open Design, open Settings → Models & Providers → API Provider. Set Base URL, model id, and Max tokens (65536 or 32768).
     4. Start with a simple single-slide prompt, then move to multi-page decks.
   upgradeDescription: |
-    Open Design 0.0.14
+    Fixed access to user-configured model endpoints on private networks. The provider hostname is allowed for its requests only; asset download restrictions remain unchanged. Added arm64 support.
 
-    - Seed app-config with onboardingCompleted so Olares installs open the workspace directly.
-    - Existing installs missing that flag are patched on pod start; no OpenDesign cloud login required.
+    Upgraded Open Design to 0.22.1 and bundled OpenCode 1.18.30.
+
+    Improved failed-run recovery, API key error guidance, and Docker plugin previews.
+
+    Back up application data before upgrading. Existing application data remains mounted at `/app/.od`.
+
+    Release notes: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.22.1
+
   developer: nexu-io
   website: https://open-design.ai/
   sourceCode: https://github.com/nexu-io/open-design
-  submitter: harveyff
+  submitter: Olares
   locale:
   - en-US
   - zh-CN
+  - de-DE
+  - es-ES
+  - it-IT
+  - fr-FR
+  - ja-JP
   license:
   - text: Apache-2.0
     url: https://github.com/nexu-io/open-design/blob/main/LICENSE

--- a/opendesign/i18n/de-DE/OlaresManifest.yaml
+++ b/opendesign/i18n/de-DE/OlaresManifest.yaml
@@ -1,0 +1,37 @@
+metadata:
+  title: Open Design
+  description: Local-first KI-Designstudio für Folien, Prototypen und Decks auf Olares
+spec:
+  fullDescription: |
+    Open Design ist ein local-first KI-Designstudio von nexu-io/open-design. Auf Olares läuft es als Web-App mit BYOK-Modellanbietern, OpenCode-Agenten-Workflows und echten HTML/PDF/PPTX-Artefakten.
+    
+    Highlights
+    - Folien, Landing Pages, Wireframes und Designdokumente aus Prompts generieren
+    - Olares-gehostetes llama.cpp oder LiteLLM als OpenAI-kompatible Gateways verbinden
+    - Gebündelte OpenCode-Runtime für agentengesteuerte Designaufgaben
+    - Persistente Projektdaten unter appData
+    
+    Empfohlene Einrichtung auf Olares
+    - Modell: ein lokales Qwen3.8-Modell nutzen, das von llama.cpp bereitgestellt wird (z. B. Qwen3.8-27B) auf Ihrem Olares-Knoten
+    - Max tokens: 65536 oder 32768 in den Open-Design-Einstellungen setzen, um abgeschnittene Läufe bei mehrstufigen Decks zu reduzieren
+    - Olares-gehostete Modell-Base-URLs werden von Ihrem konfigurierten Provider-Hostnamen automatisch erlaubt; zusätzliche Hostnamen nur bei Bedarf in OD_ALLOWED_INTERNAL_HOSTS hinzufügen
+    
+    Anforderungen
+    - Olares >= 1.12.6
+    - amd64- oder arm64-Knoten
+    
+    Erste Schritte
+    1. Open Design aus dem Markt installieren.
+    2. Ein lokales Qwen3.8-llama.cpp-Modell installieren und starten, dann die OpenAI-kompatible Base URL kopieren.
+    3. In Open Design Einstellungen → Models & Providers → API Provider öffnen. Base URL, Modell-ID und Max tokens (65536 oder 32768) setzen.
+    4. Mit einem einfachen Ein-Folien-Prompt starten, dann zu mehrseitigen Decks übergehen.
+  upgradeDescription: |
+    Der Zugriff auf benutzerdefinierte Modell-Endpunkte in privaten Netzwerken wurde korrigiert. Der Provider-Hostname wird nur für seine Anfragen zugelassen; Einschränkungen für Asset-Downloads bleiben unverändert. arm64 wird jetzt unterstützt.
+
+    Open Design wurde auf 0.22.1 aktualisiert und enthält OpenCode 1.18.30.
+
+    Die Wiederherstellung fehlgeschlagener Aufgaben, Hinweise zu API-Schlüsselfehlern und Plugin-Vorschauen in Docker wurden verbessert.
+
+    Sichern Sie die Anwendungsdaten vor dem Upgrade. Bestehende Daten bleiben unter `/app/.od` eingebunden.
+
+    Versionshinweise: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.22.1

--- a/opendesign/i18n/en-US/OlaresManifest.yaml
+++ b/opendesign/i18n/en-US/OlaresManifest.yaml
@@ -1,6 +1,6 @@
 metadata:
   title: Open Design
-  description: Local-first AI design studio for slides, prototypes, and decks on Olares.
+  description: Local-first AI design studio for slides, prototypes, and decks on Olares
 
 spec:
   fullDescription: |
@@ -27,8 +27,12 @@ spec:
     3. In Open Design, open Settings → Models & Providers → API Provider. Set Base URL, model id, and Max tokens (65536 or 32768).
     4. Start with a simple single-slide prompt, then move to multi-page decks.
   upgradeDescription: |
-    Open Design 0.0.12
+    Fixed access to user-configured model endpoints on private networks. The provider hostname is allowed for its requests only; asset download restrictions remain unchanged. Added arm64 support.
 
-    - Switch to beclab/harveyff-opendesign:0.19.2-2 (amd64 and arm64).
-    - Fix OpenCode output cap and long-run inactivity timeout for local llama.cpp decks.
-    - Auto-allow Olares model API hostnames from configured BYOK Base URL.
+    Upgraded Open Design to 0.22.1 and bundled OpenCode 1.18.30.
+
+    Improved failed-run recovery, API key error guidance, and Docker plugin previews.
+
+    Back up application data before upgrading. Existing application data remains mounted at `/app/.od`.
+
+    Release notes: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.22.1

--- a/opendesign/i18n/es-ES/OlaresManifest.yaml
+++ b/opendesign/i18n/es-ES/OlaresManifest.yaml
@@ -1,0 +1,37 @@
+metadata:
+  title: Open Design
+  description: Estudio de diseño con IA local-first para diapositivas, prototipos y decks en Olares
+spec:
+  fullDescription: |
+    Open Design es un estudio de diseño con IA local-first de nexu-io/open-design. En Olares se ejecuta como una app web con proveedores de modelos BYOK, flujos de agentes OpenCode y artefactos reales HTML/PDF/PPTX.
+    
+    Destacados
+    - Genera diapositivas, landing pages, wireframes y documentos de diseño a partir de prompts
+    - Conecta llama.cpp o LiteLLM alojados en Olares como puertas de enlace compatibles con OpenAI
+    - Runtime OpenCode incluido para tareas de diseño impulsadas por agentes
+    - Datos de proyecto persistentes en appData
+    
+    Configuración recomendada en Olares
+    - Modelo: usa un modelo Qwen3.8 local servido por llama.cpp (por ejemplo Qwen3.8-27B) en tu nodo Olares
+    - Max tokens: establece 65536 o 32768 en los ajustes de Open Design para reducir ejecuciones truncadas en decks de varios pasos
+    - Las Base URL de modelos alojados en Olares se permiten automáticamente desde el hostname del proveedor configurado; añade hostnames extra en OD_ALLOWED_INTERNAL_HOSTS solo cuando sea necesario
+    
+    Requisitos
+    - Olares >= 1.12.6
+    - Nodo amd64 o arm64
+    
+    Primeros pasos
+    1. Instala Open Design desde Mercado.
+    2. Instala e inicia un modelo Qwen3.8 local con llama.cpp, luego copia su Base URL compatible con OpenAI.
+    3. En Open Design, abre Ajustes → Models & Providers → API Provider. Establece Base URL, model id y Max tokens (65536 o 32768).
+    4. Empieza con un prompt simple de una diapositiva y luego pasa a decks multipágina.
+  upgradeDescription: |
+    Se corrigió el acceso a los endpoints de modelos configurados por el usuario en redes privadas. El hostname del proveedor solo se permite para sus solicitudes; se mantienen las restricciones de descarga de recursos. Se añadió soporte para arm64.
+
+    Open Design se ha actualizado a 0.22.1 e incluye OpenCode 1.18.30.
+
+    Se han mejorado la recuperación de tareas fallidas, las indicaciones sobre errores de claves API y las vistas previas de plugins en Docker.
+
+    Haga una copia de seguridad antes de actualizar. Los datos existentes siguen montados en `/app/.od`.
+
+    Notas de la versión: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.22.1

--- a/opendesign/i18n/fr-FR/OlaresManifest.yaml
+++ b/opendesign/i18n/fr-FR/OlaresManifest.yaml
@@ -1,0 +1,37 @@
+metadata:
+  title: Open Design
+  description: Studio de design IA local-first pour diapositives, prototypes et decks sur Olares
+spec:
+  fullDescription: |
+    Open Design est un studio de design IA local-first de nexu-io/open-design. Sur Olares, il s'exécute en application web avec des fournisseurs de modèles BYOK, des workflows d'agents OpenCode et de vrais artefacts HTML/PDF/PPTX.
+    
+    Points forts
+    - Générer diapositives, landing pages, wireframes et documents de design à partir de prompts
+    - Connecter llama.cpp ou LiteLLM hébergés sur Olares comme passerelles compatibles OpenAI
+    - Runtime OpenCode inclus pour les tâches de design pilotées par agents
+    - Données de projet persistantes sous appData
+    
+    Configuration recommandée sur Olares
+    - Modèle : utilisez un modèle Qwen3.8 local servi par llama.cpp (par exemple Qwen3.8-27B) sur votre nœud Olares
+    - Max tokens : définissez 65536 ou 32768 dans les réglages Open Design pour réduire les exécutions tronquées sur les decks multi-étapes
+    - Les Base URL des modèles hébergés sur Olares sont auto-autorisées depuis le hostname du fournisseur configuré ; ajoutez des hostnames supplémentaires dans OD_ALLOWED_INTERNAL_HOSTS uniquement si nécessaire
+    
+    Exigences
+    - Olares >= 1.12.6
+    - Nœud amd64 ou arm64
+    
+    Pour démarrer
+    1. Installez Open Design depuis le Marché.
+    2. Installez et démarrez un modèle Qwen3.8 local llama.cpp, puis copiez son Base URL compatible OpenAI.
+    3. Dans Open Design, ouvrez Paramètres → Models & Providers → API Provider. Définissez Base URL, model id et Max tokens (65536 ou 32768).
+    4. Commencez par un prompt simple d'une diapositive, puis passez à des decks multipages.
+  upgradeDescription: |
+    Correction de l’accès aux endpoints de modèles configurés par l’utilisateur sur les réseaux privés. Le nom d’hôte du fournisseur est autorisé uniquement pour ses requêtes ; les restrictions de téléchargement des ressources restent inchangées. Ajout de la prise en charge d’arm64.
+
+    Open Design a été mis à jour vers la version 0.22.1 et inclut OpenCode 1.18.30.
+
+    La reprise des tâches en échec, les indications sur les erreurs de clé API et les aperçus des plugins dans Docker ont été améliorés.
+
+    Sauvegardez les données avant la mise à jour. Les données existantes restent montées dans `/app/.od`.
+
+    Notes de version : https://github.com/nexu-io/open-design/releases/tag/open-design-v0.22.1

--- a/opendesign/i18n/it-IT/OlaresManifest.yaml
+++ b/opendesign/i18n/it-IT/OlaresManifest.yaml
@@ -1,0 +1,37 @@
+metadata:
+  title: Open Design
+  description: Studio di design IA local-first per slide, prototipi e deck su Olares
+spec:
+  fullDescription: |
+    Open Design è uno studio di design IA local-first di nexu-io/open-design. Su Olares gira come web app con provider di modelli BYOK, workflow agent OpenCode e artefatti reali HTML/PDF/PPTX.
+    
+    Highlights
+    - Genera slide, landing page, wireframe e documenti di design dai prompt
+    - Collega llama.cpp o LiteLLM ospitati su Olares come gateway compatibili OpenAI
+    - Runtime OpenCode incluso per attività di design guidate da agenti
+    - Dati di progetto persistenti sotto appData
+    
+    Configurazione consigliata su Olares
+    - Modello: usa un modello Qwen3.8 locale servito da llama.cpp (ad esempio Qwen3.8-27B) sul tuo nodo Olares
+    - Max tokens: imposta 65536 o 32768 nelle impostazioni di Open Design per ridurre esecuzioni troncate su deck multi-step
+    - Le Base URL dei modelli ospitati su Olares sono auto-consentite dall'hostname del provider configurato; aggiungi hostname extra in OD_ALLOWED_INTERNAL_HOSTS solo quando necessario
+    
+    Requisiti
+    - Olares >= 1.12.6
+    - Nodo amd64 o arm64
+    
+    Per iniziare
+    1. Installa Open Design dal Mercato.
+    2. Installa e avvia un modello Qwen3.8 locale con llama.cpp, poi copia la sua Base URL compatibile OpenAI.
+    3. In Open Design, apri Impostazioni → Models & Providers → API Provider. Imposta Base URL, model id e Max tokens (65536 o 32768).
+    4. Inizia con un semplice prompt a una slide, poi passa a deck multipagina.
+  upgradeDescription: |
+    Corretto l’accesso agli endpoint dei modelli configurati dall’utente su reti private. L’hostname del provider è consentito solo per le relative richieste; le restrizioni sul download delle risorse restano invariate. Aggiunto il supporto arm64.
+
+    Open Design è stato aggiornato alla versione 0.22.1 e include OpenCode 1.18.30.
+
+    Sono stati migliorati il recupero delle attività non riuscite, le indicazioni sugli errori delle chiavi API e le anteprime dei plugin in Docker.
+
+    Eseguire un backup prima di aggiornare. I dati esistenti restano montati in `/app/.od`.
+
+    Note di rilascio: https://github.com/nexu-io/open-design/releases/tag/open-design-v0.22.1

--- a/opendesign/i18n/ja-JP/OlaresManifest.yaml
+++ b/opendesign/i18n/ja-JP/OlaresManifest.yaml
@@ -1,0 +1,37 @@
+metadata:
+  title: Open Design
+  description: Olares 上のスライド、プロトタイプ、デッキ向けローカルファースト AI デザインスタジオ
+spec:
+  fullDescription: |
+    Open Design は nexu-io/open-design によるローカルファーストの AI デザインスタジオです。Olares 上では BYOK モデルプロバイダー、OpenCode エージェントワークフロー、実 HTML/PDF/PPTX 成果物付きの Web アプリとして動作します。
+    
+    ハイライト
+    - プロンプトからスライド、ランディングページ、ワイヤーフレーム、デザイン文書を生成
+    - Olares ホストの llama.cpp または LiteLLM を OpenAI 互換ゲートウェイとして接続
+    - エージェント駆動のデザインタスク向けに OpenCode ランタイムを同梱
+    - appData 配下に永続的なプロジェクトデータ
+    
+    Olares での推奨セットアップ
+    - モデル: Olares ノード上で llama.cpp が提供するローカル Qwen3.8 モデル（例: Qwen3.8-27B）を使用
+    - Max tokens: 多段階デッキでの途切れを減らすため、Open Design 設定で 65536 または 32768 を設定
+    - Olares ホストのモデル Base URL は設定済みプロバイダーのホスト名から自動許可；追加ホスト名は必要な場合のみ OD_ALLOWED_INTERNAL_HOSTS に追加
+    
+    要件
+    - Olares >= 1.12.6
+    - amd64 または arm64 ノード
+    
+    始め方
+    1. マーケットから Open Design をインストール。
+    2. ローカル Qwen3.8 llama.cpp モデルをインストールして起動し、OpenAI 互換 Base URL をコピー。
+    3. Open Design で設定 → Models & Providers → API Provider を開く。Base URL、model id、Max tokens（65536 または 32768）を設定。
+    4. まず簡単な 1 スライドのプロンプトから始め、その後マルチページデッキへ。
+  upgradeDescription: |
+    ユーザーが設定したプライベートネットワーク上のモデル接続先へのアクセスを修正しました。モデルのリクエストに限り対応するホスト名を許可し、リソースのダウンロード制限は維持します。arm64対応を追加しました。
+
+    Open Designを0.22.1に更新し、OpenCode 1.18.30を同梱しました。
+
+    失敗したタスクの復旧、APIキーのエラー案内、Dockerのプラグインプレビューを改善しました。
+
+    更新前にアプリのデータをバックアップしてください。既存データのマウント先は引き続き`/app/.od`です。
+
+    リリースノート：https://github.com/nexu-io/open-design/releases/tag/open-design-v0.22.1

--- a/opendesign/i18n/zh-CN/OlaresManifest.yaml
+++ b/opendesign/i18n/zh-CN/OlaresManifest.yaml
@@ -1,6 +1,6 @@
 metadata:
   title: Open Design
-  description: 在 Olares 上运行的本地优先 AI 设计工作室，支持幻灯片、原型与 Deck 生成。
+  description: 在 Olares 上运行的本地优先 AI 设计工作室，支持幻灯片、原型与 Deck 生成
 
 spec:
   fullDescription: |
@@ -27,8 +27,12 @@ spec:
     3. 在 Open Design 中进入 设置 → 模型与提供商 → API 提供商，配置 Base URL、模型 ID，并将 Max tokens 设为 65536 或 32768。
     4. 先用简单单页任务验证，再尝试多页 Deck。
   upgradeDescription: |
-    Open Design 0.0.12
+    修复用户配置的内网模型地址被拦截的问题。仅对模型请求放行对应主机名，资源下载限制保持不变。新增 arm64 支持。
 
-    - 切换至 beclab/harveyff-opendesign:0.19.2-2（支持 amd64 与 arm64）。
-    - 修复 OpenCode 输出上限与长任务无活动超时，适配本地 llama.cpp 多步 Deck。
-    - BYOK Base URL 主机名自动放行，减少 Internal IPs blocked。
+    Open Design 已升级至 0.22.1，并内置 OpenCode 1.18.30。
+
+    改进了失败任务恢复、API Key 错误提示和 Docker 插件预览。
+
+    升级前请备份应用数据。现有应用数据仍挂载在 `/app/.od`。
+
+    发布说明：https://github.com/nexu-io/open-design/releases/tag/open-design-v0.22.1

--- a/opendesign/patches/README.md
+++ b/opendesign/patches/README.md
@@ -1,0 +1,20 @@
+# Olares provider endpoint adaptation
+
+Upstream: `nexu-io/open-design`, tag `open-design-v0.22.1`.
+
+`apply-provider-hosts.mjs` runs before compilation. It adds the hostname from
+the user-configured HTTP(S) model Base URL to a request-local allowlist. This
+covers model discovery, connection checks, chat proxy requests and handoff
+summaries. It neither persists hosts nor mutates the process environment, so
+changing a provider URL leaves no stale global allowance behind.
+
+The upstream URL syntax/protocol checks remain active. URLs supplied by upstream
+responses, such as generated asset download links, retain their separate strict
+SSRF validation and do not inherit this allowance.
+
+Patch contexts must match exactly once; a changed upstream implementation fails
+the build instead of silently omitting the adaptation. Both target images run
+`provider-hosts.test.mjs` against the compiled daemon module during construction.
+This checks private provider endpoints, invalid protocols and isolation from
+asset-download validation. Actual model quality and generation need separate
+user testing.

--- a/opendesign/patches/apply-provider-hosts.mjs
+++ b/opendesign/patches/apply-provider-hosts.mjs
@@ -1,0 +1,36 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = process.argv[2] || '/app';
+function replaceOnce(file, before, after) {
+  const path = join(root, file);
+  const source = readFileSync(path, 'utf8');
+  if (source.split(before).length !== 2) throw new Error(`Upstream patch context changed: ${file}`);
+  writeFileSync(path, source.replace(before, after));
+}
+
+replaceOnce('apps/daemon/src/connectionTest.ts',
+`  return validateBaseUrlResolved(baseUrl, lookup, {
+    allowedInternalHosts: configuredAllowedInternalHosts(),
+  });`,
+`  // Olares: the user explicitly chose this provider endpoint. Trust its exact
+  // hostname for this request only; never mutate the process-wide allowlist.
+  // Asset URLs still use the strict validateBaseUrlResolved path below.
+  const allowedInternalHosts = configuredAllowedInternalHosts();
+  try {
+    const provider = new URL(baseUrl);
+    if (provider.protocol === 'http:' || provider.protocol === 'https:') {
+      allowedInternalHosts.push(provider.hostname.toLowerCase());
+    }
+  } catch {
+    // Preserve upstream validation and its error message for malformed URLs.
+  }
+  return validateBaseUrlResolved(baseUrl, lookup, { allowedInternalHosts });`);
+
+// Handoff summaries also use the user-configured provider endpoint.
+replaceOnce('apps/daemon/src/server.ts',
+  '  validateBaseUrlResolved,', '  validateUserProviderBaseUrl,');
+replaceOnce('apps/daemon/src/server.ts',
+  'const validateExternalApiBaseUrl = (baseUrl) => validateBaseUrlResolved(baseUrl);',
+  'const validateExternalApiBaseUrl = (baseUrl) => validateUserProviderBaseUrl(baseUrl);');
+console.log('Applied Olares request-scoped provider hostname support');

--- a/opendesign/patches/provider-hosts.test.mjs
+++ b/opendesign/patches/provider-hosts.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { validateUserProviderBaseUrl, validateBaseUrlResolved, assertExternalAssetUrl } from '/app/apps/daemon/dist/connectionTest.js';
+
+const privateDns = async () => [{ address: '192.168.50.138', family: 4 }];
+test('user provider domains and private literals work without a preset hostname', async () => {
+  for (const url of ['https://4824d8d8.olarestest001.olares.com/v1', 'https://another.example/v1', 'http://10.0.0.8:8080/v1', 'http://[fd00::8]:8080/v1']) {
+    const result = await validateUserProviderBaseUrl(url, privateDns);
+    assert.equal(result.error, undefined, url);
+    assert.ok(result.parsed, url);
+  }
+});
+test('provider URL still requires HTTP or HTTPS', async () => {
+  for (const url of ['not-a-url', 'file:///etc/passwd', 'ftp://example.com']) {
+    assert.ok((await validateUserProviderBaseUrl(url, privateDns)).error, url);
+  }
+});
+test('allowance does not leak to other URLs or upstream assets', async () => {
+  await validateUserProviderBaseUrl('https://another.example/v1', privateDns);
+  assert.ok((await validateBaseUrlResolved('https://another.example/file', privateDns)).error);
+  assert.equal((await assertExternalAssetUrl('https://another.example/file', privateDns)).ok, false);
+  assert.equal((await assertExternalAssetUrl('http://169.254.169.254/latest/meta-data', privateDns)).ok, false);
+});

--- a/opendesign/templates/opendesign.yaml
+++ b/opendesign/templates/opendesign.yaml
@@ -32,7 +32,7 @@ spec:
         - -c
         - |
           set -e
-          for d in /app/.od /tmp /app/.od/agent-tools/bin /app/.od/agent-tools/lib /app/.od/.config/opencode; do
+          for d in /app/.od /tmp /app/.od/.config/opencode; do
             mkdir -p "$d" && chown 1000:1000 "$d"
           done
           printf '%s\n' '{"permission":{"external_directory":{"/app/**":"allow"},"bash":{"*":"allow"},"read":{"*":"allow"},"write":{"*":"allow"}}}' > /app/.od/.config/opencode/opencode.json
@@ -71,50 +71,15 @@ spec:
           mountPath: /app/.od
         - name: tmp
           mountPath: /tmp
-      - name: install-opencode
-        image: docker.io/beclab/alpine:3.18
-        imagePullPolicy: IfNotPresent
-        command:
-        - sh
-        - -c
-        - |
-          set -ex
-          OPENCODE_VERSION=1.18.18
-          INSTALL_BIN=/app/.od/agent-tools/bin/opencode
-          if [ -x "$INSTALL_BIN" ] && "$INSTALL_BIN" --version >/dev/null 2>&1; then
-            exit 0
-          fi
-          rm -rf /app/.od/.opencode /app/.od/agent-tools
-          mkdir -p /app/.od/agent-tools/bin
-          apk add --no-cache curl ca-certificates libstdc++ libgcc
-          curl -fsSL -o /tmp/opencode.tar.gz \
-            "https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-x64-baseline-musl.tar.gz"
-          tar -xzf /tmp/opencode.tar.gz -C /app/.od/agent-tools/bin
-          chmod 755 /app/.od/agent-tools/bin/opencode
-          rm -f /tmp/opencode.tar.gz
-          /app/.od/agent-tools/bin/opencode --version
-          chown -R 1000:1000 /app/.od/agent-tools
-        securityContext:
-          runAsUser: 0
-        resources:
-          requests:
-            cpu: 100m
-            memory: 256Mi
-          limits:
-            cpu: 1000m
-            memory: 1Gi
-        volumeMounts:
-        - name: app-data
-          mountPath: /app/.od
       containers:
       - name: opendesign
-        image: docker.io/beclab/harveyff-opendesign:0.19.2-2
+        image: docker.io/beclab/harveyff-opendesign:0.22.1-4
         imagePullPolicy: IfNotPresent
         env:
         - name: HOME
           value: /app/.od
         - name: PATH
-          value: /app/.od/agent-tools/bin:/usr/local/bin:/usr/bin:/bin
+          value: /opt/opencode/bin:/usr/local/bin:/usr/bin:/bin
         - name: OPENCODE_CONFIG_CONTENT
           value: '{"permission":{"external_directory":{"/app/**":"allow"},"bash":{"*":"allow"},"read":{"*":"allow"},"write":{"*":"allow"}}}'
         - name: OD_OPENCODE_MAX_OUTPUT_TOKENS
@@ -164,6 +129,8 @@ spec:
             cpu: 1000m
             memory: 2Gi
         securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
           allowPrivilegeEscalation: false
         volumeMounts:
         - name: app-data


### PR DESCRIPTION
### App Title
opendesign

### Description

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`