### PR TITLE
[UPDATE][homeassistant][1.0.37] v1.0.36: Upgrade Home Assistant Core to 2026.9.1. Modbus setup can pick

### DIFF
--- a/homeassistant/Chart.yaml
+++ b/homeassistant/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.36
+version: 1.0.37
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/homeassistant/OlaresManifest.yaml
+++ b/homeassistant/OlaresManifest.yaml
@@ -9,7 +9,7 @@ metadata:
   description: Awaken your home
   icon: https://app.cdn.olares.com/appstore/homeassistant/icon.png
   appid: homeassistant
-  version: '1.0.36'
+  version: '1.0.37'
   title: Home Assistant
   categories:
   - Lifestyle
@@ -131,6 +131,7 @@ entrances:
   title: Home Assistant
   icon: https://app.cdn.olares.com/appstore/homeassistant/icon.png
   authLevel: internal
+  openMethod: window
 overlayGateway:
   enable: true
   entrances:

--- a/homeassistant/templates/deployment.yaml
+++ b/homeassistant/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
           securityContext:
             runAsUser: 0
         - name: init-http-config
-          image: "homeassistant/home-assistant:2026.9.1"
+          image: "beclab/homeassistant-home-assistant:2026.9.1"
           command:
             - python3
             - /bootstrap/http-bootstrap.py
@@ -80,7 +80,7 @@ spec:
             runAsUser: 1000
       containers:
         - name: homeassistant
-          image: "homeassistant/home-assistant:2026.9.1"
+          image: "beclab/homeassistant-home-assistant:2026.9.1"
           {{- if eq (toString .Values.olaresEnv.USB_PASSTHROUGH) "true" }}
           securityContext:
             privileged: true


### PR DESCRIPTION
### App Title
homeassistant

### Description

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`