### PR TITLE
[UPDATE][miniflux][1.0.28] Upgrade Miniflux from 2.2.16 to 2.3.3 (`miniflux/miniflux:2.3.3-distroless`).

### DIFF
--- a/miniflux/Chart.yaml
+++ b/miniflux/Chart.yaml
@@ -15,10 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.22
-
+version: 1.0.28
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.2.16"
+appVersion: "2.3.3"

--- a/miniflux/OlaresManifest.yaml
+++ b/miniflux/OlaresManifest.yaml
@@ -9,13 +9,17 @@ metadata:
   description: Miniflux is a minimalist and opinionated feed reader.
   icon: https://app.cdn.olares.com/appstore/miniflux/icon.png
   appid: miniflux
-  version: "1.0.22"
+  version: "1.0.28"
   title: Miniflux
   categories:
-    - Fun
+  - Fun
+  - homelab
+  tags:
+  - lifestyle
+  - reading
 
 spec:
-  versionName: "2.2.16"
+  versionName: "2.3.3"
   promoteImage:
     - https://app.cdn.olares.com/appstore/miniflux/1.webp
     - https://app.cdn.olares.com/appstore/miniflux/2.webp
@@ -123,6 +127,10 @@ spec:
     More Detailed Features: https://miniflux.app/features.html
 
   upgradeDescription: |
+    Upgrade Miniflux from 2.2.16 to 2.3.3 (`miniflux/miniflux:2.3.3-distroless`).
+
+    2.3.x includes feed, API, and UI fixes on top of the 2.2 series. Full notes: https://github.com/miniflux/v2/releases/tag/2.3.3
+
     v1.0.22: Move `ADMIN_PASSWORD` and `DATABASE_URL` into Secret (`secretKeyRef`).
 
     **Security**
@@ -164,6 +172,11 @@ spec:
   locale:
     - en-US
     - zh-CN
+    - de-DE
+    - es-ES
+    - it-IT
+    - fr-FR
+    - ja-JP
   requiredMemory: 256Mi
   limitedMemory: 512Mi
   requiredDisk: 200Mi

