### PR TITLE
[UPDATE][jdownloader2][1.0.13] Upgrade JDownloader 2 to v26.08.2 (`jlesage/jdownloader-2:v26.08.2`).

### DIFF
--- a/jdownloader2/Chart.yaml
+++ b/jdownloader2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: '26.02.3'
+appVersion: '26.08.2'
 description: Free, open-source download management tool with web UI.
 name: jdownloader2
 type: application
-version: 1.0.7
+version: 1.0.13

--- a/jdownloader2/OlaresManifest.yaml
+++ b/jdownloader2/OlaresManifest.yaml
@@ -9,11 +9,13 @@ metadata:
   description: Free, open-source download management tool with web browser access.
   icon: https://app.cdn.olares.com/appstore/jdownloader2/icon.png
   appid: jdownloader2
-  version: '1.0.7'
+  version: '1.0.13'
   title: JDownloader 2
   categories:
-
   - Utilities_v112
+  - homelab
+  tags:
+  - downloader
 permission:
   appData: true
   appCache: true
@@ -21,7 +23,7 @@ permission:
   - Home
   externalData: true
 spec:
-  versionName: '26.02.3'
+  versionName: '26.08.2'
   promoteImage:
   - https://app.cdn.olares.com/appstore/jdownloader2/1.webp
   - https://app.cdn.olares.com/appstore/jdownloader2/2.webp
@@ -56,11 +58,11 @@ spec:
     - Improved integration into web browsers.
     - Download full photo albums from Facebook or Flickr.
   upgradeDescription: |
-    Stop recursively chowning the whole Home on startup; only fix ownership on Downloads/jdownloader2 and appData.
+    Upgrade JDownloader 2 to v26.08.2 (`jlesage/jdownloader-2:v26.08.2`).
 
-    Stop recursively chowning the external (sharedlib) download path on startup.
+    The image updates the jlesage baseimage to 4.13.2 (26.08.x also brings clipboard-sync controls and web-UI/service reliability and security improvements from 4.13.1).
 
-    Drop legacy appData path branching for Olares < 1.12.3; minimum supported version is now 1.12.6.
+    Full notes: https://github.com/jlesage/docker-jdownloader-2/releases/tag/v26.08.2
   developer: jlesage
   website: https://jdownloader.org/
   sourceCode: https://github.com/jlesage/docker-jdownloader-2
@@ -68,6 +70,11 @@ spec:
   locale:
   - en-US
   - zh-CN
+  - de-DE
+  - es-ES
+  - it-IT
+  - fr-FR
+  - ja-JP
   doc: https://github.com/jlesage/docker-jdownloader-2#readme
   license:
   - text: MIT

--- a/jdownloader2/i18n/de-DE/OlaresManifest.yaml
+++ b/jdownloader2/i18n/de-DE/OlaresManifest.yaml
@@ -1,0 +1,39 @@
+metadata:
+  title: JDownloader 2
+  description: Kostenloses Open-Source-Download-Management-Tool mit Webbrowser-Zugang
+spec:
+  fullDescription: |
+    JDownloader ist ein kostenloses Open-Source-Download-Management-Tool mit einer großen Community, das Downloads so einfach und schnell macht, wie sie sein sollten. Benutzer können Downloads starten, stoppen oder pausieren, Bandbreitenlimits setzen, Archive automatisch extrahieren und vieles mehr. Es ist ein leicht erweiterbares Framework, das Ihnen täglich Stunden wertvoller Zeit sparen kann!
+
+    **Speicher**
+    - Standard-Downloads nutzen `/output` (derselbe Host-Ordner wie `Downloads/jdownloader2`). `/downloads/home` und `/downloads/external` sind unter Einstellungen → Download für andere Pfade verfügbar.
+
+    **Funktionen**
+    - Plattformunabhängig (Windows, Linux, Mac, ..)
+    - Läuft auf Java 1.5 oder höher
+    - Vollständig Open Source (GPL)
+    - 24-Stunden-Support
+    - Mehrere Dateien gleichzeitig herunterladen
+    - Download mit mehreren Verbindungen
+    - JD hat ein eigenes leistungsstarkes OCR-Modul
+    - Automatischer Extraktor (inkl. Passwortlisten-Suche) (RAR-Archive)
+    - Theme-Unterstützung
+    - Mehrsprachig
+    - Etwa 110 Hoster und über 300 Decrypt-Plugins
+    - Reconnect mit JDLiveHeaderScripts: (1400 Router unterstützt)
+    - Webupdate
+    - Integrierter Paketmanager für zusätzliche Module (z. B. Webinterface, Shutdown)
+
+    **Was ist neu in JDownloader 2?**
+    - Ästhetische Änderungen an der Oberfläche.
+    - Kompatibilität mit mehr Speicherdiensten, Servern und Download-Websites.
+    - Erweiterte Filter, die einschränken, welche Links hinzugefügt werden (nach Dateityp, Größe oder Name).
+    - Vereinfachung und Neuordnung des Optionsmenüs.
+    - Verbesserte Integration in Webbrowser.
+    - Vollständige Fotoalben von Facebook oder Flickr herunterladen.
+  upgradeDescription: |
+    JDownloader 2 auf v26.08.2 (`jlesage/jdownloader-2:v26.08.2`) aktualisieren.
+
+    Baseimage 4.13.2 (26.08.x enthält außerdem Zwischenablage-Steuerung und Zuverlässigkeits-/Sicherheitsverbesserungen der Web-UI aus 4.13.1).
+
+    Notes: https://github.com/jlesage/docker-jdownloader-2/releases/tag/v26.08.2

