### PR TITLE
[UPDATE][teable][1.0.27] Fix image-cache permission errors by mounting a writable temporary Next.js cache owned by UID/GID 1000.

### DIFF
--- a/teable/Chart.yaml
+++ b/teable/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.26
+version: 1.0.27
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "release.2026-09-07T09-32-29Z.2963"
+appVersion: "release.2026-09-11T07-36-49Z.3059"

--- a/teable/OlaresManifest.yaml
+++ b/teable/OlaresManifest.yaml
@@ -11,7 +11,7 @@ metadata:
   description: 'The Next Gen Airtable Alternative: No-Code Postgres'
   icon: https://app.cdn.olares.com/appstore/teable/icon.png
   appid: teable
-  version: '1.0.26'
+  version: '1.0.27'
   title: Teable
   categories:
   - Productivity_v112
@@ -26,21 +26,12 @@ permission:
   userData:
     - Home
 spec:
-  versionName: 'release.2026-09-07T09-32-29Z.2963'
+  versionName: 'release.2026-09-11T07-36-49Z.3059'
   runAsUser: true
   upgradeDescription: |
-    Fix image-cache permission errors by mounting a writable temporary Next.js cache owned by UID/GID 1000.
-
-    Add the Helm release revision to the database migration Job name so upgrades do not patch its immutable pod template.
-    Upgrade Teable to `teableio/teable:release.2026-09-07T09-32-29Z.2963` (official image, amd64 and arm64).
-
-    Chart:
-    - Switch from the `beclab/teableio-teable` mirror to the official Docker Hub image.
-    - Database migrate Job uses the same app image with `migrate-only` (the app also migrates on startup).
-    - Allow outbound 80/443 so Prisma migrate can fetch pnpm via Corepack (npm registry).
-    - Probes use `/health`. Attachments stay on `appData` at `/app/.assets`.
-
-    Release notes: https://github.com/teableio/teable/releases/tag/release.2026-09-07T09-32-29Z.2963
+    Upgrade Teable to release.2026-09-11T07-36-49Z.3059.
+    Repair ownership and owner write permissions on the local upload directories before startup, so upgrades can replace existing official plugin assets.
+    Preserve existing database, attachments, and writable temporary caches.
   featuredImage: https://app.cdn.olares.com/appstore/teable/1.jpg
   promoteImage:
     - https://app.cdn.olares.com/appstore/teable/1.jpg

--- a/teable/i18n/de-DE/OlaresManifest.yaml
+++ b/teable/i18n/de-DE/OlaresManifest.yaml
@@ -3,16 +3,7 @@ metadata:
   description: "Die Next-Gen-Airtable-Alternative: No-Code PostgreSQL"
 spec:
   upgradeDescription: |
-    Behebt Berechtigungsfehler im Bild-Cache durch einen temporären, für UID/GID 1000 beschreibbaren Next.js-Cache.
-
-    Teable auf `teableio/teable:release.2026-09-07T09-32-29Z.2963` aktualisieren (offizielles Image, amd64 und arm64).
-
-    Chart:
-    - Wechsel vom Spiegel `beclab/teableio-teable` zum offiziellen Docker-Hub-Image.
-    - Der Migrate-Job nutzt dasselbe App-Image mit `migrate-only` (die App migriert auch beim Start).
-    - Probes verwenden `/health`. Anhänge bleiben unter `appData` auf `/app/.assets`.
-
-    Release Notes: https://github.com/teableio/teable/releases/tag/release.2026-09-07T09-32-29Z.2963
+    Aktualisiert Teable auf release.2026-09-11T07-36-49Z.3059. Repariert die Berechtigungen lokaler Upload-Verzeichnisse, damit vorhandene Plugin-Dateien beim Upgrade ersetzt werden können.
   fullDescription: |
     Teable nutzt eine einfache, tabellenkalkulationsähnliche Oberfläche, um leistungsstarke Datenbankanwendungen zu erstellen. Arbeiten Sie in Echtzeit mit Ihrem Team zusammen und skalieren Sie auf Millionen von Zeilen.
 

--- a/teable/i18n/en-US/OlaresManifest.yaml
+++ b/teable/i18n/en-US/OlaresManifest.yaml
@@ -3,17 +3,8 @@ metadata:
   description: "The Next Gen Airtable Alternative: No-Code Postgrese"
 spec:
   upgradeDescription: |
-    Fix image-cache permission errors by mounting a writable temporary Next.js cache owned by UID/GID 1000.
-
-    Upgrade Teable to `teableio/teable:release.2026-09-07T09-32-29Z.2963` (official image, amd64 and arm64).
-
-    Chart:
-    - Switch from the `beclab/teableio-teable` mirror to the official Docker Hub image.
-    - Database migrate Job uses the same app image with `migrate-only` (the app also migrates on startup).
-    - Allow outbound 80/443 so Prisma migrate can fetch pnpm via Corepack (npm registry).
-    - Probes use `/health`. Attachments stay on `appData` at `/app/.assets`.
-
-    Release notes: https://github.com/teableio/teable/releases/tag/release.2026-09-07T09-32-29Z.2963
+    Upgrade Teable to release.2026-09-11T07-36-49Z.3059.
+    Repair local upload directory permissions for existing plugin assets during upgrades.
   fullDescription: |
     Teable uses a simple, spreadsheet-like interface to create powerful database applications. Collaborate with your team in real-time, and scale to millions of rows
 