--- a/miniflux/i18n/de-DE/OlaresManifest.yaml
+++ b/miniflux/i18n/de-DE/OlaresManifest.yaml
@@ -1,0 +1,140 @@
+metadata:
+  title: Miniflux
+  description: Miniflux ist ein minimalistischer und meinungsstarker Feed-Reader
+spec:
+  fullDescription: |
+    Miniflux ist ein minimalistischer und meinungsstarker Feed-Reader. Er ist einfach, schnell, leichtgewichtig und extrem einfach zu installieren.
+    
+    **Funktionen**
+    
+    Feed-Reader
+    - Unterstützte Feed-Formate: Atom 0.3/1.0, RSS 1.0/2.0 und JSON Feed 1.0/1.1.
+    - OPML-Datei-Import/Export und URL-Import.
+    - Unterstützt mehrere Anhänge (Podcasts, Videos, Musik und Bild-Enclosures).
+    - Spielt Videos von YouTube direkt in Miniflux ab.
+    - Organisiert Artikel mit Kategorien und Lesezeichen.
+    - Einzelne Artikel öffentlich teilen.
+    - Lädt Website-Icons (Favicons).
+    - Speichert Artikel in Drittanbieter-Diensten.
+    - Bietet Volltextsuche (powered by Postgres).
+    - Verfügbar in 20 Sprachen: Portugiesisch (Brasilianisch), Chinesisch (Vereinfacht und Traditionell), Niederländisch, Englisch (US), Finnisch, Französisch, Deutsch, Griechisch, Hindi, Indonesisch, Italienisch, Japanisch, Polnisch, Rumänisch, Russisch, Taiwanesisch POJ, Ukrainisch, Spanisch und Türkisch.
+    
+    Datenschutz und Sicherheit
+    - Entfernt Pixel-Tracker.
+    - Entfernt Tracking-Parameter aus URLs (z. B. utm_source, utm_medium, utm_campaign, fbclid usw.).
+    - Ruft Original-Links ab, wenn Feeds von FeedBurner stammen.
+    - Öffnet externe Links mit den Attributen rel="noopener noreferrer" referrerpolicy="no-referrer" für bessere Sicherheit.
+    - Setzt den HTTP-Header Referrer-Policy: no-referrer, um Referrer-Leakage zu verhindern.
+    - Bietet einen Media-Proxy, um Tracking zu vermeiden und Mixed-Content-Warnungen bei HTTPS zu lösen.
+    - Spielt YouTube-Videos über die datenschutzorientierte Domain youtube-nocookie.com ab.
+    - Unterstützt alternative YouTube-Videoplayer wie Invidious.
+    - Blockiert externes JavaScript, um Tracking zu verhindern und die Sicherheit zu erhöhen.
+    - Bereinigt externe Inhalte vor dem Rendern.
+    - Erzwingt eine Content Security und Trusted Types Policy, damit nur Anwendungs-JavaScript ausgeführt wird und Inline-Skripte sowie Styles blockiert werden.
+    
+    Mechanismen zur Umgehung von Bot-Schutz
+    - Optional HTTP/2 deaktivieren, um Fingerprinting zu mindern.
+    - Ermöglicht die Konfiguration eines benutzerdefinierten User-Agents.
+    - Unterstützt das Hinzufügen benutzerdefinierter Cookies für spezielle Anwendungsfälle.
+    - Ermöglicht die Nutzung von Proxys für mehr Privatsphäre oder zum Umgehen von Einschränkungen.
+    
+    Inhaltsbearbeitung
+    - Originalartikel abrufen und nur relevante Inhalte zurückgeben (Readability-Parser)
+    - Benutzerdefinierte Scraper-Regeln basierend auf CSS-Selektoren
+    - Benutzerdefinierte Rewriting-Regeln
+    - Regex-Filter zum Zulassen oder Blockieren von Artikeln
+    - Standard-User-Agent überschreiben, um Website-Einschränkungen zu umgehen
+    - Option zum Zulassen selbstsignierter oder ungültiger Zertifikate (standardmäßig deaktiviert)
+    - YouTube-Website scrapen, um die Videodauer als Lesezeit zu erhalten (standardmäßig deaktiviert)
+    
+    Benutzeroberfläche
+    - Optimiertes Stylesheet für Lesbarkeit.
+    - Responsives Design, das sich nahtlos an Desktop, Tablet und Mobilgeräte anpasst.
+    - Minimalistische und ablenkungsfreie Benutzeroberfläche.
+    - Kein Download einer App aus dem Apple App Store oder Google Play Store erforderlich.
+    - Kann direkt zum Home-Bildschirm hinzugefügt werden für schnellen Zugriff.
+    - Unterstützt eine große Auswahl an Tastaturkürzeln für effiziente Navigation.
+    - Optionaler Touch-Gesten-Support für Navigation auf Mobilgeräten.
+    - Benutzerdefinierte Stylesheets und JavaScript zur Personalisierung der Benutzeroberfläche.
+    - Themes:
+      - Light (Sans-Serif)
+      - Light (Serif)
+      - Dark (Sans-Serif)
+      - Dark (Serif)
+      - System (Sans-Serif) – Wechselt automatisch zwischen Dark- und Light-Themes basierend auf Systemeinstellungen.
+      - System (Serif)
+    
+    Integrationen
+    - Über 25 Integrationen mit Drittanbieter-Diensten: Apprise, Betula, Cubox, Discord, Espial, Instapaper, LinkAce, Linkding, LinkTaco, LinkWarden, Matrix, Notion, Ntfy, Nunux Keeper, Pinboard, Pushover, RainDrop, Readeck, Readwise Reader, RssBridge, Shaarli, Shiori, Slack, Telegram, Wallabag usw.
+    - Bookmarklet zum Abonnieren von Websites direkt aus jedem Webbrowser.
+    - Webhooks für Echtzeit-Benachrichtigungen oder benutzerdefinierte Integrationen.
+    - Kompatibilität mit bestehenden mobilen Anwendungen über die Fever- oder Google-Reader-API.
+    - REST API mit Client-Bibliotheken in Go und Python.
+    
+    Authentifizierung
+    - Lokaler Benutzername und Passwort.
+    - Passkeys (WebAuthn).
+    - Google (OAuth2).
+    - Generisches OpenID Connect.
+    - Reverse-Proxy-Authentifizierung.
+    
+    Technisches
+    - Geschrieben in Go (Golang).
+    - Einzelnes binäres, statisch kompiliertes Binary ohne Abhängigkeit.
+    - Funktioniert nur mit PostgreSQL.
+    - Verwendet kein ORM und keine komplizierten Frameworks.
+    - Nutzt modernes Vanilla-JavaScript nur wenn nötig.
+    - Alle statischen Dateien werden mit dem Go-embed-Paket in die Anwendungs-Binary gebündelt.
+    - Unterstützt das Systemd-sd_notify-Protokoll zur Prozessüberwachung.
+    - Konfiguriert HTTPS automatisch mit Let's Encrypt.
+    - Ermöglicht die Nutzung benutzerdefinierter SSL-Zertifikate.
+    - Unterstützt HTTP/2, wenn TLS aktiviert ist.
+    - Aktualisiert Feeds im Hintergrund mit einem internen Scheduler oder einem klassischen Cron-Job.
+    - Nutzt natives Lazy Loading für Bilder und Iframes.
+    - Nur mit modernen Browsern kompatibel.
+    - Folgt der Twelve-Factor-App-Methodik.
+    - Bietet offizielle Debian/RPM-Pakete und vorgebaute Binaries.
+    - Veröffentlicht ein Docker-Image auf Docker Hub, GitHub Registry und Quay.io Registry, mit ARM-Architektur-Support.
+    - Verwendet nur eine begrenzte Anzahl von Drittanbieter-Go-Abhängigkeiten
+    - Hat eine umfassende Testsuite mit Unit- und Integrationstests.
+    - Nutzt nur ein paar MB Speicher und vernachlässigbar wenig CPU, selbst mit mehreren hundert Feeds.
+    - Respektiert/sendet Last-Modified, If-Modified-Since, If-None-Match, Cache-Control, Expires und ETags-Header und hat ein Standard-Polling-Intervall von 1h.
+    
+    Ausführlichere Funktionen: https://miniflux.app/features.html
+  upgradeDescription: |
+    Miniflux von 2.2.16 auf 2.3.3 aktualisieren (`miniflux/miniflux:2.3.3-distroless`).
+
+    2.3.x enthält Korrekturen an Feeds, API und UI gegenüber 2.2. Hinweise: https://github.com/miniflux/v2/releases/tag/2.3.3
+
+    **Sicherheit**
+    - Dem Media-Proxy verbieten, Ressourcen in privaten Netzwerken abzurufen, um potenzielle SSRF-Probleme zu mindern. Dieses Verhalten ist auf Instanzebene konfigurierbar.
+    - Abrufen von Feed-Icons aus privaten Netzwerken verbieten, um die SSRF-Angriffsfläche zu verringern. Ebenfalls auf Instanzebene konfigurierbar.
+    - Die Konfigurationsoption TRUSTED_REVERSE_PROXY_NETWORKS hinzufügen, um Spoofing von HTTP-Headern wie X-Forwarded-For, X-Forwarded-Proto und X-Real-Ip zu verhindern. Diese Option muss konfiguriert werden, wenn AUTH_PROXY_HEADER aktiviert ist.
+    - Generierte Google-Reader-API-Tokens nicht mehr protokollieren, auch wenn der Debug-Modus aktiviert ist.
+    - Den CORS-Handler von der Google-Reader-API entfernen, da sie nicht für Web-Clients gedacht ist, und so die Angriffsfläche verringern.
+    
+    **Leistung und Speicher**
+    - Inhalt entfernter Einträge nicht indexieren, wodurch die Datenbankindexgröße nach Cleanup deutlich reduziert wird.
+    - Kleinere Storage- und Datenbank-Refaktorierungen zur Vereinfachung von Codepfaden und Reduzierung unnötigen Formatierungs-Overheads.
+    
+    **API und Integrationen**
+    - Neuen API-Endpunkt zum Importieren von Einträgen in einen bestehenden Feed hinzufügen.
+    - Content-Sanitizer beim Aktualisieren oder Importieren von Einträgen über die API ausführen, um konsistente Bereinigung sicherzustellen.
+    - Google-Reader-API-Kompatibilität verbessern, indem unnötige Output-Parameterprüfungen entfernt und das Verhalten an andere Open-Source-RSS-Reader angeglichen wird.
+    - Auto-Push-Option zur Readeck-Integration hinzufügen.
+    
+    **Benutzeroberfläche**
+    - Sanfte Seitenübergänge für eine poliertere Navigation hinzufügen.
+    - Route hinzufügen, um einzelne markierte Einträge direkt aus der Sternliste einer Kategorie anzuzeigen.
+    - Link zur GitHub-Contributors-Seite in Templates hinzufügen.
+    - Alle Übersetzungen aktualisieren.
+    
+    **Dokumentation und Werkzeuge**
+    - Konsistenz verbessern und Tippfehler in der miniflux(1)-Manualpage beheben.
+    - Veralteten version-Key aus Docker-Compose-Beispielen entfernen.
+    - Go-devcontainer-Image auf go:1-trixie aktualisieren.
+    - Distroless-Container-Basisimage auf Debian 13 aktualisieren.
+    - GitHub-Actions-Abhängigkeiten aktualisieren.
+    
+    
+    Release Note: https://github.com/miniflux/v2/releases/tag/2.2.16

--- a/miniflux/i18n/en-US/OlaresManifest.yaml
+++ b/miniflux/i18n/en-US/OlaresManifest.yaml
@@ -102,6 +102,10 @@ spec:
 
     More Detailed Features: https://miniflux.app/features.html
   upgradeDescription: |
