### PR TITLE
[UPDATE][metube][1.0.13] Run the official OpenResty entrance as UID/GID 1000 with writable runtime paths.

### DIFF
--- a/metube/Chart.yaml
+++ b/metube/Chart.yaml
@@ -15,10 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.6
-
+version: 1.0.13
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2026.01.11"
+appVersion: "2026.08.28"

--- a/metube/OlaresManifest.yaml
+++ b/metube/OlaresManifest.yaml
@@ -10,10 +10,13 @@ metadata:
   description: Self-hosted YouTube downloader
   icon: https://app.cdn.olares.com/appstore/metube/icon.png
   appid: metube
-  version: '1.0.6'
+  version: '1.0.13'
   title: Metube
   categories:
   - Utilities_v112
+  - homelab
+  tags:
+  - downloader
 
 permission:
   appData: true
@@ -22,10 +25,15 @@ permission:
   - Home
 spec:
   upgradeDescription: |
+    Run the official OpenResty entrance as UID/GID 1000 with writable runtime paths.
+    Upgrade MeTube from 2026.01.11 to 2026.08.28 (`alexta69/metube:2026.08.28`).
+
+    This tag updates yt-dlp and the download UI. Releases: https://github.com/alexta69/metube/releases
+
     Switch the reverse-proxy image from Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) to the official OpenResty image `openresty/openresty:1.29.2.5-bookworm-fat`.
 
     Align nginx config mounts and log paths with the official image layout (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`), and drop Bitnami-specific `OPENRESTY_CONF_FILE` wiring.
-  versionName: '2026.01.11'
+  versionName: '2026.08.28'
   promoteImage:
   - https://app.cdn.olares.com/appstore/metube/1.webp
   - https://app.cdn.olares.com/appstore/metube/2.webp
@@ -48,6 +56,11 @@ spec:
   locale:
   - en-US
   - zh-CN
+  - de-DE
+  - es-ES
+  - it-IT
+  - fr-FR
+  - ja-JP
   requiredMemory: 512Mi
   limitedMemory: 2.5Gi
   requiredDisk: 256Mi

--- a/metube/i18n/de-DE/OlaresManifest.yaml
+++ b/metube/i18n/de-DE/OlaresManifest.yaml
@@ -1,0 +1,23 @@
+metadata:
+  title: Metube
+  description: Selbst gehosteter YouTube-Downloader
+spec:
+  upgradeDescription: |
+    MeTube von 2026.01.11 auf 2026.08.28 aktualisieren (`alexta69/metube:2026.08.28`).
+
+    Dieses Tag aktualisiert yt-dlp und die Download-Oberfläche. Releases: https://github.com/alexta69/metube/releases
+
+    Reverse-Proxy-Image von Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) auf das offizielle OpenResty-Image `openresty/openresty:1.29.2.5-bookworm-fat` umstellen.
+
+    nginx-Konfigurations-Mounts und Protokollpfade an das Layout des offiziellen Images anpassen (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`) und die Bitnami-spezifische `OPENRESTY_CONF_FILE`-Verkabelung entfernen.
+  fullDescription: |
+    Eine grafische Web-Benutzeroberfläche auf Basis von youtube-dl (unter Verwendung des yt-dlp-Forks), die Wiedergabelisten unterstützt. Ermöglicht das Herunterladen von Videos von YouTube und Dutzenden anderen Websites.
+
+    Hauptfunktionen:
+    Unterstützung mehrerer Videoqualitätsoptionen
+    Nur-Audio-Downloads
+    Batch-Downloads
+    Verwaltung der Download-Warteschlange
+    Unterstützung für über 1000 Websites neben YouTube
+    Fortschrittsanzeige für Downloads
+    Mobilfreundliche Benutzeroberfläche

--- a/metube/i18n/en-US/OlaresManifest.yaml
+++ b/metube/i18n/en-US/OlaresManifest.yaml
@@ -3,6 +3,10 @@ metadata:
   description: Self-hosted YouTube downloader
 spec:
   upgradeDescription: |