--- a/teable/i18n/es-ES/OlaresManifest.yaml
+++ b/teable/i18n/es-ES/OlaresManifest.yaml
@@ -3,16 +3,7 @@ metadata:
   description: "La alternativa Next Gen a Airtable: PostgreSQL sin código"
 spec:
   upgradeDescription: |
-    Corrige los errores de permisos de la caché de imágenes con una caché temporal de Next.js escribible por UID/GID 1000.
-
-    Actualiza Teable a `teableio/teable:release.2026-09-07T09-32-29Z.2963` (imagen oficial, amd64 y arm64).
-
-    Chart:
-    - Cambia el espejo `beclab/teableio-teable` por la imagen oficial de Docker Hub.
-    - El Job de migración usa la misma imagen de la app con `migrate-only` (la app también migra al arrancar).
-    - Las sondas usan `/health`. Los adjuntos siguen en `appData` en `/app/.assets`.
-
-    Notas: https://github.com/teableio/teable/releases/tag/release.2026-09-07T09-32-29Z.2963
+    Actualiza Teable a release.2026-09-11T07-36-49Z.3059. Corrige los permisos de los directorios de archivos locales para poder reemplazar los recursos de plugins durante la actualización.
   fullDescription: |
     Teable usa una interfaz sencilla tipo hoja de cálculo para crear potentes aplicaciones de base de datos. Colabora con tu equipo en tiempo real y escala a millones de filas.
 

--- a/teable/i18n/fr-FR/OlaresManifest.yaml
+++ b/teable/i18n/fr-FR/OlaresManifest.yaml
@@ -3,16 +3,7 @@ metadata:
   description: "L'alternative Next Gen à Airtable : PostgreSQL no-code"
 spec:
   upgradeDescription: |
-    Corrige les erreurs de permission du cache des images avec un cache temporaire Next.js accessible en écriture à UID/GID 1000.
-
-    Mise à jour de Teable vers `teableio/teable:release.2026-09-07T09-32-29Z.2963` (image officielle, amd64 et arm64).
-
-    Chart :
-    - Remplacement du miroir `beclab/teableio-teable` par l’image officielle Docker Hub.
-    - Le Job de migration utilise la même image avec `migrate-only` (l’app migre aussi au démarrage).
-    - Les sondes utilisent `/health`. Les pièces jointes restent sur `appData` dans `/app/.assets`.
-
-    Notes : https://github.com/teableio/teable/releases/tag/release.2026-09-07T09-32-29Z.2963
+    Met à jour Teable vers release.2026-09-11T07-36-49Z.3059. Corrige les permissions des répertoires de fichiers locaux afin de remplacer les ressources des plugins lors de la mise à jour.
   fullDescription: |
     Teable utilise une interface simple de type tableur pour créer de puissantes applications de base de données. Collaborez avec votre équipe en temps réel et montez à l'échelle jusqu'à des millions de lignes.
 

--- a/teable/i18n/it-IT/OlaresManifest.yaml
+++ b/teable/i18n/it-IT/OlaresManifest.yaml
@@ -3,16 +3,7 @@ metadata:
   description: "L'alternativa Next Gen ad Airtable: PostgreSQL no-code"
 spec:
   upgradeDescription: |
-    Corregge gli errori di permesso della cache delle immagini con una cache temporanea Next.js scrivibile da UID/GID 1000.
-
-    Aggiorna Teable a `teableio/teable:release.2026-09-07T09-32-29Z.2963` (immagine ufficiale, amd64 e arm64).
-
-    Chart:
-    - Passaggio dal mirror `beclab/teableio-teable` all’immagine ufficiale Docker Hub.
-    - Il Job di migrate usa la stessa immagine app con `migrate-only` (l’app migra anche all’avvio).
-    - I probe usano `/health`. Gli allegati restano su `appData` in `/app/.assets`.
-
-    Note: https://github.com/teableio/teable/releases/tag/release.2026-09-07T09-32-29Z.2963
+    Aggiorna Teable a release.2026-09-11T07-36-49Z.3059. Corregge i permessi delle directory dei file locali per consentire la sostituzione delle risorse dei plugin durante gli aggiornamenti.
   fullDescription: |
     Teable usa un'interfaccia semplice simile a un foglio di calcolo per creare potenti applicazioni database. Collabora con il tuo team in tempo reale e scala a milioni di righe.
 

--- a/teable/i18n/ja-JP/OlaresManifest.yaml
+++ b/teable/i18n/ja-JP/OlaresManifest.yaml
@@ -3,16 +3,7 @@ metadata:
   description: "次世代 Airtable 代替：ノーコード PostgreSQL"
 spec:
   upgradeDescription: |