+    Upgrade Miniflux from 2.2.16 to 2.3.3 (`miniflux/miniflux:2.3.3-distroless`).
+
+    2.3.x includes feed, API, and UI fixes on top of the 2.2 series. Full notes: https://github.com/miniflux/v2/releases/tag/2.3.3
+
     **Security**
     - Disallow the media proxy from fetching resources on private networks to mitigate potential SSRF issues. This behavior is configurable at the instance level.
     - Disallow fetching feed icons from private networks to reduce the SSRF attack surface. This is also configurable at the instance level.

--- a/miniflux/i18n/es-ES/OlaresManifest.yaml
+++ b/miniflux/i18n/es-ES/OlaresManifest.yaml
@@ -1,0 +1,140 @@
+metadata:
+  title: Miniflux
+  description: Miniflux es un lector de feeds minimalista y con criterio propio
+spec:
+  fullDescription: |
+    Miniflux es un lector de feeds minimalista y con criterio propio. Es simple, rápido, ligero y extremadamente fácil de instalar.
+
+    **Funciones**
+
+    Lector de feeds
+    - Formatos de feed admitidos: Atom 0.3/1.0, RSS 1.0/2.0 y JSON Feed 1.0/1.1.
+    - Importación/exportación de archivos OPML e importación por URL.
+    - Admite varios adjuntos (enclosures de podcasts, vídeos, música e imágenes).
+    - Reproduce vídeos de YouTube directamente dentro de Miniflux.
+    - Organiza artículos con categorías y marcadores.
+    - Comparte artículos individuales de forma pública.
+    - Obtiene iconos de sitios web (favicons).
+    - Guarda artículos en servicios de terceros.
+    - Ofrece búsqueda de texto completo (powered by Postgres).
+    - Disponible en 20 idiomas: portugués (brasileño), chino (simplificado y tradicional), neerlandés, inglés (EE. UU.), finés, francés, alemán, griego, hindi, indonesio, italiano, japonés, polaco, rumano, ruso, taiwanés POJ, ucraniano, español y turco.
+
+    Privacidad y seguridad
+    - Elimina rastreadores de píxeles.
+    - Quita parámetros de seguimiento de las URL (p. ej., utm_source, utm_medium, utm_campaign, fbclid, etc.).
+    - Recupera los enlaces originales cuando los feeds provienen de FeedBurner.
+    - Abre enlaces externos con los atributos rel="noopener noreferrer" referrerpolicy="no-referrer" para mayor seguridad.
+    - Implementa la cabecera HTTP Referrer-Policy: no-referrer para evitar fugas del referrer.
+    - Proporciona un proxy de medios para evitar el seguimiento y resolver advertencias de contenido mixto al usar HTTPS.
+    - Reproduce vídeos de YouTube a través del dominio centrado en la privacidad youtube-nocookie.com.
+    - Admite reproductores alternativos de YouTube como Invidious.
+    - Bloquea JavaScript externo para prevenir el seguimiento y mejorar la seguridad.
+    - Depura el contenido externo antes de renderizarlo.
+    - Aplica una política de Content Security y Trusted Types para permitir solo el JavaScript de la aplicación y bloquear scripts y estilos en línea.
+
+    Mecanismos para eludir la protección antibots
+    - Opción de desactivar HTTP/2 para mitigar el fingerprinting.
+    - Permite configurar un user agent personalizado.
+    - Admite añadir cookies personalizadas para casos de uso específicos.
+    - Permite el uso de proxies para mayor privacidad o para eludir restricciones.
+
+    Manipulación de contenido
+    - Obtiene el artículo original y devuelve solo el contenido relevante (parser Readability)
+    - Reglas de scraper personalizadas basadas en selectores CSS
+    - Reglas de reescritura personalizadas
+    - Filtro regex para permitir o bloquear artículos
+    - Sobrescribe el user agent predeterminado para eludir restricciones de sitios web
+    - Opción para permitir certificados autofirmados o inválidos (desactivada por defecto)
+    - Extrae la duración del vídeo del sitio de YouTube como tiempo de lectura (desactivado por defecto)
+
+    Interfaz de usuario
+    - Hoja de estilos optimizada para la legibilidad.
+    - Diseño responsive que se adapta sin problemas a escritorio, tableta y dispositivos móviles.
+    - Interfaz minimalista y sin distracciones.
+    - No es necesario descargar una app desde Apple App Store o Google Play Store.
+    - Se puede añadir directamente a la pantalla de inicio para un acceso rápido.
+    - Admite una amplia gama de atajos de teclado para una navegación eficiente.
+    - Soporte opcional de gestos táctiles para la navegación en dispositivos móviles.
+    - Hojas de estilos y JavaScript personalizados para personalizar la interfaz según tus preferencias.
+    - Temas:
+      - Light (Sans-Serif)
+      - Light (Serif)
+      - Dark (Sans-Serif)
+      - Dark (Serif)
+      - System (Sans-Serif) – Cambia automáticamente entre los temas Dark y Light según las preferencias del sistema.
+      - System (Serif)
+
+    Integraciones
+    - Más de 25 integraciones con servicios de terceros: Apprise, Betula, Cubox, Discord, Espial, Instapaper, LinkAce, Linkding, LinkTaco, LinkWarden, Matrix, Notion, Ntfy, Nunux Keeper, Pinboard, Pushover, RainDrop, Readeck, Readwise Reader, RssBridge, Shaarli, Shiori, Slack, Telegram, Wallabag, etc.
+    - Bookmarklet para suscribirse a sitios web directamente desde cualquier navegador.
+    - Webhooks para notificaciones en tiempo real o integraciones personalizadas.
+    - Compatibilidad con aplicaciones móviles existentes mediante la API Fever o Google Reader.
+    - API REST con bibliotecas cliente disponibles en Go y Python.
+
+    Autenticación
+    - Nombre de usuario y contraseña locales.
+    - Passkeys (WebAuthn).
+    - Google (OAuth2).
+    - OpenID Connect genérico.
+    - Autenticación por reverse-proxy.
+
+    Aspectos técnicos
+    - Escrito en Go (Golang).
+    - Un único binario compilado estáticamente sin dependencias.
+    - Funciona solo con PostgreSQL.
+    - No usa ningún ORM ni frameworks complicados.
+    - Usa JavaScript vanilla moderno solo cuando es necesario.
+    - Todos los archivos estáticos se empaquetan en el binario de la aplicación con el paquete Go embed.
+    - Admite el protocolo Systemd sd_notify para la supervisión de procesos.
+    - Configura HTTPS automáticamente con Let's Encrypt.
+    - Permite el uso de certificados SSL personalizados.
+    - Admite HTTP/2 cuando TLS está habilitado.
+    - Actualiza los feeds en segundo plano con un programador interno o un trabajo cron tradicional.
+    - Usa carga diferida nativa para imágenes e iframes.
+    - Compatible solo con navegadores modernos.
+    - Sigue la metodología Twelve-Factor App.
+    - Ofrece paquetes oficiales Debian/RPM y binarios precompilados.
+    - Publica una imagen Docker en Docker Hub, GitHub Registry y Quay.io Registry, con soporte de arquitectura ARM.
+    - Usa una cantidad limitada de dependencias de Go de terceros
+    - Tiene una suite de pruebas completa, con tests unitarios y de integración.
+    - Usa solo unos pocos MB de memoria y una cantidad insignificante de CPU, incluso con varios cientos de feeds.
+    - Respeta/envía las cabeceras Last-Modified, If-Modified-Since, If-None-Match, Cache-Control, Expires y ETags, y tiene un intervalo de sondeo predeterminado de 1 h.
+
+    Funciones más detalladas: https://miniflux.app/features.html
+  upgradeDescription: |
+    Actualiza Miniflux de 2.2.16 a 2.3.3 (`miniflux/miniflux:2.3.3-distroless`).
+
+    2.3.x incluye correcciones de feeds, API e interfaz sobre la serie 2.2. Notas: https://github.com/miniflux/v2/releases/tag/2.3.3
+
+    **Seguridad**
+    - Impedir que el proxy de medios obtenga recursos en redes privadas para mitigar posibles problemas de SSRF. Este comportamiento es configurable a nivel de instancia.
+    - Impedir la obtención de iconos de feeds desde redes privadas para reducir la superficie de ataque SSRF. También es configurable a nivel de instancia.
+    - Añadir la opción de configuración TRUSTED_REVERSE_PROXY_NETWORKS para evitar la falsificación de cabeceras HTTP como X-Forwarded-For, X-Forwarded-Proto y X-Real-Ip. Esta opción debe configurarse cuando AUTH_PROXY_HEADER está habilitado.
+    - Dejar de registrar los tokens generados de la API Google Reader, incluso cuando el modo debug está activado.
+    - Eliminar el manejador CORS de la API Google Reader, ya que no está pensada para clientes web, reduciendo la superficie de ataque general.
+
+    **Rendimiento y almacenamiento**
+    - Evitar indexar el contenido de las entradas eliminadas, reduciendo significativamente el tamaño del índice de la base de datos tras la limpieza.
+    - Pequeña refactorización de almacenamiento y base de datos para simplificar las rutas de código y reducir el overhead de formato innecesario.
+
+    **API e integraciones**
+    - Añadir un nuevo endpoint de API para importar entradas en un feed existente.
+    - Ejecutar el sanitizador de contenido al actualizar o importar entradas a través de la API para garantizar una depuración coherente.
+    - Mejorar la compatibilidad con la API Google Reader eliminando comprobaciones innecesarias de parámetros de salida y alineando el comportamiento con otros lectores RSS de código abierto.
+    - Añadir una opción de auto-push a la integración con Readeck.
+
+    **Interfaz de usuario**
+    - Añadir transiciones de página suaves para una navegación más pulida.
+    - Añadir una ruta para ver entradas individuales marcadas directamente desde la lista de destacados de una categoría.
+    - Añadir un enlace a la página de colaboradores de GitHub en las plantillas.
+    - Actualizar todas las traducciones.
+
+    **Documentación y herramientas**
+    - Mejorar la coherencia y corregir erratas en la página del manual miniflux(1).
+    - Eliminar la clave version obsoleta de los ejemplos de Docker Compose.
+    - Actualizar la imagen del Go devcontainer a go:1-trixie.
+    - Actualizar la imagen base Distroless del contenedor a Debian 13.
+    - Actualizar las dependencias de GitHub Actions.
+
+
+    Release Note: https://github.com/miniflux/v2/releases/tag/2.2.16