+    Upgrade MeTube from 2026.01.11 to 2026.08.28 (`alexta69/metube:2026.08.28`).
+
+    This tag updates yt-dlp and the download UI. Releases: https://github.com/alexta69/metube/releases
+
     Switch the reverse-proxy image from Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) to the official OpenResty image `openresty/openresty:1.29.2.5-bookworm-fat`.
 
     Align nginx config mounts and log paths with the official image layout (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`), and drop Bitnami-specific `OPENRESTY_CONF_FILE` wiring.

--- a/metube/i18n/es-ES/OlaresManifest.yaml
+++ b/metube/i18n/es-ES/OlaresManifest.yaml
@@ -1,0 +1,23 @@
+metadata:
+  title: Metube
+  description: Descargador de YouTube autoalojado
+spec:
+  upgradeDescription: |
+    Actualiza MeTube de 2026.01.11 a 2026.08.28 (`alexta69/metube:2026.08.28`).
+
+    Esta etiqueta actualiza yt-dlp y la interfaz de descarga. Notas: https://github.com/alexta69/metube/releases
+
+    Cambiar la imagen del proxy inverso de Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) a la imagen oficial de OpenResty `openresty/openresty:1.29.2.5-bookworm-fat`.
+
+    Alinear los montajes de configuración y las rutas de registro de nginx con la estructura de la imagen oficial (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`) y eliminar la configuración específica de Bitnami `OPENRESTY_CONF_FILE`.
+  fullDescription: |
+    Una interfaz gráfica web basada en youtube-dl (que utiliza la bifurcación yt-dlp) y compatible con listas de reproducción. Permite descargar vídeos de YouTube y decenas de otros sitios web.
+
+    Características principales:
+    Opciones de distintas calidades de vídeo
+    Capacidad de descargar solo audio
+    Descargas por lotes
+    Gestión de la cola de descargas
+    Compatibilidad con más de 1000 sitios web además de YouTube
+    Seguimiento del progreso de las descargas
+    Interfaz adaptada a dispositivos móviles

--- a/metube/i18n/fr-FR/OlaresManifest.yaml
+++ b/metube/i18n/fr-FR/OlaresManifest.yaml
@@ -1,0 +1,23 @@
+metadata:
+  title: Metube
+  description: Téléchargeur YouTube auto-hébergé
+spec:
+  upgradeDescription: |
+    Mise à jour de MeTube de 2026.01.11 vers 2026.08.28 (`alexta69/metube:2026.08.28`).
+
+    Cette étiquette met à jour yt-dlp et l’interface de téléchargement. Notes : https://github.com/alexta69/metube/releases
+
+    Remplacement de l'image du proxy inverse Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) par l'image officielle OpenResty `openresty/openresty:1.29.2.5-bookworm-fat`.
+
+    Alignement des montages de configuration et des chemins de journaux nginx sur la structure de l'image officielle (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`) et suppression du câblage `OPENRESTY_CONF_FILE` spécifique à Bitnami.
+  fullDescription: |
+    Une interface utilisateur graphique web basée sur youtube-dl (utilisant le fork yt-dlp) et prenant en charge les listes de lecture. Elle permet de télécharger des vidéos depuis YouTube et des dizaines d'autres sites web.
+
+    Fonctionnalités principales :
+    Plusieurs options de qualité vidéo
+    Téléchargement audio uniquement
+    Téléchargements par lots
+    Gestion de la file d'attente des téléchargements
+    Prise en charge de plus de 1000 sites web en plus de YouTube
+    Suivi de la progression des téléchargements
+    Interface adaptée aux appareils mobiles

--- a/metube/i18n/it-IT/OlaresManifest.yaml
+++ b/metube/i18n/it-IT/OlaresManifest.yaml
@@ -1,0 +1,23 @@
+metadata:
+  title: Metube
+  description: Downloader YouTube self-hosted
+spec:
+  upgradeDescription: |
+    Aggiorna MeTube da 2026.01.11 a 2026.08.28 (`alexta69/metube:2026.08.28`).
+
+    Questo tag aggiorna yt-dlp e l’interfaccia di download. Note: https://github.com/alexta69/metube/releases
+
+    Sostituzione dell'immagine reverse proxy Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) con l'immagine OpenResty ufficiale `openresty/openresty:1.29.2.5-bookworm-fat`.
+
+    Allineamento dei mount di configurazione e dei percorsi di log di nginx al layout dell'immagine ufficiale (`/etc/nginx/conf.d/default.conf`, `/usr/local/openresty/nginx/logs/...`) e rimozione del collegamento `OPENRESTY_CONF_FILE` specifico di Bitnami.
+  fullDescription: |
+    Un'interfaccia utente grafica web basata su youtube-dl (che utilizza il fork yt-dlp) con supporto per le playlist. Consente di scaricare video da YouTube e decine di altri siti web.
+
+    Funzionalità principali:
+    Supporto per più opzioni di qualità video
+    Download del solo audio
+    Supporto per download in batch
+    Gestione della coda di download
+    Supporto per oltre 1000 siti web oltre a YouTube
+    Monitoraggio dell'avanzamento dei download
+    Interfaccia ottimizzata per dispositivi mobili