--- a/jdownloader2/i18n/en-US/OlaresManifest.yaml
+++ b/jdownloader2/i18n/en-US/OlaresManifest.yaml
@@ -32,10 +32,8 @@ spec:
     - Improved integration into web browsers.
     - Download full photo albums from Facebook or Flickr.
   upgradeDescription: |
-    Upgrade to v26.03.1
+    Upgrade JDownloader 2 to v26.08.2 (`jlesage/jdownloader-2:v26.08.2`).
 
-    Changes:
-    * Updated baseimage to version 4.11.2
-    * Fixed X server failing to find the appropriate Mesa driver on some setups
+    The image updates the jlesage baseimage to 4.13.2 (26.08.x also brings clipboard-sync controls and web-UI/service reliability and security improvements from 4.13.1).
 
-    Full release notes at: https://github.com/jlesage/docker-jdownloader-2/releases/tag/v26.03.1
+    Full notes: https://github.com/jlesage/docker-jdownloader-2/releases/tag/v26.08.2

--- a/jdownloader2/i18n/es-ES/OlaresManifest.yaml
+++ b/jdownloader2/i18n/es-ES/OlaresManifest.yaml
@@ -1,0 +1,39 @@
+metadata:
+  title: JDownloader 2
+  description: Herramienta gratuita y de código abierto de gestión de descargas con acceso por navegador web
+spec:
+  fullDescription: |
+    JDownloader es una herramienta gratuita y de código abierto de gestión de descargas con una gran comunidad que hace que descargar sea tan fácil y rápido como debería. Los usuarios pueden iniciar, detener o pausar descargas, establecer límites de ancho de banda, autoextraer archivos y mucho más. ¡Es un framework fácil de ampliar que puede ahorrarte horas de tiempo valioso cada día!
+
+    **Almacenamiento**
+    - Las descargas predeterminadas usan `/output` (la misma carpeta del host que `Downloads/jdownloader2`). `/downloads/home` y `/downloads/external` están disponibles para otras rutas en Ajustes → Download.
+
+    **Funciones**
+    - Independiente de la plataforma (Windows, Linux, Mac, ..)
+    - Funciona con Java 1.5 o superior
+    - Completamente de código abierto (GPL)
+    - Soporte 24 horas
+    - Descargar varios archivos a la vez
+    - Descargar con múltiples conexiones
+    - JD tiene su propio potente módulo OCR
+    - Extractor automático (incluida búsqueda en lista de contraseñas) (archivos Rar)
+    - Compatibilidad con temas
+    - Multilingüe
+    - Unos 110 hosters y más de 300 plugins de descifrado
+    - Reconexión con JDLiveHeaderScripts: (1400 routers compatibles)
+    - Actualización web
+    - Gestor de paquetes integrado para módulos adicionales (p. ej. Webinterface, Shutdown)
+
+    **¿Qué hay de nuevo en JDownloader 2?**
+    - Cambios estéticos en la interfaz.
+    - Compatibilidad con más servicios de almacenamiento, servidores y webs de descarga.
+    - Filtros avanzados que permiten restringir qué enlaces se añaden (por tipo, tamaño o nombre de archivo).
+    - Simplificación y reorganización del menú de opciones.
+    - Mejor integración en navegadores web.
+    - Descargar álbumes completos de fotos de Facebook o Flickr.
+  upgradeDescription: |
+    Actualizar JDownloader 2 a v26.08.2 (`jlesage/jdownloader-2:v26.08.2`).
+
+    Baseimage 4.13.2 (26.08.x también incluye control de sincronización del portapapeles y mejoras de fiabilidad/seguridad de la UI web de 4.13.1).
+
+    Notas: https://github.com/jlesage/docker-jdownloader-2/releases/tag/v26.08.2