--- a/miniflux/i18n/fr-FR/OlaresManifest.yaml
+++ b/miniflux/i18n/fr-FR/OlaresManifest.yaml
@@ -1,0 +1,140 @@
+metadata:
+  title: Miniflux
+  description: Miniflux est un lecteur de flux minimaliste et opiniâtre
+spec:
+  fullDescription: |
+    Miniflux est un lecteur de flux minimaliste et opiniâtre. Il est simple, rapide, léger et extrêmement facile à installer.
+
+    **Fonctionnalités**
+
+    Lecteur de flux
+    - Formats de flux pris en charge : Atom 0.3/1.0, RSS 1.0/2.0 et JSON Feed 1.0/1.1.
+    - Import/export de fichiers OPML et import par URL.
+    - Prend en charge plusieurs pièces jointes (enclosures podcasts, vidéos, musique et images).
+    - Lit les vidéos YouTube directement dans Miniflux.
+    - Organise les articles avec des catégories et des signets.
+    - Partage des articles individuels publiquement.
+    - Récupère les icônes des sites web (favicons).
+    - Enregistre les articles vers des services tiers.
+    - Fournit une recherche en texte intégral (powered by Postgres).
+    - Disponible en 20 langues : portugais (brésilien), chinois (simplifié et traditionnel), néerlandais, anglais (US), finnois, français, allemand, grec, hindi, indonésien, italien, japonais, polonais, roumain, russe, taïwanais POJ, ukrainien, espagnol et turc.
+
+    Confidentialité et sécurité
+    - Supprime les trackers pixel.
+    - Retire les paramètres de suivi des URL (p. ex. utm_source, utm_medium, utm_campaign, fbclid, etc.).
+    - Récupère les liens d'origine lorsque les flux proviennent de FeedBurner.
+    - Ouvre les liens externes avec les attributs rel="noopener noreferrer" referrerpolicy="no-referrer" pour une meilleure sécurité.
+    - Implémente l'en-tête HTTP Referrer-Policy: no-referrer pour empêcher les fuites de referrer.
+    - Fournit un proxy média pour éviter le suivi et résoudre les avertissements de contenu mixte lors de l'utilisation de HTTPS.
+    - Lit les vidéos YouTube via le domaine axé sur la confidentialité youtube-nocookie.com.
+    - Prend en charge des lecteurs YouTube alternatifs tels qu'Invidious.
+    - Bloque le JavaScript externe pour prévenir le suivi et renforcer la sécurité.
+    - Assainit le contenu externe avant de le rendre.
+    - Applique une politique Content Security et Trusted Types pour n'autoriser que le JavaScript de l'application et bloquer les scripts et styles en ligne.
+
+    Mécanismes de contournement de la protection anti-bots
+    - Désactivation optionnelle de HTTP/2 pour atténuer le fingerprinting.
+    - Permet de configurer un user agent personnalisé.
+    - Prend en charge l'ajout de cookies personnalisés pour des cas d'usage spécifiques.
+    - Autorise l'utilisation de proxies pour une meilleure confidentialité ou pour contourner des restrictions.
+
+    Manipulation de contenu
+    - Récupère l'article original et ne renvoie que le contenu pertinent (parseur Readability)
+    - Règles de scraper personnalisées basées sur des sélecteurs CSS
+    - Règles de réécriture personnalisées
+    - Filtre regex pour autoriser ou bloquer des articles
+    - Remplace le user agent par défaut pour contourner les restrictions des sites web
+    - Option pour autoriser les certificats auto-signés ou invalides (désactivée par défaut)
+    - Extrait la durée de la vidéo depuis le site YouTube comme temps de lecture (désactivé par défaut)
+
+    Interface utilisateur
+    - Feuille de style optimisée pour la lisibilité.
+    - Design responsive qui s'adapte parfaitement aux ordinateurs, tablettes et appareils mobiles.
+    - Interface minimaliste et sans distraction.
+    - Aucun besoin de télécharger une app depuis l'Apple App Store ou le Google Play Store.
+    - Peut être ajouté directement à l'écran d'accueil pour un accès rapide.
+    - Prend en charge un large éventail de raccourcis clavier pour une navigation efficace.
+    - Prise en charge optionnelle des gestes tactiles pour la navigation sur mobile.
+    - Feuilles de style et JavaScript personnalisés pour adapter l'interface à vos préférences.
+    - Thèmes :
+      - Light (Sans-Serif)
+      - Light (Serif)
+      - Dark (Sans-Serif)
+      - Dark (Serif)
+      - System (Sans-Serif) – Bascule automatiquement entre les thèmes Dark et Light selon les préférences système.
+      - System (Serif)
+
+    Intégrations
+    - Plus de 25 intégrations avec des services tiers : Apprise, Betula, Cubox, Discord, Espial, Instapaper, LinkAce, Linkding, LinkTaco, LinkWarden, Matrix, Notion, Ntfy, Nunux Keeper, Pinboard, Pushover, RainDrop, Readeck, Readwise Reader, RssBridge, Shaarli, Shiori, Slack, Telegram, Wallabag, etc.
+    - Bookmarklet pour s'abonner à des sites web directement depuis n'importe quel navigateur.
+    - Webhooks pour des notifications en temps réel ou des intégrations personnalisées.
+    - Compatibilité avec les applications mobiles existantes via l'API Fever ou Google Reader.
+    - API REST avec des bibliothèques clientes disponibles en Go et Python.
+
+    Authentification
+    - Nom d'utilisateur et mot de passe locaux.
+    - Passkeys (WebAuthn).
+    - Google (OAuth2).
+    - OpenID Connect générique.
+    - Authentification par reverse-proxy.
+
+    Aspects techniques
+    - Écrit en Go (Golang).
+    - Binaire unique compilé statiquement sans dépendance.
+    - Fonctionne uniquement avec PostgreSQL.
+    - N'utilise aucun ORM ni framework compliqué.
+    - Utilise du JavaScript vanilla moderne uniquement lorsque nécessaire.
+    - Tous les fichiers statiques sont intégrés dans le binaire de l'application via le package Go embed.
+    - Prend en charge le protocole Systemd sd_notify pour la surveillance des processus.
+    - Configure HTTPS automatiquement avec Let's Encrypt.
+    - Autorise l'utilisation de certificats SSL personnalisés.
+    - Prend en charge HTTP/2 lorsque TLS est activé.
+    - Met à jour les flux en arrière-plan avec un planificateur interne ou un cron job traditionnel.
+    - Utilise le lazy loading natif pour les images et les iframes.
+    - Compatible uniquement avec les navigateurs modernes.
+    - Suit la méthodologie Twelve-Factor App.
+    - Fournit des paquets officiels Debian/RPM et des binaires précompilés.
+    - Publie une image Docker sur Docker Hub, GitHub Registry et Quay.io Registry, avec prise en charge de l'architecture ARM.
+    - Utilise un nombre limité de dépendances Go tierces
+    - Dispose d'une suite de tests complète, avec des tests unitaires et d'intégration.
+    - N'utilise que quelques Mo de mémoire et une quantité négligeable de CPU, même avec plusieurs centaines de flux.
+    - Respecte/envoie les en-têtes Last-Modified, If-Modified-Since, If-None-Match, Cache-Control, Expires et ETags, et a un intervalle de sondage par défaut de 1 h.
+
+    Fonctionnalités plus détaillées : https://miniflux.app/features.html
+  upgradeDescription: |
+    Mise à jour de Miniflux de 2.2.16 vers 2.3.3 (`miniflux/miniflux:2.3.3-distroless`).
+
+    2.3.x ajoute des correctifs flux, API et interface par rapport à 2.2. Notes : https://github.com/miniflux/v2/releases/tag/2.3.3
+
+    **Sécurité**
+    - Interdire au proxy média de récupérer des ressources sur des réseaux privés afin d'atténuer d'éventuels problèmes SSRF. Ce comportement est configurable au niveau de l'instance.
+    - Interdire la récupération des icônes de flux depuis des réseaux privés afin de réduire la surface d'attaque SSRF. Également configurable au niveau de l'instance.
+    - Ajouter l'option de configuration TRUSTED_REVERSE_PROXY_NETWORKS pour empêcher l'usurpation d'en-têtes HTTP tels que X-Forwarded-For, X-Forwarded-Proto et X-Real-Ip. Cette option doit être configurée lorsque AUTH_PROXY_HEADER est activé.
+    - Arrêter de journaliser les jetons générés de l'API Google Reader, même lorsque le mode debug est activé.
+    - Retirer le gestionnaire CORS de l'API Google Reader, car elle n'est pas destinée aux clients web, réduisant ainsi la surface d'attaque globale.
+
+    **Performance et stockage**
+    - Éviter d'indexer le contenu des entrées supprimées, réduisant significativement la taille de l'index de la base de données après le nettoyage.
+    - Léger refactoring du stockage et de la base de données pour simplifier les chemins de code et réduire le surcoût de formatage inutile.
+
+    **API et intégrations**
+    - Ajouter un nouvel endpoint API pour importer des entrées dans un flux existant.
+    - Exécuter le sanitizer de contenu lors de la mise à jour ou de l'import d'entrées via l'API pour assurer un assainissement cohérent.
+    - Améliorer la compatibilité avec l'API Google Reader en supprimant des vérifications inutiles des paramètres de sortie et en alignant le comportement sur d'autres lecteurs RSS open source.
+    - Ajouter une option auto-push à l'intégration Readeck.
+
+    **Interface utilisateur**
+    - Ajouter des transitions de page fluides pour une navigation plus soignée.
+    - Ajouter une route pour consulter des entrées individuelles marquées directement depuis la liste des favoris d'une catégorie.
+    - Ajouter un lien vers la page des contributeurs GitHub dans les templates.
+    - Mettre à jour toutes les traductions.
+
+    **Documentation et outillage**
+    - Améliorer la cohérence et corriger des coquilles dans la page de manuel miniflux(1).
+    - Retirer la clé version obsolète des exemples Docker Compose.
+    - Mettre à jour l'image Go du devcontainer vers go:1-trixie.
+    - Mettre à jour l'image de base Distroless du conteneur vers Debian 13.
+    - Mettre à jour les dépendances GitHub Actions.
+
+
+    Release Note: https://github.com/miniflux/v2/releases/tag/2.2.16