--- a/metube/i18n/ja-JP/OlaresManifest.yaml
+++ b/metube/i18n/ja-JP/OlaresManifest.yaml
@@ -1,0 +1,23 @@
+metadata:
+  title: Metube
+  description: セルフホスト型 YouTube ダウンローダー
+spec:
+  upgradeDescription: |
+    MeTube を 2026.01.11 から 2026.08.28 にアップグレードします（`alexta69/metube:2026.08.28`）。
+
+    このタグは yt-dlp とダウンロード UI を更新します。リリース: https://github.com/alexta69/metube/releases
+
+    リバースプロキシイメージを Bitnami OpenResty (`beclab/aboveos-bitnami-openresty:1.25.3-2`) から公式 OpenResty イメージ `openresty/openresty:1.29.2.5-bookworm-fat` に変更。
+
+    nginx の設定マウントとログパスを公式イメージのレイアウト（`/etc/nginx/conf.d/default.conf`、`/usr/local/openresty/nginx/logs/...`）に合わせ、Bitnami 固有の `OPENRESTY_CONF_FILE` 設定を削除。
+  fullDescription: |
+    youtube-dl（yt-dlp フォークを使用）をベースにした、プレイリスト対応の Web グラフィカルユーザーインターフェースです。YouTube をはじめ、数十の Web サイトから動画をダウンロードできます。
+
+    主な機能：
+    複数の動画品質オプション
+    音声のみのダウンロード
+    一括ダウンロード
+    ダウンロードキュー管理
+    YouTube 以外の 1000 以上の Web サイトに対応
+    ダウンロード進捗の追跡
+    モバイル対応インターフェース

--- a/metube/i18n/zh-CN/OlaresManifest.yaml
+++ b/metube/i18n/zh-CN/OlaresManifest.yaml
@@ -3,6 +3,10 @@ metadata:
   description: 自托管的YouTube下载器
 spec:
   upgradeDescription: |
+    将 MeTube 从 2026.01.11 升级到 2026.08.28（`alexta69/metube:2026.08.28`）。
+
+    该版本更新 yt-dlp 与下载界面。发行说明：https://github.com/alexta69/metube/releases
+
     将反向代理镜像从 Bitnami OpenResty（`beclab/aboveos-bitnami-openresty:1.25.3-2`）切换为官方 OpenResty 镜像 `openresty/openresty:1.29.2.5-bookworm-fat`。
 
     同步调整 nginx 配置挂载与日志路径以匹配官方镜像布局（`/etc/nginx/conf.d/default.conf`、`/usr/local/openresty/nginx/logs/...`），并移除 Bitnami 专用的 `OPENRESTY_CONF_FILE` 配置。

--- a/metube/owners
+++ b/metube/owners
@@ -1,8 +1,3 @@
 owners:
-- 'LittleLollipop'
-- 'TShentu'
-- 'hysyeah'
-- 'pengpeng'
-- 'harveyff'
-- 'zdf-org'
-- 'lovehunter9'
+  - username: '@beclab'
+    title: 'Olares'

--- a/metube/templates/ingress.yaml
+++ b/metube/templates/ingress.yaml
@@ -6,9 +6,14 @@ metadata:
 data:
   nginx.conf: |
     server {
+      client_body_temp_path /tmp/client_body;
+      proxy_temp_path /tmp/proxy;
+      fastcgi_temp_path /tmp/fastcgi;
+      uwsgi_temp_path /tmp/uwsgi;
+      scgi_temp_path /tmp/scgi;
       listen 8080;
-      access_log /usr/local/openresty/nginx/logs/access.log;
-      error_log /usr/local/openresty/nginx/logs/error.log;
+      access_log /dev/stdout;
+      error_log /dev/stderr;
 
       # Support large file uploads
       client_max_body_size 100m;
@@ -68,9 +73,20 @@ spec:
             items:
             - key: nginx.conf
               path: nginx.conf
+        - name: nginx-runtime
+          emptyDir: {}
       containers:
         - name: nginx
           image: "docker.io/openresty/openresty:1.29.2.5-bookworm-fat"
+          command:
+            - /usr/local/openresty/bin/openresty
+          args:
+            - -g
+            - "daemon off; pid /tmp/nginx.pid;"
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+
           ports:
             - containerPort: 8080
               protocol: TCP
@@ -99,6 +115,8 @@ spec:
             - name: nginx-config
               mountPath: /etc/nginx/conf.d/default.conf
               subPath: nginx.conf
+            - name: nginx-runtime
+              mountPath: /var/run/openresty
 ---
 apiVersion: v1
 kind: Service

--- a/metube/templates/metube.yaml
+++ b/metube/templates/metube.yaml
@@ -39,7 +39,7 @@ spec:
               readOnly: true
       containers:
         - name: metube
-          image: docker.io/beclab/alexta69-metube:2026.01.11
+          image: docker.io/alexta69/metube:2026.08.28
           envFrom:
             - configMapRef:
                 name: metube-env


### PR DESCRIPTION
### App Title
metube

### Description

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`