--- a/jdownloader2/i18n/fr-FR/OlaresManifest.yaml
+++ b/jdownloader2/i18n/fr-FR/OlaresManifest.yaml
@@ -1,0 +1,39 @@
+metadata:
+  title: JDownloader 2
+  description: Outil gratuit et open-source de gestion des téléchargements avec accès navigateur web
+spec:
+  fullDescription: |
+    JDownloader est un outil gratuit et open-source de gestion des téléchargements avec une grande communauté qui rend le téléchargement aussi simple et rapide qu'il devrait l'être. Les utilisateurs peuvent démarrer, arrêter ou mettre en pause les téléchargements, définir des limites de bande passante, extraire automatiquement les archives et bien plus. C'est un framework facile à étendre qui peut vous faire gagner des heures précieuses chaque jour !
+
+    **Stockage**
+    - Les téléchargements par défaut utilisent `/output` (même dossier hôte que `Downloads/jdownloader2`). `/downloads/home` et `/downloads/external` sont disponibles pour d'autres chemins dans Paramètres → Download.
+
+    **Fonctionnalités**
+    - Indépendant de la plateforme (Windows, Linux, Mac, ..)
+    - Fonctionne avec Java 1.5 ou supérieur
+    - Entièrement open-source (GPL)
+    - Support 24 h/24
+    - Télécharger plusieurs fichiers à la fois
+    - Télécharger avec plusieurs connexions
+    - JD dispose de son propre module OCR puissant
+    - Extracteur automatique (y compris recherche dans liste de mots de passe) (archives Rar)
+    - Prise en charge des thèmes
+    - Multilingue
+    - Environ 110 hébergeurs et plus de 300 plugins de décryptage
+    - Reconnexion avec JDLiveHeaderScripts : (1400 routeurs pris en charge)
+    - Mise à jour web
+    - Gestionnaire de paquets intégré pour modules supplémentaires (ex. Webinterface, Shutdown)
+
+    **Quoi de neuf dans JDownloader 2 ?**
+    - Changements esthétiques de l'interface.
+    - Compatibilité avec plus de services de stockage, serveurs et sites de téléchargement.
+    - Filtres avancés pour restreindre quels liens ajouter (par type, taille ou nom de fichier).
+    - Simplification et réorganisation du menu d'options.
+    - Meilleure intégration dans les navigateurs web.
+    - Télécharger des albums photo complets depuis Facebook ou Flickr.
+  upgradeDescription: |
+    Mettre à niveau JDownloader 2 vers v26.08.2 (`jlesage/jdownloader-2:v26.08.2`).
+
+    Baseimage 4.13.2 (26.08.x ajoute aussi le contrôle de synchro du presse-papiers et des améliorations fiabilité/sécurité de l'UI web issues de 4.13.1).
+
+    Notes : https://github.com/jlesage/docker-jdownloader-2/releases/tag/v26.08.2

--- a/jdownloader2/i18n/it-IT/OlaresManifest.yaml
+++ b/jdownloader2/i18n/it-IT/OlaresManifest.yaml
@@ -1,0 +1,39 @@
+metadata:
+  title: JDownloader 2
+  description: Strumento gratuito e open-source di gestione download con accesso via browser web
+spec:
+  fullDescription: |
+    JDownloader è uno strumento gratuito e open-source di gestione download con una grande community che rende il download facile e veloce come dovrebbe essere. Gli utenti possono avviare, fermare o mettere in pausa i download, impostare limiti di banda, estrarre automaticamente gli archivi e molto altro. È un framework facile da estendere che può farti risparmiare ore di tempo prezioso ogni giorno!
+
+    **Archiviazione**
+    - I download predefiniti usano `/output` (stessa cartella host di `Downloads/jdownloader2`). `/downloads/home` e `/downloads/external` sono disponibili per altri percorsi in Impostazioni → Download.
+
+    **Funzionalità**
+    - Indipendente dalla piattaforma (Windows, Linux, Mac, ..)
+    - Funziona con Java 1.5 o superiore
+    - Completamente open-source (GPL)
+    - Supporto 24 ore
+    - Scarica più file contemporaneamente
+    - Download con connessioni multiple
+    - JD ha un proprio potente modulo OCR
+    - Estrattore automatico (inclusa ricerca elenco password) (archivi Rar)
+    - Supporto temi
+    - Multilingue
+    - Circa 110 hoster e oltre 300 plugin di decrypt
+    - Riconnessione con JDLiveHeaderScripts: (1400 router supportati)
+    - Webupdate
+    - Package manager integrato per moduli aggiuntivi (es. Webinterface, Shutdown)
+
+    **Novità in JDownloader 2?**
+    - Modifiche estetiche all'interfaccia.
+    - Compatibilità con più servizi di storage, server e siti di download.
+    - Filtri avanzati per restringere quali link aggiungere (per tipo, dimensione o nome file).
+    - Semplificazione e riorganizzazione del menu opzioni.
+    - Migliore integrazione nei browser web.
+    - Scaricare album fotografici completi da Facebook o Flickr.
+  upgradeDescription: |
+    Aggiornare JDownloader 2 a v26.08.2 (`jlesage/jdownloader-2:v26.08.2`).
+
+    Baseimage 4.13.2 (26.08.x include anche controlli di sync clipboard e miglioramenti di affidabilità/sicurezza della web UI da 4.13.1).
+
+    Note: https://github.com/jlesage/docker-jdownloader-2/releases/tag/v26.08.2

--- a/jdownloader2/i18n/ja-JP/OlaresManifest.yaml
+++ b/jdownloader2/i18n/ja-JP/OlaresManifest.yaml
@@ -1,0 +1,39 @@
+metadata:
+  title: JDownloader 2
+  description: Web ブラウザから使える無料オープンソースのダウンロード管理ツール
+spec:
+  fullDescription: |
+    JDownloader は大規模コミュニティを持つ無料オープンソースのダウンロード管理ツールで、ダウンロードをあるべき姿のように簡単・高速にします。ユーザーはダウンロードの開始・停止・一時停止、帯域制限、アーカイブの自動展開などが可能です。毎日何時間もの貴重な時間を節約できる、拡張しやすいフレームワークです！
+
+    **ストレージ**
+    - デフォルトのダウンロードは `/output`（ホスト上の `Downloads/jdownloader2` と同じフォルダ）を使用。`/downloads/home` と `/downloads/external` は設定 → Download で他のパスとして利用可能。
+
+    **機能**
+    - プラットフォーム非依存（Windows、Linux、Mac など）
+    - Java 1.5 以上で動作
+    - 完全オープンソース（GPL）
+    - 24時間サポート
+    - 複数ファイルの同時ダウンロード
+    - 複数接続でのダウンロード
+    - JD 独自の強力な OCR モジュール
+    - 自動展開（パスワードリスト検索含む）（Rar アーカイブ）
+    - テーマ対応
+    - 多言語
+    - 約110のホスターと300以上の復号プラグイン
+    - JDLiveHeaderScripts による再接続：（1400ルーター対応）
+    - Webupdate
+    - 追加モジュール用の統合パッケージマネージャ（例：Webinterface、Shutdown）
+
+    **JDownloader 2 の新機能は？**
+    - インターフェースの美観改善。
+    - より多くのストレージサービス、サーバー、ダウンロードサイトとの互換性。
+    - 追加するリンクを制限する高度なフィルター（ファイル種別、サイズ、名前）。
+    - オプションメニューの簡素化と再編成。
+    - Web ブラウザへの統合改善。
+    - Facebook や Flickr からフルフォトアルバムをダウンロード。
+  upgradeDescription: |
+    JDownloader 2 を v26.08.2（`jlesage/jdownloader-2:v26.08.2`）へ。
+
+    baseimage を 4.13.2 に更新（26.08.x は 4.13.1 のクリップボード同期制御と Web UI／サービスの信頼性・セキュリティ改善も含む）。
+
+    詳細: https://github.com/jlesage/docker-jdownloader-2/releases/tag/v26.08.2

--- a/jdownloader2/i18n/zh-CN/OlaresManifest.yaml
+++ b/jdownloader2/i18n/zh-CN/OlaresManifest.yaml
@@ -32,10 +32,8 @@ spec:
     - 浏览器集成体验提升
     - 支持下载 Facebook 或 Flickr 全部照片专辑
   upgradeDescription: |
-    升级到 v26.03.1
+    升级 JDownloader 2 至 v26.08.2（`jlesage/jdownloader-2:v26.08.2`）。
 
-    更新内容:
-    * 更新基础镜像到版本 4.11.2
-    * 修复某些设置下 X 服务器找不到合适 Mesa 驱动的问题
+    镜像将 jlesage baseimage 更新到 4.13.2（26.08.x 还包含 4.13.1 的剪贴板同步控制以及 Web UI/服务可靠性与安全改进）。
 
-    完整发布说明参见: https://github.com/jlesage/docker-jdownloader-2/releases/tag/v26.03.1
+    完整说明：https://github.com/jlesage/docker-jdownloader-2/releases/tag/v26.08.2

--- a/jdownloader2/owners
+++ b/jdownloader2/owners
@@ -1,8 +1,3 @@
 owners:
-- 'LittleLollipop'
-- 'TShentu'
-- 'hysyeah'
-- 'pengpeng'
-- 'harveyff'
-- 'zdf-org'
-- 'kaki-admin'
+  - username: '@beclab'
+    title: 'Olares'

--- a/jdownloader2/templates/deployment.yaml
+++ b/jdownloader2/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
             runAsUser: 0
       containers:
         - name: jdownloader2
-          image: "docker.io/jlesage/jdownloader-2:v26.03.1"
+          image: "docker.io/jlesage/jdownloader-2:v26.08.2"
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 5800


### PR DESCRIPTION
### App Title
jdownloader2

### Description

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`