--- a/miniflux/i18n/it-IT/OlaresManifest.yaml
+++ b/miniflux/i18n/it-IT/OlaresManifest.yaml
@@ -1,0 +1,140 @@
+metadata:
+  title: Miniflux
+  description: Miniflux è un feed reader minimalista e con un proprio punto di vista
+spec:
+  fullDescription: |
+    Miniflux è un feed reader minimalista e con un proprio punto di vista. È semplice, veloce, leggero ed estremamente facile da installare.
+
+    **Funzionalità**
+
+    Feed Reader
+    - Formati di feed supportati: Atom 0.3/1.0, RSS 1.0/2.0 e JSON Feed 1.0/1.1.
+    - Importazione/esportazione di file OPML e importazione da URL.
+    - Supporta più allegati (enclosure di podcast, video, musica e immagini).
+    - Riproduce i video di YouTube direttamente all'interno di Miniflux.
+    - Organizza gli articoli con categorie e segnalibri.
+    - Condividi singoli articoli pubblicamente.
+    - Recupera le icone dei siti web (favicon).
+    - Salva gli articoli su servizi di terze parti.
+    - Offre ricerca full-text (powered by Postgres).
+    - Disponibile in 20 lingue: portoghese (brasiliano), cinese (semplificato e tradizionale), olandese, inglese (US), finlandese, francese, tedesco, greco, hindi, indonesiano, italiano, giapponese, polacco, rumeno, russo, taiwanese POJ, ucraino, spagnolo e turco.
+
+    Privacy e sicurezza
+    - Rimuove i pixel tracker.
+    - Elimina i parametri di tracciamento dalle URL (ad es. utm_source, utm_medium, utm_campaign, fbclid, ecc.).
+    - Recupera i link originali quando i feed provengono da FeedBurner.
+    - Apre i link esterni con gli attributi rel="noopener noreferrer" referrerpolicy="no-referrer" per una maggiore sicurezza.
+    - Implementa l'header HTTP Referrer-Policy: no-referrer per prevenire la fuga del referrer.
+    - Fornisce un media proxy per evitare il tracciamento e risolvere gli avvisi di mixed content quando si usa HTTPS.
+    - Riproduce i video di YouTube tramite il dominio incentrato sulla privacy youtube-nocookie.com.
+    - Supporta player YouTube alternativi come Invidious.
+    - Blocca JavaScript esterni per prevenire il tracciamento e migliorare la sicurezza.
+    - Sanifica i contenuti esterni prima di renderizzarli.
+    - Applica una Content Security e Trusted Types Policy per consentire solo il JavaScript dell'applicazione e bloccare script e stili inline.
+
+    Meccanismi di bypass della protezione bot
+    - Disabilitazione opzionale di HTTP/2 per mitigare il fingerprinting.
+    - Consente di configurare un user agent personalizzato.
+    - Supporta l'aggiunta di cookie personalizzati per casi d'uso specifici.
+    - Consente l'uso di proxy per maggiore privacy o per aggirare le restrizioni.
+
+    Manipolazione dei contenuti
+    - Recupera l'articolo originale e restituisce solo i contenuti rilevanti (parser Readability)
+    - Regole scraper personalizzate basate su selettori CSS
+    - Regole di rewriting personalizzate
+    - Filtro regex per consentire o bloccare articoli
+    - Sovrascrive lo user agent predefinito per aggirare le restrizioni dei siti web
+    - Opzione per consentire certificati auto-firmati o non validi (disabilitata per impostazione predefinita)
+    - Estrae la durata del video dal sito di YouTube come tempo di lettura (disabilitato per impostazione predefinita)
+
+    Interfaccia utente
+    - Foglio di stile ottimizzato per la leggibilità.
+    - Design responsive che si adatta senza problemi a desktop, tablet e dispositivi mobili.
+    - Interfaccia minimalista e senza distrazioni.
+    - Non è necessario scaricare un'app dall'Apple App Store o da Google Play Store.
+    - Può essere aggiunto direttamente alla schermata Home per un accesso rapido.
+    - Supporta un'ampia gamma di scorciatoie da tastiera per una navigazione efficiente.
+    - Supporto opzionale dei gesti touch per la navigazione sui dispositivi mobili.
+    - Fogli di stile e JavaScript personalizzati per personalizzare l'interfaccia secondo le proprie preferenze.
+    - Temi:
+      - Light (Sans-Serif)
+      - Light (Serif)
+      - Dark (Sans-Serif)
+      - Dark (Serif)
+      - System (Sans-Serif) – Passa automaticamente tra i temi Dark e Light in base alle preferenze di sistema.
+      - System (Serif)
+
+    Integrazioni
+    - Oltre 25 integrazioni con servizi di terze parti: Apprise, Betula, Cubox, Discord, Espial, Instapaper, LinkAce, Linkding, LinkTaco, LinkWarden, Matrix, Notion, Ntfy, Nunux Keeper, Pinboard, Pushover, RainDrop, Readeck, Readwise Reader, RssBridge, Shaarli, Shiori, Slack, Telegram, Wallabag, ecc.
+    - Bookmarklet per iscriversi ai siti web direttamente da qualsiasi browser.
+    - Webhook per notifiche in tempo reale o integrazioni personalizzate.
+    - Compatibilità con applicazioni mobili esistenti tramite l'API Fever o Google Reader.
+    - API REST con librerie client disponibili in Go e Python.
+
+    Autenticazione
+    - Nome utente e password locali.
+    - Passkey (WebAuthn).
+    - Google (OAuth2).
+    - OpenID Connect generico.
+    - Autenticazione tramite reverse-proxy.
+
+    Aspetti tecnici
+    - Scritto in Go (Golang).
+    - Singolo binario compilato staticamente senza dipendenze.
+    - Funziona solo con PostgreSQL.
+    - Non usa ORM né framework complicati.
+    - Usa JavaScript vanilla moderno solo quando necessario.
+    - Tutti i file statici sono inclusi nel binario dell'applicazione tramite il pacchetto Go embed.
+    - Supporta il protocollo Systemd sd_notify per il monitoraggio dei processi.
+    - Configura HTTPS automaticamente con Let's Encrypt.
+    - Consente l'uso di certificati SSL personalizzati.
+    - Supporta HTTP/2 quando TLS è abilitato.
+    - Aggiorna i feed in background con uno scheduler interno o un tradizionale cron job.
+    - Usa il lazy loading nativo per immagini e iframe.
+    - Compatibile solo con browser moderni.
+    - Segue la metodologia Twelve-Factor App.
+    - Offre pacchetti ufficiali Debian/RPM e binari precompilati.
+    - Pubblica un'immagine Docker su Docker Hub, GitHub Registry e Quay.io Registry, con supporto per l'architettura ARM.
+    - Usa una quantità limitata di dipendenze Go di terze parti
+    - Ha una suite di test completa, con test unitari e di integrazione.
+    - Usa solo pochi MB di memoria e una quantità trascurabile di CPU, anche con diverse centinaia di feed.
+    - Rispetta/invia gli header Last-Modified, If-Modified-Since, If-None-Match, Cache-Control, Expires ed ETags, e ha un intervallo di polling predefinito di 1h.
+
+    Funzionalità più dettagliate: https://miniflux.app/features.html
+  upgradeDescription: |
+    Aggiorna Miniflux da 2.2.16 a 2.3.3 (`miniflux/miniflux:2.3.3-distroless`).
+
+    2.3.x include correzioni a feed, API e UI rispetto alla serie 2.2. Note: https://github.com/miniflux/v2/releases/tag/2.3.3
+
+    **Sicurezza**
+    - Impedire al media proxy di recuperare risorse su reti private per mitigare potenziali problemi SSRF. Questo comportamento è configurabile a livello di istanza.
+    - Impedire il recupero delle icone dei feed da reti private per ridurre la superficie di attacco SSRF. Anche questo è configurabile a livello di istanza.
+    - Aggiungere l'opzione di configurazione TRUSTED_REVERSE_PROXY_NETWORKS per prevenire lo spoofing di header HTTP come X-Forwarded-For, X-Forwarded-Proto e X-Real-Ip. Questa opzione deve essere configurata quando AUTH_PROXY_HEADER è abilitato.
+    - Interrompere la registrazione nei log dei token generati dell'API Google Reader, anche quando la modalità debug è attiva.
+    - Rimuovere l'handler CORS dall'API Google Reader, poiché non è destinata ai client web, riducendo la superficie di attacco complessiva.
+
+    **Prestazioni e storage**
+    - Evitare di indicizzare il contenuto delle voci rimosse, riducendo significativamente la dimensione dell'indice del database dopo la pulizia.
+    - Piccolo refactoring di storage e database per semplificare i percorsi del codice e ridurre l'overhead di formattazione non necessario.
+
+    **API e integrazioni**
+    - Aggiungere un nuovo endpoint API per importare voci in un feed esistente.
+    - Eseguire il content sanitizer quando si aggiornano o importano voci tramite l'API per garantire una sanificazione coerente.
+    - Migliorare la compatibilità con l'API Google Reader rimuovendo controlli non necessari sui parametri di output e allineando il comportamento ad altri feed reader RSS open source.
+    - Aggiungere un'opzione auto-push all'integrazione Readeck.
+
+    **Interfaccia utente**
+    - Aggiungere transizioni di pagina fluide per un'esperienza di navigazione più curata.
+    - Aggiungere una route per visualizzare singole voci con stella direttamente dall'elenco starred di una categoria.
+    - Aggiungere un link alla pagina dei contributor GitHub nei template.
+    - Aggiornare tutte le traduzioni.
+
+    **Documentazione e tooling**
+    - Migliorare la coerenza e correggere refusi nella pagina del manuale miniflux(1).
+    - Rimuovere la chiave version obsoleta dagli esempi Docker Compose.
+    - Aggiornare l'immagine Go del devcontainer a go:1-trixie.
+    - Aggiornare l'immagine base Distroless del container a Debian 13.
+    - Aggiornare le dipendenze di GitHub Actions.
+
+
+    Release Note: https://github.com/miniflux/v2/releases/tag/2.2.16