-    UID/GID 1000 が書き込める Next.js 一時キャッシュをマウントし、画像キャッシュの権限エラーを修正します。
-
-    Teable を `teableio/teable:release.2026-09-07T09-32-29Z.2963` にアップグレードします（公式イメージ、amd64 と arm64）。
-
-    Chart:
-    - `beclab/teableio-teable` ミラーから Docker Hub 公式イメージへ切り替えます。
-    - マイグレーション Job は同じアプリイメージを `migrate-only` で実行します（起動時にもマイグレーションします）。
-    - プローブは `/health` です。添付ファイルはこれまでどおり `appData` の `/app/.assets` に保存します。
-
-    リリースノート: https://github.com/teableio/teable/releases/tag/release.2026-09-07T09-32-29Z.2963
+    Teable を release.2026-09-11T07-36-49Z.3059 に更新します。ローカルのアップロードディレクトリの権限を修正し、更新時に既存のプラグインファイルを置き換えられるようにします。
   fullDescription: |
     Teable はシンプルなスプレッドシート風インターフェースで強力なデータベースアプリケーションを作成します。チームとリアルタイムで共同作業し、数百万行までスケールできます。
 

--- a/teable/i18n/zh-CN/OlaresManifest.yaml
+++ b/teable/i18n/zh-CN/OlaresManifest.yaml
@@ -3,17 +3,9 @@ metadata:
   title: Teable
 spec:
   upgradeDescription: |
-    为 Next.js 图片缓存挂载 UID/GID 1000 可写的临时目录，修复缓存写入权限错误。
-
-    将 Teable 升级到 `teableio/teable:release.2026-09-07T09-32-29Z.2963`（官方镜像，amd64 与 arm64）。
-
-    Chart：
-    - 从 `beclab/teableio-teable` 镜像源切换为 Docker Hub 官方镜像。
-    - 数据库迁移 Job 使用同一应用镜像，参数为 `migrate-only`（应用启动时也会执行迁移）。
-    - 放行出站 80/443，以便 Prisma 迁移通过 Corepack 拉取 pnpm。
-    - 探针改为 `/health`。附件仍持久化在 `appData` 的 `/app/.assets`。
-
-    发行说明：https://github.com/teableio/teable/releases/tag/release.2026-09-07T09-32-29Z.2963
+    升级 Teable 至 release.2026-09-11T07-36-49Z.3059。
+    启动前修复本地上传目录的属主和写权限，解决旧版插件文件在升级时无法替换的问题。
+    保留现有数据库、附件和临时缓存挂载。
   fullDescription: |
     Teable 使用简单的电子表格式界面来创建功能强大的数据库应用程序。实时与您的团队协作，并扩展到数百万行
 

--- a/teable/templates/teable.yaml
+++ b/teable/templates/teable.yaml
@@ -27,7 +27,32 @@ spec:
             - sh
             - -c
             - |
-              chown 1000:1000 /app/.assets
+              set -eu
+              # Old images left upload directories owned by root. Replacing
+              # plugin files requires write permission on their parent directory.
+              for relative in . uploads uploads/public uploads/private \
+                uploads/public/plugin uploads/public/avatar uploads/public/form \
+                uploads/public/oauth uploads/public/logo uploads/public/template \
+                uploads/public/chat-data-visualization-code uploads/public/space-avatar \
+                uploads/private/table uploads/private/import uploads/private/export-base \
+                uploads/private/comment uploads/private/app uploads/private/chat-file \
+                uploads/private/automation uploads/private/record-history \
+                uploads/private/record-removal uploads/private/artifact \
+                uploads/private/workflow-run uploads/private/audit-log; do
+                directory="/app/.assets/$relative"
+                if [ -L "$directory" ]; then
+                  echo "Refusing upload directory symlink: $directory" >&2
+                  exit 1
+                fi
+                mkdir -p "$directory"
+                case "$(stat -c '%A' "$directory")" in
+                  drwx*) ;;
+                  *) chmod u+rwx "$directory" ;;
+                esac
+                if [ "$(stat -c '%u:%g' "$directory")" != '1000:1000' ]; then
+                  chown 1000:1000 "$directory"
+                fi
+              done
               mkdir -p /app/.temporary
               chown 1000:1000 /app/.temporary
               touch /swagger/openapi.json
@@ -58,7 +83,7 @@ spec:
           imagePullPolicy: IfNotPresent
       containers:
         - name: teable
-          image: "docker.io/teableio/teable:release.2026-09-07T09-32-29Z.2963"
+          image: "docker.io/teableio/teable:release.2026-09-11T07-36-49Z.3059"
           imagePullPolicy: IfNotPresent
           env:
             - name: TZ
@@ -163,7 +188,7 @@ spec:
     spec:
       containers:
         - name: teable-db-migrate
-          image: "docker.io/teableio/teable:release.2026-09-07T09-32-29Z.2963"
+          image: "docker.io/teableio/teable:release.2026-09-11T07-36-49Z.3059"
           args:
             - migrate-only
           securityContext:


### PR DESCRIPTION
### App Title
teable

### Description

### Statement
- [x] I have tested this application to ensure it is compatible with the Olares OS version stated in the `OlaresManifest.yaml`