--- a/miniflux/i18n/ja-JP/OlaresManifest.yaml
+++ b/miniflux/i18n/ja-JP/OlaresManifest.yaml
@@ -1,0 +1,140 @@
+metadata:
+  title: Miniflux
+  description: Miniflux はミニマリストで独自の方針を持つフィードリーダーです
+spec:
+  fullDescription: |
+    Miniflux はミニマリストで独自の方針を持つフィードリーダーです。シンプルで高速、軽量で、インストールも非常に簡単です。
+
+    **機能**
+
+    フィードリーダー
+    - 対応フィード形式: Atom 0.3/1.0、RSS 1.0/2.0、JSON Feed 1.0/1.1。
+    - OPML ファイルのインポート/エクスポートおよび URL インポート。
+    - 複数の添付ファイルに対応（ポッドキャスト、動画、音楽、画像の enclosure）。
+    - YouTube の動画を Miniflux 内で直接再生。
+    - カテゴリとブックマークで記事を整理。
+    - 個別の記事を公開共有。
+    - ウェブサイトのアイコン（favicon）を取得。
+    - 記事をサードパーティサービスに保存。
+    - 全文検索を提供（powered by Postgres）。
+    - 20 言語に対応: ポルトガル語（ブラジル）、中国語（簡体字・繁体字）、オランダ語、英語（米国）、フィンランド語、フランス語、ドイツ語、ギリシャ語、ヒンディー語、インドネシア語、イタリア語、日本語、ポーランド語、ルーマニア語、ロシア語、台湾語 POJ、ウクライナ語、スペイン語、トルコ語。
+
+    プライバシーとセキュリティ
+    - ピクセルトラッカーを除去。
+    - URL からトラッキングパラメータを除去（例: utm_source、utm_medium、utm_campaign、fbclid など）。
+    - FeedBurner 由来のフィードでは元のリンクを取得。
+    - 外部リンクを rel="noopener noreferrer" referrerpolicy="no-referrer" 属性付きで開き、セキュリティを向上。
+    - HTTP ヘッダー Referrer-Policy: no-referrer を実装し、リファラー漏洩を防止。
+    - メディアプロキシを提供し、トラッキングを回避するとともに HTTPS 利用時の混合コンテンツ警告を解消。
+    - プライバシー重視のドメイン youtube-nocookie.com 経由で YouTube 動画を再生。
+    - Invidious などの代替 YouTube 動画プレイヤーに対応。
+    - 外部 JavaScript をブロックしてトラッキングを防ぎ、セキュリティを強化。
+    - 外部コンテンツをレンダリング前にサニタイズ。
+    - Content Security および Trusted Types Policy を強制し、アプリケーションの JavaScript のみを許可してインラインスクリプトとスタイルをブロック。
+
+    ボット保護バイパス機構
+    - フィンガープリンティング緩和のため、任意で HTTP/2 を無効化可能。
+    - カスタム User-Agent の設定が可能。
+    - 特定の用途向けにカスタム Cookie を追加可能。
+    - プライバシー強化や制限回避のためのプロキシ利用に対応。
+
+    コンテンツ操作
+    - 元記事を取得し、関連コンテンツのみを返す（Readability パーサー）
+    - CSS セレクターに基づくカスタムスクレイパールール
+    - カスタムリライトルール
+    - 記事の許可/ブロック用の正規表現フィルター
+    - ウェブサイトの制限を回避するためデフォルトの User-Agent を上書き
+    - 自己署名または無効な証明書を許可するオプション（デフォルトは無効）
+    - YouTube のサイトをスクレイプして動画の長さを読書時間として取得（デフォルトは無効）
+
+    ユーザーインターフェース
+    - 可読性に最適化されたスタイルシート。
+    - デスクトップ、タブレット、モバイルにシームレスに適応するレスポンシブデザイン。
+    - ミニマリスティックで気が散らないユーザーインターフェース。
+    - Apple App Store や Google Play Store からのアプリダウンロードは不要。
+    - ホーム画面に直接追加して素早くアクセス可能。
+    - 効率的な操作のための豊富なキーボードショートカットに対応。
+    - モバイルでのナビゲーション向けに任意のタッチジェスチャー対応。
+    - カスタムスタイルシートと JavaScript で UI を好みに合わせてパーソナライズ。
+    - テーマ:
+      - Light (Sans-Serif)
+      - Light (Serif)
+      - Dark (Sans-Serif)
+      - Dark (Serif)
+      - System (Sans-Serif) – システム設定に応じて Dark / Light テーマを自動切替。
+      - System (Serif)
+
+    連携
+    - 25 以上のサードパーティサービス連携: Apprise、Betula、Cubox、Discord、Espial、Instapaper、LinkAce、Linkding、LinkTaco、LinkWarden、Matrix、Notion、Ntfy、Nunux Keeper、Pinboard、Pushover、RainDrop、Readeck、Readwise Reader、RssBridge、Shaarli、Shiori、Slack、Telegram、Wallabag など。
+    - 任意のウェブブラウザから直接サイトを購読できるブックマークレット。
+    - リアルタイム通知やカスタム連携のための Webhook。
+    - Fever API または Google Reader API を使う既存のモバイルアプリとの互換性。
+    - Go および Python のクライアントライブラリ付き REST API。
+
+    認証
+    - ローカルのユーザー名とパスワード。
+    - パスキー（WebAuthn）。
+    - Google（OAuth2）。
+    - 汎用 OpenID Connect。
+    - リバースプロキシ認証。
+
+    技術的な詳細
+    - Go（Golang）で記述。
+    - 依存関係なしで静的にコンパイルされた単一バイナリ。
+    - PostgreSQL のみで動作。
+    - ORM や複雑なフレームワークを使用しない。
+    - 必要な場合にのみモダンなバニラ JavaScript を使用。
+    - 静的ファイルはすべて Go の embed パッケージでアプリケーションバイナリに同梱。
+    - プロセス監視のための Systemd sd_notify プロトコルに対応。
+    - Let's Encrypt で HTTPS を自動設定。
+    - カスタム SSL 証明書の利用が可能。
+    - TLS 有効時に HTTP/2 をサポート。
+    - 内部スケジューラまたは従来の cron ジョブでバックグラウンド更新。
+    - 画像と iframe にネイティブな遅延読み込みを使用。
+    - モダンブラウザのみ対応。
+    - Twelve-Factor App 手法に準拠。
+    - 公式 Debian/RPM パッケージと事前ビルド済みバイナリを提供。
+    - Docker Hub、GitHub Registry、Quay.io Registry に Docker イメージを公開（ARM アーキテクチャ対応）。
+    - サードパーティの Go 依存関係は最小限
+    - 単体テストと統合テストを含む包括的なテストスイートを装備。
+    - 数百のフィードがあってもメモリは数 MB、CPU 使用量はごくわずか。
+    - Last-Modified、If-Modified-Since、If-None-Match、Cache-Control、Expires、ETags ヘッダーを尊重/送信し、デフォルトのポーリング間隔は 1 時間。
+
+    より詳細な機能: https://miniflux.app/features.html
+  upgradeDescription: |
+    Miniflux を 2.2.16 から 2.3.3 にアップグレードします（`miniflux/miniflux:2.3.3-distroless`）。
+
+    2.3.x は 2.2 系列に加え、フィード、API、UI の修正があります。詳細: https://github.com/miniflux/v2/releases/tag/2.3.3
+
+    **セキュリティ**
+    - メディアプロキシがプライベートネットワーク上のリソースを取得できないようにし、潜在的な SSRF 問題を緩和。この動作はインスタンスレベルで設定可能。
+    - プライベートネットワークからのフィードアイコン取得を禁止し、SSRF 攻撃面を縮小。こちらもインスタンスレベルで設定可能。
+    - X-Forwarded-For、X-Forwarded-Proto、X-Real-Ip などの HTTP ヘッダー偽装を防ぐため、TRUSTED_REVERSE_PROXY_NETWORKS 設定オプションを追加。AUTH_PROXY_HEADER が有効な場合はこのオプションの設定が必須。
+    - デバッグモードが有効でも、生成された Google Reader API トークンをログ出力しないように変更。
+    - Web クライアント向けではないため Google Reader API から CORS ハンドラを削除し、全体の攻撃面を縮小。
+
+    **パフォーマンスとストレージ**
+    - 削除済みエントリの内容をインデックスしないようにし、クリーンアップ後のデータベースインデックスサイズを大幅に削減。
+    - ストレージとデータベースの小規模なリファクタリングにより、コードパスを簡素化し不要なフォーマットオーバーヘッドを削減。
+
+    **API と連携**
+    - 既存フィードへエントリをインポートする新しい API エンドポイントを追加。
+    - API 経由でエントリを更新またはインポートする際にコンテンツサニタイザを実行し、一貫したサニタイズを保証。
+    - 不要な出力パラメータチェックを削除し、他のオープンソース RSS リーダーと動作を揃えて Google Reader API 互換性を改善。
+    - Readeck 連携にオートプッシュオプションを追加。
+
+    **ユーザーインターフェース**
+    - より洗練されたナビゲーション体験のためのスムーズなページ遷移を追加。
+    - カテゴリのスター付き一覧から個別のスター付きエントリを直接表示するルートを追加。
+    - テンプレートに GitHub コントリビューターページへのリンクを追加。
+    - すべての翻訳を更新。
+
+    **ドキュメントとツール**
+    - miniflux(1) マニュアルページの一貫性を改善し、誤字を修正。
+    - Docker Compose の例から廃止された version キーを削除。
+    - Go の devcontainer イメージを go:1-trixie に更新。
+    - Distroless コンテナのベースイメージを Debian 13 に更新。
+    - GitHub Actions の依存関係を更新。
+
+
+    Release Note: https://github.com/miniflux/v2/releases/tag/2.2.16

--- a/miniflux/i18n/zh-CN/OlaresManifest.yaml
+++ b/miniflux/i18n/zh-CN/OlaresManifest.yaml
@@ -102,6 +102,10 @@ spec:
 
     更多详细功能：https://miniflux.app/features.html
   upgradeDescription: |
+    将 Miniflux 从 2.2.16 升级到 2.3.3（`miniflux/miniflux:2.3.3-distroless`）。
+
+    2.3.x 在 2.2 系列之上包含订阅源、API 与界面修复。完整说明：https://github.com/miniflux/v2/releases/tag/2.3.3
+
     **安全（Security）**
     - 禁止媒体代理从私有网络获取资源，以降低潜在的 SSRF 风险。此行为可在实例级别配置。
     - 禁止从私有网络获取订阅源（feed）图标，以减少 SSRF 攻击面。同样可在实例级别配置。

--- a/miniflux/owners
+++ b/miniflux/owners
@@ -1,8 +1,3 @@
 owners:
-- 'LittleLollipop'
-- 'TShentu'
-- 'hysyeah'
-- 'pengpeng'
-- 'harveyff'
-- 'zdf-org'
-- 'aby913'
+  - username: '@beclab'
+    title: 'Olares'

--- a/miniflux/templates/miniflux-deployment.yaml
+++ b/miniflux/templates/miniflux-deployment.yaml
@@ -42,7 +42,7 @@ spec:
               value: "1"
             - name: RUN_MIGRATIONS
               value: "1"
-          image: "docker.io/beclab/miniflux-miniflux:2.2.16-distroless"
+          image: "docker.io/miniflux/miniflux:2.3.3-distroless"
           name: miniflux
           resources:
             requests:


### PR DESCRIPTION
### App Title
miniflux

### Description

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`